### PR TITLE
Add board of directors management

### DIFF
--- a/src/CyberCorp.sol
+++ b/src/CyberCorp.sol
@@ -74,11 +74,18 @@ contract CyberCorp is Initializable, BorgAuthACL {
     address public upgradeFactory;
     /// @notice Array of company officers with their roles and details
     CompanyOfficer[] public companyOfficers;
+    /// @notice Array of company directors with their roles and details
+    CompanyDirector[] public companyDirectors;
+    /// @notice Board information for the corporation
+    BoardInfo public boardInfo;
 
 
     event CyberCORPDetailsUpdated(string cyberCORPName, string cyberCORPType, string cyberCORPJurisdiction, string cyberCORPContactDetails, string defaultDisputeResolution);
     event OfficerAdded(address indexed officer, uint256 index);
     event OfficerRemoved(address indexed officer, uint256 index);
+    event DirectorAdded(address indexed director, uint256 index);
+    event DirectorRemoved(address indexed director, uint256 index);
+    event BoardInfoUpdated(uint256 seats, string votingRule, address chairman, address boardSafe);
     event CompanyPayableUpdated(address indexed companyPayable, address indexed oldCompanyPayable);
 
     /// @custom:oz-upgrades-unsafe-allow constructor
@@ -199,6 +206,62 @@ contract CyberCorp is Initializable, BorgAuthACL {
         companyOfficers[_index] = companyOfficers[companyOfficers.length - 1];
         companyOfficers.pop();
         emit OfficerRemoved(officerEOA, _index);
+    }
+
+    /// @notice Adds a new director to the board
+    /// @dev Only callable by owner, sets director role to 200
+    /// @param _director Director details including address and role
+    function addDirector(CompanyDirector memory _director) external onlyOwner() {
+        companyDirectors.push(_director);
+        AUTH.updateRole(_director.eoa, 200);
+        emit DirectorAdded(_director.eoa, companyDirectors.length - 1);
+    }
+
+    /// @notice Removes a director by their address
+    /// @dev Only callable by owner, revokes director role
+    /// @param _address Address of the director to remove
+    function removeDirector(address _address) external onlyOwner() {
+        AUTH.updateRole(_address, 0);
+        for (uint256 i = 0; i < companyDirectors.length; i++) {
+            if (companyDirectors[i].eoa == _address) {
+                companyDirectors[i] = companyDirectors[companyDirectors.length - 1];
+                companyDirectors.pop();
+                emit DirectorRemoved(_address, i);
+                break;
+            }
+        }
+    }
+
+    /// @notice Removes a director by index
+    /// @dev Only callable by owner, revokes director role
+    /// @param _index Index of the director to remove
+    function removeDirectorAt(uint256 _index) external onlyOwner() {
+        require(_index < companyDirectors.length, "Index out of bounds");
+        address directorEOA = companyDirectors[_index].eoa;
+        AUTH.updateRole(directorEOA, 0);
+        companyDirectors[_index] = companyDirectors[companyDirectors.length - 1];
+        companyDirectors.pop();
+        emit DirectorRemoved(directorEOA, _index);
+    }
+
+    /// @notice Sets board information
+    /// @param _seats Number of board seats
+    /// @param _votingRule Voting rule description
+    /// @param _chairman Address of the board chairman (0 if none)
+    /// @param _boardSafe Address of the gnosis safe used for votes
+    function setBoardInfo(
+        uint256 _seats,
+        string memory _votingRule,
+        address _chairman,
+        address _boardSafe
+    ) external onlyOwner() {
+        boardInfo = BoardInfo({
+            seats: _seats,
+            votingRule: _votingRule,
+            chairman: _chairman,
+            boardSafe: _boardSafe
+        });
+        emit BoardInfoUpdated(_seats, _votingRule, _chairman, _boardSafe);
     }
 
     function setCompanyPayable(address _companyPayable) external onlyOwner() {

--- a/src/CyberCorpConstants.sol
+++ b/src/CyberCorpConstants.sol
@@ -82,6 +82,20 @@ struct CompanyOfficer {
     string title;
 }
 
+struct CompanyDirector {
+    address eoa;
+    string name;
+    string contact;
+    string title;
+}
+
+struct BoardInfo {
+    uint256 seats;
+    string votingRule;
+    address chairman;
+    address boardSafe;
+}
+
 enum ExercisePriceMethod {
     perToken,
     perWarrant

--- a/src/interfaces/ICyberCorp.sol
+++ b/src/interfaces/ICyberCorp.sol
@@ -39,7 +39,7 @@ distributed, transmitted, sublicensed, sold, or otherwise used in any form or by
 mechanical, including photocopying, recording, or by any information storage and retrieval system, 
 except with the express prior written permission of the copyright holder.*/
 
-import {CompanyOfficer} from "../CyberCorpConstants.sol";
+import {CompanyOfficer, CompanyDirector, BoardInfo} from "../CyberCorpConstants.sol";
 
 pragma solidity 0.8.28;
 
@@ -62,6 +62,23 @@ interface ICyberCorp {
     function defaultDisputeResolution() external view returns (string memory);
     function companyPayable() external view returns (address);
     function companyOfficers() external view returns (address[] memory);
+    function companyDirectors(uint256)
+        external
+        view
+        returns (address eoa, string memory name, string memory contact, string memory title);
+    function boardInfo()
+        external
+        view
+        returns (uint256 seats, string memory votingRule, address chairman, address boardSafe);
+    function addDirector(CompanyDirector memory _director) external;
+    function removeDirector(address _address) external;
+    function removeDirectorAt(uint256 _index) external;
+    function setBoardInfo(
+        uint256 _seats,
+        string memory _votingRule,
+        address _chairman,
+        address _boardSafe
+    ) external;
     function cyberCORPType() external view returns (string memory);
     function dealManager() external view returns (address);
     function setDealManager(address _dealManager) external;


### PR DESCRIPTION
## Summary
- add `CompanyDirector` and `BoardInfo` structs
- store directors and board info in `CyberCorp`
- allow adding/removing directors and updating board configuration
- expose new fields/functions through `ICyberCorp`

## Testing
- `forge build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e6808a4cc8332b871f5075672ab1d