### PR TITLE
Fix variable name typo

### DIFF
--- a/src/interfaces/IDealManager.sol
+++ b/src/interfaces/IDealManager.sol
@@ -70,7 +70,7 @@ interface IDealManager {
         CertificateDetails[] memory _certDetails,
         address proposer,
         bytes memory signature,
-        string[][] memory paryValues,
+        string[][] memory partyValues,
         address[] memory conditions,
         bytes32 secretHash,
         uint256 expiry


### PR DESCRIPTION
## Summary
- fix a typo in `IDealManager.sol` function parameter

## Testing
- `forge fmt --check` *(fails: command not found)*