### PR TITLE
LeXcheX & minter fixes and upgradeability

### DIFF
--- a/src/creds/lexchex.sol
+++ b/src/creds/lexchex.sol
@@ -42,6 +42,7 @@ pragma solidity 0.8.28;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "./storage/lexchexStorage.sol";
 import "../libs/auth.sol";  
 import "../interfaces/ICyberAgreementRegistry.sol";
@@ -65,7 +66,7 @@ interface IERC5484 {
     function burnAuth(uint256 tokenId) external view returns (BurnAuth);
 }
 
-contract LeXcheX is Initializable, ERC721EnumerableUpgradeable, BorgAuthACL, IERC5484 {
+contract LeXcheX is Initializable, ERC721EnumerableUpgradeable, UUPSUpgradeable, BorgAuthACL, IERC5484 {
     using LeXcheXStorage for *;
     using Strings for uint256;
 
@@ -314,6 +315,11 @@ contract LeXcheX is Initializable, ERC721EnumerableUpgradeable, BorgAuthACL, IER
         }
         return string(abi.encodePacked("0x", string(str)));
     }
+
+    /// @dev Only owner can upgrade it
+    function _authorizeUpgrade(
+        address newImplementation
+    ) internal virtual override onlyOwner {}
 }
 
 /// @title Base64

--- a/src/creds/lexchexMinter.sol
+++ b/src/creds/lexchexMinter.sol
@@ -53,7 +53,7 @@ contract LeXcheXMinter is Initializable, UUPSUpgradeable, BorgAuthACL {
         string name;
         string entityType;
         string jurisdiction;
-        // TODO no contact?
+        string contact;
         uint256 mintPrice;
         uint256 expiry;
     }
@@ -90,7 +90,7 @@ contract LeXcheXMinter is Initializable, UUPSUpgradeable, BorgAuthACL {
         );
 
         AUTHORITY_TYPEHASH = keccak256(
-            "AuthorityData(address owner,string name,string entityType,string jurisdiction,uint256 mintPrice,uint256 expiry)"
+            "AuthorityData(address owner,string name,string entityType,string jurisdiction,string contact,uint256 mintPrice,uint256 expiry)"
         );
     }
 
@@ -176,6 +176,7 @@ contract LeXcheXMinter is Initializable, UUPSUpgradeable, BorgAuthACL {
             name: request.name,
             entityType: request.entityType,
             jurisdiction: request.jurisdiction,
+            contact: request.contact,
             mintPrice: request.mintPrice,
             expiry: request.expiry
         });
@@ -202,6 +203,7 @@ contract LeXcheXMinter is Initializable, UUPSUpgradeable, BorgAuthACL {
                         keccak256(bytes(data.name)),
                         keccak256(bytes(data.entityType)),
                         keccak256(bytes(data.jurisdiction)),
+                        keccak256(bytes(data.contact)),
                         data.mintPrice,
                         data.expiry
                     )

--- a/src/creds/lexchexMinter.sol
+++ b/src/creds/lexchexMinter.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.28;
 
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "../interfaces/ICyberAgreementRegistry.sol";
 import "../libs/auth.sol";
 import "./lexchex.sol";
@@ -9,7 +10,7 @@ import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 
-contract LeXcheXMinter is Initializable, BorgAuthACL {
+contract LeXcheXMinter is Initializable, UUPSUpgradeable, BorgAuthACL {
     using ECDSA for bytes32;
     using SafeERC20 for IERC20;
 
@@ -225,4 +226,9 @@ contract LeXcheXMinter is Initializable, BorgAuthACL {
     function setTreasury(address _treasury) external onlyOwner {
         treasury = _treasury;
     }
+
+    /// @dev Only owner can upgrade it
+    function _authorizeUpgrade(
+        address newImplementation
+    ) internal virtual override onlyOwner {}
 }

--- a/src/creds/lexchexMinter.sol
+++ b/src/creds/lexchexMinter.sol
@@ -52,6 +52,7 @@ contract LeXcheXMinter is Initializable, BorgAuthACL {
         string name;
         string entityType;
         string jurisdiction;
+        // TODO no contact?
         uint256 mintPrice;
         uint256 expiry;
     }
@@ -103,9 +104,7 @@ contract LeXcheXMinter is Initializable, BorgAuthACL {
         bytes memory authoritySignature    // Signature from authority for verification
     ) external returns (bytes32 agreementId, uint256 tokenId) {
         // 1. Verify authority signature is from an admin using EIP-712
-        if (!_verifyAuthoritySignature(request, authoritySignature)) {
-            revert InvalidSignature();
-        }
+        _verifyAuthoritySignature(request, authoritySignature);
 
         // 2. Handle payment using safeTransferFrom
         if (request.mintPrice > 0) {
@@ -169,7 +168,7 @@ contract LeXcheXMinter is Initializable, BorgAuthACL {
     function _verifyAuthoritySignature(
         MintRequest memory request,
         bytes memory signature
-    ) internal view returns (bool) {
+    ) internal view {
         // Create AuthorityData struct for signature verification
         AuthorityData memory data = AuthorityData({
             owner: request.owner,
@@ -186,8 +185,8 @@ contract LeXcheXMinter is Initializable, BorgAuthACL {
         // Recover the signer address
         address recoveredSigner = digest.recover(signature);
 
-        // Check if the recovered signer is an admin
-        return (BorgAuthACL(auth).userRoles(recoveredSigner) == BorgAuth(BorgAuthACL(auth).AUTH()).ADMIN_ROLE());
+        // Check if the recovered signer is at least an admin
+        BorgAuth(auth).onlyRole(BorgAuth(auth).ADMIN_ROLE(), recoveredSigner);
     }
 
     function _hashTypedDataV4(AuthorityData memory data) internal view returns (bytes32) {

--- a/src/creds/lexchexMinter.sol
+++ b/src/creds/lexchexMinter.sol
@@ -1,4 +1,43 @@
-// SPDX-License-Identifier: UNLICENSED
+/*    .o.
+     .888.
+    .8"888.
+   .8' `888.
+  .88ooo8888.
+ .8'     `888.
+o88o     o8888o
+
+
+
+ooo        ooooo               .             ooooo                  ooooooo  ooooo
+`88.       .888'             .o8             `888'                   `8888    d8'
+ 888b     d'888   .ooooo.  .o888oo  .oooo.    888          .ooooo.     Y888..8P
+ 8 Y88. .P  888  d88' `88b   888   `P  )88b   888         d88' `88b     `8888'
+ 8  `888'   888  888ooo888   888    .oP"888   888         888ooo888    .8PY888.
+ 8    Y     888  888    .o   888 . d8(  888   888       o 888    .o   d8'  `888b
+o8o        o888o `Y8bod8P'   "888" `Y888""8o o888ooooood8 `Y8bod8P' o888o  o88888o
+
+
+
+  .oooooo.                .o8                            .oooooo.
+ d8P'  `Y8b              "888                           d8P'  `Y8b
+888          oooo    ooo  888oooo.   .ooooo.  oooo d8b 888           .ooooo.  oooo d8b oo.ooooo.
+888           `88.  .8'   d88' `88b d88' `88b `888""8P 888          d88' `88b `888""8P  888' `88b
+888            `88..8'    888   888 888ooo888  888     888          888   888  888      888   888
+`88b    ooo     `888'     888   888 888    .o  888     `88b    ooo  888   888  888      888   888 .o.
+ `Y8bood8P'      .8'      `Y8bod8P' `Y8bod8P' d888b     `Y8bood8P'  `Y8bod8P' d888b     888bod8P' Y8P
+             .o..P'                                                                     888
+             `Y8P'                                                                     o888o
+_______________________________________________________________________________________________________
+
+All software, documentation and other files and information in this repository (collectively, the "Software")
+are copyright MetaLeX Labs, Inc., a Delaware corporation.
+
+All rights reserved.
+
+The Software is proprietary and shall not, in part or in whole, be used, copied, modified, merged, published,
+distributed, transmitted, sublicensed, sold, or otherwise used in any form or by any means, electronic or
+mechanical, including photocopying, recording, or by any information storage and retrieval system,
+except with the express prior written permission of the copyright holder.*/
 pragma solidity 0.8.28;
 
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";

--- a/test/CyberCorpTest.t.sol
+++ b/test/CyberCorpTest.t.sol
@@ -66,6 +66,7 @@ import {Escrow} from "../src/storage/LexScrowStorage.sol";
 import {CyberCorp} from "../src/CyberCorp.sol";
 import {TokenWarrantExtension, TokenWarrantData} from "../src/storage/extensions/TokenWarrantExtension.sol";
 import {ERC1967ProxyLib} from "./libs/ERC1967ProxyLib.sol";
+import {CyberAgreementUtils} from "./libs/CyberAgreementUtils.sol";
 import {SAFTEExtension, SAFTEData} from "../src/storage/extensions/SAFTEExtension.sol";
 
 contract CyberCorpTest is Test {
@@ -286,7 +287,8 @@ contract CyberCorpTest is Test {
         string[] memory partyFields = new string[](1);
         partyFields[0] = "Party Field 1";
 
-        bytes memory signature = _signAgreementTypedData(
+        bytes memory signature = CyberAgreementUtils.signAgreementTypedData(
+            vm,
             registry.DOMAIN_SEPARATOR(),
             registry.SIGNATUREDATA_TYPEHASH(),
             contractId,
@@ -379,7 +381,8 @@ contract CyberCorpTest is Test {
         string[] memory partyFields = new string[](1);
         partyFields[0] = "Party Field 1";
 
-        bytes memory signature = _signAgreementTypedData(
+        bytes memory signature = CyberAgreementUtils.signAgreementTypedData(
+            vm,
             registry.DOMAIN_SEPARATOR(),
             registry.SIGNATUREDATA_TYPEHASH(),
             contractId,
@@ -433,7 +436,8 @@ contract CyberCorpTest is Test {
             address(dealManager),
             _paymentAmount
         );
-        bytes memory newPartySignature = _signAgreementTypedData(
+        bytes memory newPartySignature = CyberAgreementUtils.signAgreementTypedData(
+            vm,
             registry.DOMAIN_SEPARATOR(),
             registry.SIGNATUREDATA_TYPEHASH(),
             contractId,
@@ -523,7 +527,8 @@ contract CyberCorpTest is Test {
         string[] memory partyFields = new string[](1);
         partyFields[0] = "Party Field 1";
 
-        bytes memory signature = _signAgreementTypedData(
+        bytes memory signature = CyberAgreementUtils.signAgreementTypedData(
+            vm,
             registry.DOMAIN_SEPARATOR(),
             registry.SIGNATUREDATA_TYPEHASH(),
             contractId,
@@ -617,7 +622,8 @@ contract CyberCorpTest is Test {
             address(dealManager),
             _paymentAmount
         );
-        bytes memory newPartySignature = _signAgreementTypedData(
+        bytes memory newPartySignature = CyberAgreementUtils.signAgreementTypedData(
+            vm,
             registry.DOMAIN_SEPARATOR(),
             registry.SIGNATUREDATA_TYPEHASH(),
             contractId,
@@ -692,7 +698,8 @@ contract CyberCorpTest is Test {
         string[] memory partyFields = new string[](1);
         partyFields[0] = "Party Field 1";
 
-        bytes memory signature = _signAgreementTypedData(
+        bytes memory signature = CyberAgreementUtils.signAgreementTypedData(
+            vm,
             registry.DOMAIN_SEPARATOR(),
             registry.SIGNATUREDATA_TYPEHASH(),
             contractId,
@@ -804,7 +811,8 @@ contract CyberCorpTest is Test {
             )
         );
 
-        bytes memory signature = _signAgreementTypedData(
+        bytes memory signature = CyberAgreementUtils.signAgreementTypedData(
+            vm,
             registrya.DOMAIN_SEPARATOR(),
             registrya.SIGNATUREDATA_TYPEHASH(),
             contractId,
@@ -831,7 +839,8 @@ contract CyberCorpTest is Test {
         uint256 newPartyPk = 80085;
         address newPartyAddr = vm.addr(newPartyPk);
 
-        signature = _signAgreementTypedData(
+        signature = CyberAgreementUtils.signAgreementTypedData(
+            vm,
             registrya.DOMAIN_SEPARATOR(),
             registrya.SIGNATUREDATA_TYPEHASH(),
             contractId,
@@ -904,7 +913,8 @@ contract CyberCorpTest is Test {
         string[] memory partyFields = new string[](1);
         partyFields[0] = "Party Field 1";
 
-        bytes memory proposerSignature = _signAgreementTypedData(
+        bytes memory proposerSignature = CyberAgreementUtils.signAgreementTypedData(
+            vm,
             registry.DOMAIN_SEPARATOR(),
             registry.SIGNATUREDATA_TYPEHASH(),
             contractId,
@@ -953,7 +963,8 @@ contract CyberCorpTest is Test {
         partyValuesB[0] = "Party Value B";
 
         vm.startPrank(newPartyAddr);
-        bytes memory newPartySignature = _signAgreementTypedData(
+        bytes memory newPartySignature = CyberAgreementUtils.signAgreementTypedData(
+            vm,
             registry.DOMAIN_SEPARATOR(),
             registry.SIGNATUREDATA_TYPEHASH(),
             contractId,
@@ -1034,7 +1045,8 @@ contract CyberCorpTest is Test {
         string[] memory partyFields = new string[](1);
         partyFields[0] = "Party Field 1";
 
-        bytes memory proposerSignature = _signAgreementTypedData(
+        bytes memory proposerSignature = CyberAgreementUtils.signAgreementTypedData(
+            vm,
             registry.DOMAIN_SEPARATOR(),
             registry.SIGNATUREDATA_TYPEHASH(),
             contractId,
@@ -1083,7 +1095,8 @@ contract CyberCorpTest is Test {
         partyValuesB[0] = "Party Value B";
 
         vm.startPrank(newPartyAddr);
-        bytes memory newPartySignature = _signAgreementTypedData(
+        bytes memory newPartySignature = CyberAgreementUtils.signAgreementTypedData(
+            vm,
             registry.DOMAIN_SEPARATOR(),
             registry.SIGNATUREDATA_TYPEHASH(),
             contractId,
@@ -1167,7 +1180,8 @@ contract CyberCorpTest is Test {
         string[] memory partyFields = new string[](1);
         partyFields[0] = "Party Field 1";
 
-        bytes memory proposerSignature = _signAgreementTypedData(
+        bytes memory proposerSignature = CyberAgreementUtils.signAgreementTypedData(
+            vm,
             registry.DOMAIN_SEPARATOR(),
             registry.SIGNATUREDATA_TYPEHASH(),
             contractId,
@@ -1216,7 +1230,8 @@ contract CyberCorpTest is Test {
         partyValuesB[0] = "Party Value B";
 
         vm.startPrank(newPartyAddr);
-        bytes memory newPartySignature = _signAgreementTypedData(
+        bytes memory newPartySignature = CyberAgreementUtils.signAgreementTypedData(
+            vm,
             registry.DOMAIN_SEPARATOR(),
             registry.SIGNATUREDATA_TYPEHASH(),
             contractId,
@@ -1251,46 +1266,6 @@ contract CyberCorpTest is Test {
         vm.stopPrank();
     }
 
-    function _signAgreementTypedData(
-        bytes32 _domainSeparator,
-        bytes32 _typeHash,
-        bytes32 contractId,
-        string memory contractUri,
-        string[] memory globalFields,
-        string[] memory partyFields,
-        string[] memory globalValues,
-        string[] memory partyValues,
-        uint256 privKey
-    ) internal pure returns (bytes memory signature) {
-        // Hash string arrays the same way as the contract
-        bytes32 contractUriHash = keccak256(bytes(contractUri));
-        bytes32 globalFieldsHash = _hashStringArray(globalFields);
-        bytes32 partyFieldsHash = _hashStringArray(partyFields);
-        bytes32 globalValuesHash = _hashStringArray(globalValues);
-        bytes32 partyValuesHash = _hashStringArray(partyValues);
-
-        // Create the message hash using the same approach as the contract
-        bytes32 structHash = keccak256(
-            abi.encode(
-                _typeHash,
-                contractId,
-                contractUriHash,
-                globalFieldsHash,
-                partyFieldsHash,
-                globalValuesHash,
-                partyValuesHash
-            )
-        );
-
-        bytes32 digest = keccak256(
-            abi.encodePacked("\x19\x01", _domainSeparator, structHash)
-        );
-
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privKey, digest);
-        signature = abi.encodePacked(r, s, v);
-        return signature;
-    }
-
     function _signVoidRequest(
         bytes32 _domainSeparator,
         bytes32 _typeHash,
@@ -1310,17 +1285,6 @@ contract CyberCorpTest is Test {
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(privKey, digest);
         signature = abi.encodePacked(r, s, v);
         return signature;
-    }
-
-    // Add this helper function to your test contract
-    function _hashStringArray(
-        string[] memory array
-    ) internal pure returns (bytes32) {
-        bytes32[] memory hashes = new bytes32[](array.length);
-        for (uint256 i = 0; i < array.length; i++) {
-            hashes[i] = keccak256(bytes(array[i]));
-        }
-        return keccak256(abi.encodePacked(hashes));
     }
 
     function testRevokeDealBeforePayment() public {
@@ -1367,7 +1331,8 @@ contract CyberCorpTest is Test {
             )
         );
 
-        bytes memory signature = _signAgreementTypedData(
+        bytes memory signature = CyberAgreementUtils.signAgreementTypedData(
+            vm,
             registry.DOMAIN_SEPARATOR(),
             registry.SIGNATUREDATA_TYPEHASH(),
             contractId,
@@ -1470,7 +1435,8 @@ contract CyberCorpTest is Test {
             )
         );
 
-        bytes memory signature = _signAgreementTypedData(
+        bytes memory signature = CyberAgreementUtils.signAgreementTypedData(
+            vm,
             registry.DOMAIN_SEPARATOR(),
             registry.SIGNATUREDATA_TYPEHASH(),
             contractId,
@@ -1520,7 +1486,8 @@ contract CyberCorpTest is Test {
         partyValuesB[0] = "Party Value B";
 
         vm.startPrank(newPartyAddr);
-        bytes memory newPartySignature = _signAgreementTypedData(
+        bytes memory newPartySignature = CyberAgreementUtils.signAgreementTypedData(
+            vm,
             registry.DOMAIN_SEPARATOR(),
             registry.SIGNATUREDATA_TYPEHASH(),
             contractId,
@@ -1602,7 +1569,8 @@ contract CyberCorpTest is Test {
             )
         );
 
-        bytes memory signature = _signAgreementTypedData(
+        bytes memory signature = CyberAgreementUtils.signAgreementTypedData(
+            vm,
             registry.DOMAIN_SEPARATOR(),
             registry.SIGNATUREDATA_TYPEHASH(),
             contractId,
@@ -1705,7 +1673,8 @@ contract CyberCorpTest is Test {
             )
         );
 
-        bytes memory signature = _signAgreementTypedData(
+        bytes memory signature = CyberAgreementUtils.signAgreementTypedData(
+            vm,
             registry.DOMAIN_SEPARATOR(),
             registry.SIGNATUREDATA_TYPEHASH(),
             contractId,
@@ -1811,7 +1780,8 @@ contract CyberCorpTest is Test {
             )
         );
 
-        bytes memory signature = _signAgreementTypedData(
+        bytes memory signature = CyberAgreementUtils.signAgreementTypedData(
+            vm,
             registry.DOMAIN_SEPARATOR(),
             registry.SIGNATUREDATA_TYPEHASH(),
             contractId,
@@ -1911,7 +1881,8 @@ contract CyberCorpTest is Test {
             )
         );
 
-        bytes memory signature = _signAgreementTypedData(
+        bytes memory signature = CyberAgreementUtils.signAgreementTypedData(
+            vm,
             registry.DOMAIN_SEPARATOR(),
             registry.SIGNATUREDATA_TYPEHASH(),
             contractId,
@@ -1959,7 +1930,8 @@ contract CyberCorpTest is Test {
         partyValuesB[0] = "Party Value B";
 
         vm.startPrank(newPartyAddr);
-        bytes memory newPartySignature = _signAgreementTypedData(
+        bytes memory newPartySignature = CyberAgreementUtils.signAgreementTypedData(
+            vm,
             registry.DOMAIN_SEPARATOR(),
             registry.SIGNATUREDATA_TYPEHASH(),
             contractId,
@@ -2037,7 +2009,8 @@ contract CyberCorpTest is Test {
             )
         );
 
-        bytes memory signature = _signAgreementTypedData(
+        bytes memory signature = CyberAgreementUtils.signAgreementTypedData(
+            vm,
             registry.DOMAIN_SEPARATOR(),
             registry.SIGNATUREDATA_TYPEHASH(),
             contractId,
@@ -2085,7 +2058,8 @@ contract CyberCorpTest is Test {
         partyValuesB[0] = "Party Value B";
 
         vm.startPrank(newPartyAddr);
-        bytes memory newPartySignature = _signAgreementTypedData(
+        bytes memory newPartySignature = CyberAgreementUtils.signAgreementTypedData(
+            vm,
             registry.DOMAIN_SEPARATOR(),
             registry.SIGNATUREDATA_TYPEHASH(),
             contractId,
@@ -2175,7 +2149,8 @@ contract CyberCorpTest is Test {
             )
         );
 
-        bytes memory signature = _signAgreementTypedData(
+        bytes memory signature = CyberAgreementUtils.signAgreementTypedData(
+            vm,
             registry.DOMAIN_SEPARATOR(),
             registry.SIGNATUREDATA_TYPEHASH(),
             contractId,
@@ -2231,7 +2206,8 @@ contract CyberCorpTest is Test {
         partyValuesB[0] = "Party Value B";
 
         vm.startPrank(newPartyAddr);
-        bytes memory newPartySignature = _signAgreementTypedData(
+        bytes memory newPartySignature = CyberAgreementUtils.signAgreementTypedData(
+            vm,
             registry.DOMAIN_SEPARATOR(),
             registry.SIGNATUREDATA_TYPEHASH(),
             contractId,
@@ -2319,7 +2295,8 @@ contract CyberCorpTest is Test {
             )
         );
 
-        bytes memory signature = _signAgreementTypedData(
+        bytes memory signature = CyberAgreementUtils.signAgreementTypedData(
+            vm,
             registry.DOMAIN_SEPARATOR(),
             registry.SIGNATUREDATA_TYPEHASH(),
             contractId,
@@ -2366,7 +2343,8 @@ contract CyberCorpTest is Test {
         partyValuesB[0] = "Party Value B";
 
         vm.startPrank(newPartyAddr);
-        bytes memory newPartySignature = _signAgreementTypedData(
+        bytes memory newPartySignature = CyberAgreementUtils.signAgreementTypedData(
+            vm,
             registry.DOMAIN_SEPARATOR(),
             registry.SIGNATUREDATA_TYPEHASH(),
             contractId,
@@ -2447,7 +2425,8 @@ contract CyberCorpTest is Test {
             )
         );
 
-        bytes memory signature = _signAgreementTypedData(
+        bytes memory signature = CyberAgreementUtils.signAgreementTypedData(
+            vm,
             registry.DOMAIN_SEPARATOR(),
             registry.SIGNATUREDATA_TYPEHASH(),
             contractId,
@@ -2498,7 +2477,8 @@ contract CyberCorpTest is Test {
         partyValuesB[0] = "Party Value B";
 
         vm.startPrank(newPartyAddr);
-        bytes memory newPartySignature = _signAgreementTypedData(
+        bytes memory newPartySignature = CyberAgreementUtils.signAgreementTypedData(
+            vm,
             registry.DOMAIN_SEPARATOR(),
             registry.SIGNATUREDATA_TYPEHASH(),
             contractId,
@@ -2602,7 +2582,8 @@ contract CyberCorpTest is Test {
             )
         );
 
-        bytes memory proposerSignature = _signAgreementTypedData(
+        bytes memory proposerSignature = CyberAgreementUtils.signAgreementTypedData(
+            vm,
             registry.DOMAIN_SEPARATOR(),
             registry.SIGNATUREDATA_TYPEHASH(),
             contractId,
@@ -2655,7 +2636,8 @@ contract CyberCorpTest is Test {
         partyValuesB[4] = "Deleware";
 
         vm.startPrank(newPartyAddr);
-        bytes memory newPartySignature = _signAgreementTypedData(
+        bytes memory newPartySignature = CyberAgreementUtils.signAgreementTypedData(
+            vm,
             registry.DOMAIN_SEPARATOR(),
             registry.SIGNATUREDATA_TYPEHASH(),
             contractId,
@@ -2836,7 +2818,8 @@ contract CyberCorpTest is Test {
         address[] memory extensions = new address[](1);
         extensions[0] = warrantExtension;
 
-        bytes memory proposerSignature = _signAgreementTypedData(
+        bytes memory proposerSignature = CyberAgreementUtils.signAgreementTypedData(
+            vm,
             registry.DOMAIN_SEPARATOR(),
             registry.SIGNATUREDATA_TYPEHASH(),
             contractId,
@@ -2890,7 +2873,8 @@ contract CyberCorpTest is Test {
         partyValuesB[4] = "Deleware";
 
         vm.startPrank(newPartyAddr);
-        bytes memory newPartySignature = _signAgreementTypedData(
+        bytes memory newPartySignature = CyberAgreementUtils.signAgreementTypedData(
+            vm,
             registry.DOMAIN_SEPARATOR(),
             registry.SIGNATUREDATA_TYPEHASH(),
             contractId,
@@ -3089,7 +3073,8 @@ contract CyberCorpTest is Test {
         string[] memory partyFields = new string[](1);
         partyFields[0] = "Party Field 1";
 
-        bytes memory signature = _signAgreementTypedData(
+        bytes memory signature = CyberAgreementUtils.signAgreementTypedData(
+            vm,
             registry.DOMAIN_SEPARATOR(),
             registry.SIGNATUREDATA_TYPEHASH(),
             contractId,
@@ -3199,7 +3184,8 @@ contract CyberCorpTest is Test {
         string[] memory partyFields = new string[](1);
         partyFields[0] = "Party Field 1";
 
-        bytes memory signature = _signAgreementTypedData(
+        bytes memory signature = CyberAgreementUtils.signAgreementTypedData(
+            vm,
             registry.DOMAIN_SEPARATOR(),
             registry.SIGNATUREDATA_TYPEHASH(),
             contractId,
@@ -3325,7 +3311,8 @@ contract CyberCorpTest is Test {
         string[] memory partyFields = new string[](1);
         partyFields[0] = "Party Field 1";
 
-        bytes memory signature = _signAgreementTypedData(
+        bytes memory signature = CyberAgreementUtils.signAgreementTypedData(
+            vm,
             registry.DOMAIN_SEPARATOR(),
             registry.SIGNATUREDATA_TYPEHASH(),
             contractId,
@@ -3464,7 +3451,8 @@ contract CyberCorpTest is Test {
         string[] memory partyFields = new string[](1);
         partyFields[0] = "Party Field 1";
 
-        bytes memory signature = _signAgreementTypedData(
+        bytes memory signature = CyberAgreementUtils.signAgreementTypedData(
+            vm,
             registry.DOMAIN_SEPARATOR(),
             registry.SIGNATUREDATA_TYPEHASH(),
             contractId,
@@ -3593,7 +3581,8 @@ contract CyberCorpTest is Test {
         string[] memory partyFields = new string[](1);
         partyFields[0] = "Party Field 1";
 
-        bytes memory signature = _signAgreementTypedData(
+        bytes memory signature = CyberAgreementUtils.signAgreementTypedData(
+            vm,
             registry.DOMAIN_SEPARATOR(),
             registry.SIGNATUREDATA_TYPEHASH(),
             contractId,
@@ -3823,12 +3812,12 @@ contract CyberCorpTest is Test {
         console.logBytes32(check);
 
         bytes32 salt = bytes32(keccak256("TestSAFTE"));
-        
+
         address safteExtension = address(new ERC1967Proxy{salt: salt}(
            address(new SAFTEExtension{salt: salt}()),
            abi.encodeWithSelector(SAFTEExtension.initialize.selector, address(auth))
         ));
-        
+
         SAFTEData memory safteData = SAFTEData({
             unlockStartTimeType: UnlockStartTimeType.tokenWarrantTime,
             unlockStartTime: block.timestamp,
@@ -3904,7 +3893,8 @@ contract CyberCorpTest is Test {
             )
         );
 
-        bytes memory proposerSignature = _signAgreementTypedData(
+        bytes memory proposerSignature = CyberAgreementUtils.signAgreementTypedData(
+            vm,
             registry.DOMAIN_SEPARATOR(),
             registry.SIGNATUREDATA_TYPEHASH(),
             contractId,
@@ -3958,7 +3948,8 @@ contract CyberCorpTest is Test {
         partyValuesB[4] = "Deleware";
 
         vm.startPrank(newPartyAddr);
-        bytes memory newPartySignature = _signAgreementTypedData(
+        bytes memory newPartySignature = CyberAgreementUtils.signAgreementTypedData(
+            vm,
             registry.DOMAIN_SEPARATOR(),
             registry.SIGNATUREDATA_TYPEHASH(),
             contractId,
@@ -4038,11 +4029,11 @@ contract CyberCorpTest is Test {
 
         // Now create an offer using the new createOffer function
         DealManager dealManager = DealManager(dealManagerAddr);
-        
+
         // Prepare certificate data
         string[] memory defaultLegend = new string[](1);
         defaultLegend[0] = "Test Legend";
-        
+
         DealManager.CyberCertData[] memory certData = new DealManager.CyberCertData[](1);
         certData[0] = DealManager.CyberCertData({
             name: "Test Certificate",
@@ -4081,7 +4072,8 @@ contract CyberCorpTest is Test {
         string[] memory partyFields = new string[](1);
         partyFields[0] = "Party Field 1";
 
-        bytes memory signature = _signAgreementTypedData(
+        bytes memory signature = CyberAgreementUtils.signAgreementTypedData(
+            vm,
             registry.DOMAIN_SEPARATOR(),
             registry.SIGNATUREDATA_TYPEHASH(),
             contractId,
@@ -4128,12 +4120,12 @@ contract CyberCorpTest is Test {
         // Verify the certificate printer was created correctly
         CyberCertPrinter certPrinter = CyberCertPrinter(certPrinterAddress[0]);
 
-        
+
         // Verify the certificate name includes the company name
         string memory expectedName = "TestCorp Test Certificate";
         // Note: We can't directly check the name as it's not exposed in the interface
         // but we can verify the certificate was created successfully
-        
+
         // Verify the deal was created in the registry
         assertTrue(
             CyberAgreementRegistry(registry).hasSigned(id, testAddress),
@@ -4196,13 +4188,13 @@ contract CyberCorpTest is Test {
 
         // Now create an offer with multiple certificates
         DealManager dealManager = DealManager(dealManagerAddr);
-        
+
         // Prepare certificate data for multiple certificates
         string[] memory safeLegend = new string[](1);
         safeLegend[0] = "SAFE Legend";
         string[] memory warrantLegend = new string[](1);
         warrantLegend[0] = "Token Warrant Legend";
-        
+
         DealManager.CyberCertData[] memory certData = new DealManager.CyberCertData[](2);
         certData[0] = DealManager.CyberCertData({
             name: "SAFE Certificate",
@@ -4250,7 +4242,8 @@ contract CyberCorpTest is Test {
         string[] memory partyFields = new string[](1);
         partyFields[0] = "Party Field 1";
 
-        bytes memory signature = _signAgreementTypedData(
+        bytes memory signature = CyberAgreementUtils.signAgreementTypedData(
+            vm,
             registry.DOMAIN_SEPARATOR(),
             registry.SIGNATUREDATA_TYPEHASH(),
             contractId,
@@ -4391,12 +4384,12 @@ contract CyberCorpTest is Test {
 
         // Verify the existing DealManager still works by checking its state
         DealManager dealManager = DealManager(dealManagerAddr);
-        
+
 
         // Create a simple deal to verify functionality still works
         string[] memory defaultLegend = new string[](1);
         defaultLegend[0] = "Test Legend";
-        
+
         DealManager.CyberCertData[] memory certData = new DealManager.CyberCertData[](1);
         certData[0] = DealManager.CyberCertData({
             name: "Test Certificate",
@@ -4433,7 +4426,8 @@ contract CyberCorpTest is Test {
         string[] memory partyFields = new string[](1);
         partyFields[0] = "Party Field 1";
 
-        bytes memory signature = _signAgreementTypedData(
+        bytes memory signature = CyberAgreementUtils.signAgreementTypedData(
+            vm,
             registry.DOMAIN_SEPARATOR(),
             registry.SIGNATUREDATA_TYPEHASH(),
             contractId,

--- a/test/LexChexMinterTest.t.sol
+++ b/test/LexChexMinterTest.t.sol
@@ -8,6 +8,7 @@ import {LeXcheXUtils} from "./libs/LeXcheXUtils.sol";
 import {ERC1967ProxyLib} from "./libs/ERC1967ProxyLib.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import {LeXcheXMinter} from "../src/creds/lexchexMinter.sol";
 import {LeXcheX} from "../src/creds/lexchex.sol";
 import {Test, console} from "forge-std/Test.sol";
@@ -43,6 +44,19 @@ contract LexChexMinterTest is Test {
     CyberAgreementRegistry registry;
     LeXcheX public lexchex;
     LeXcheXMinter public lexchexMinter;
+
+    uint256 requestSalt = uint256(keccak256("LexChexMinterTestRequestSalt"));
+    bytes32 templateId = bytes32(uint256(1));
+    string[] globalFields = new string[](1);
+    string[] partyFields = new string[](1);
+    string[] globalValues = new string[](1);
+    address[] parties = new address[](1);
+    string[][] partyValues = new string[][](1);
+    bytes32 agreementId;
+    bytes agreementSignature;
+    string[] portfolio = new string[](2);
+    LeXcheXMinter.MintRequest request;
+    bytes authoritySignature;
 
     function setUp() public {
         bytes32 salt = bytes32(keccak256("LexChexMinterTest"));
@@ -80,6 +94,61 @@ contract LexChexMinterTest is Test {
         coreAuth.updateRole(admin, coreAuth.ADMIN_ROLE());
 
         vm.stopPrank();
+
+        //
+        // Prepare a valid request
+        //
+
+        // Prepare funds for agent
+        deal(address(paymentToken), agent, 10e6, true);
+        vm.prank(agent);
+        paymentToken.approve(address(lexchexMinter), 10e6);
+
+        // TODO Use more realistic values
+        string memory legalContractUri = "ipfs.io/ipfs/[cid]";
+        globalFields[0] = "Global Field 1";
+        partyFields[0] = "Party Field 1";
+
+        vm.prank(owner);
+        registry.createTemplate(
+            templateId,
+            "Test Template",
+            legalContractUri,
+            globalFields,
+            partyFields
+        );
+
+        globalValues[0] = "Global Value 1";
+
+        parties[0] = address(user1);
+
+        partyValues[0] = new string[](1);
+        partyValues[0][0] = "Party Value 1";
+
+        agreementId = keccak256(
+            abi.encode(
+                templateId,
+                requestSalt,
+                globalValues,
+                parties
+            )
+        );
+
+        agreementSignature = CyberAgreementUtils.signAgreementTypedData(
+            vm,
+            registry.DOMAIN_SEPARATOR(),
+            registry.SIGNATUREDATA_TYPEHASH(),
+            agreementId,
+            legalContractUri,
+            globalFields,
+            partyFields,
+            globalValues,
+            partyValues[0],
+            user1PrivateKey
+        );
+
+        portfolio[0] = "0x123...";
+        portfolio[1] = "bc1q...";
     }
 
     function testMetadata() public view {
@@ -105,67 +174,22 @@ contract LexChexMinterTest is Test {
         ), "Unexpected AUTHORITY_TYPEHASH");
     }
 
+    function test_RevertIf_initializeImplementation() public {
+        LeXcheXMinter impl = new LeXcheXMinter();
+        vm.expectRevert(abi.encodeWithSelector(Initializable.InvalidInitialization.selector));
+        impl.initialize(
+            address(coreAuth),
+            address(lexchex),
+            address(registry),
+            address(paymentToken),
+            treasury
+        );
+    }
+
     function testRequestMint() public {
-        uint256 salt = uint256(keccak256("testRequestMint"));
+        uint256 agentPaymentBalanceBefore = paymentToken.balanceOf(agent);
 
-        // Prepare funds for agent
-        deal(address(paymentToken), agent, 10e6, true);
-        vm.prank(agent);
-        paymentToken.approve(address(lexchexMinter), 10e6);
-
-        // TODO Use more realistic values
-        bytes32 templateId = bytes32(uint256(1));
-        string memory legalContractUri = "ipfs.io/ipfs/[cid]";
-        string[] memory globalFields = new string[](1);
-        globalFields[0] = "Global Field 1";
-        string[] memory partyFields = new string[](1);
-        partyFields[0] = "Party Field 1";
-
-        vm.prank(owner);
-        registry.createTemplate(
-            templateId,
-            "Test Template",
-            legalContractUri,
-            globalFields,
-            partyFields
-        );
-
-        string[] memory globalValues = new string[](1);
-        globalValues[0] = "Global Value 1";
-
-        address[] memory parties = new address[](1);
-        parties[0] = address(user1);
-
-        string[][] memory partyValues = new string[][](1);
-        partyValues[0] = new string[](1);
-        partyValues[0][0] = "Party Value 1";
-
-        bytes32 contractId = keccak256(
-            abi.encode(
-                templateId,
-                salt,
-                globalValues,
-                parties
-            )
-        );
-
-        bytes memory agreementSignature = CyberAgreementUtils.signAgreementTypedData(
-            vm,
-            registry.DOMAIN_SEPARATOR(),
-            registry.SIGNATUREDATA_TYPEHASH(),
-            contractId,
-            legalContractUri,
-            globalFields,
-            partyFields,
-            globalValues,
-            partyValues[0],
-            user1PrivateKey
-        );
-
-        string[] memory portfolio = new string[](2);
-        portfolio[0] = "0x123...";
-        portfolio[1] = "bc1q...";
-        LeXcheXMinter.MintRequest memory request = LeXcheXMinter.MintRequest({
+        request = LeXcheXMinter.MintRequest({
             owner: user1,
             name: "Test Entity",
             entityType: "LLC",
@@ -176,7 +200,7 @@ contract LexChexMinterTest is Test {
             expiry: block.timestamp + 1 days
         });
 
-        bytes memory authoritySignature = LeXcheXUtils.signAuthorizationTypedData(
+        authoritySignature = LeXcheXUtils.signAuthorizationTypedData(
             vm,
             lexchexMinter.DOMAIN_SEPARATOR(),
             lexchexMinter.AUTHORITY_TYPEHASH(),
@@ -194,14 +218,66 @@ contract LexChexMinterTest is Test {
 
         // Request should succeed
         vm.expectEmit(true, true, true, true);
-        emit LeXcheXMinter.MintRequested(user1, 10e6, contractId);
+        emit LeXcheXMinter.MintRequested(user1, 10e6, agreementId);
         vm.expectEmit(true, true, true, true);
-        emit LeXcheXMinter.MintCompleted(user1, 0, contractId);
+        emit LeXcheXMinter.MintCompleted(user1, 0, agreementId);
         vm.prank(agent);
         lexchexMinter.requestMint(
             request,
             templateId,
-            salt,
+            requestSalt,
+            globalValues,
+            parties,
+            partyValues,
+            agreementSignature,
+            authoritySignature
+        );
+        
+        assertEq(lexchex.balanceOf(user1), 1, "user1 should get one token");
+        assertEq(lexchex.ownerOf(0), user1, "token should be owned by user 1");
+        assertEq(agentPaymentBalanceBefore - paymentToken.balanceOf(agent), 10e6, "payment is not correct");
+    }
+
+    function testRequestMintFree() public {
+        uint256 agentPaymentBalanceBefore = paymentToken.balanceOf(agent);
+
+        request = LeXcheXMinter.MintRequest({
+            owner: user1,
+            name: "Test Entity",
+            entityType: "LLC",
+            jurisdiction: "Delaware",
+            contact: "test@test.com",
+            portfolio: portfolio,
+            mintPrice: 0, // free
+            expiry: block.timestamp + 1 days
+        });
+
+        authoritySignature = LeXcheXUtils.signAuthorizationTypedData(
+            vm,
+            lexchexMinter.DOMAIN_SEPARATOR(),
+            lexchexMinter.AUTHORITY_TYPEHASH(),
+            LeXcheXMinter.AuthorityData({
+                owner: request.owner,
+                name: request.name,
+                entityType: request.entityType,
+                jurisdiction: request.jurisdiction,
+                contact: request.contact,
+                mintPrice: request.mintPrice,
+                expiry: request.expiry
+            }),
+            adminPrivateKey
+        );
+
+        // Request should succeed
+        vm.expectEmit(true, true, true, true);
+        emit LeXcheXMinter.MintRequested(user1, 0, agreementId);
+        vm.expectEmit(true, true, true, true);
+        emit LeXcheXMinter.MintCompleted(user1, 0, agreementId);
+        vm.prank(agent);
+        lexchexMinter.requestMint(
+            request,
+            templateId,
+            requestSalt,
             globalValues,
             parties,
             partyValues,
@@ -209,8 +285,53 @@ contract LexChexMinterTest is Test {
             authoritySignature
         );
 
-        assertEq(lexchex.balanceOf(user1), 1);
-        assertEq(lexchex.ownerOf(0), user1);
+        assertEq(lexchex.balanceOf(user1), 1, "user1 should get one token");
+        assertEq(lexchex.ownerOf(0), user1, "token should be owned by user 1");
+        assertEq(paymentToken.balanceOf(agent), agentPaymentBalanceBefore, "payment should be free");
+    }
+
+    function test_RevertIf_invalidAuthoritySignature() public {
+        request = LeXcheXMinter.MintRequest({
+            owner: user1,
+            name: "Test Entity",
+            entityType: "LLC",
+            jurisdiction: "Delaware",
+            contact: "test@test.com",
+            portfolio: portfolio,
+            mintPrice: 10e6,
+            expiry: block.timestamp + 1 days
+        });
+
+        // Create an invalid authority signature
+        authoritySignature = LeXcheXUtils.signAuthorizationTypedData(
+            vm,
+            lexchexMinter.DOMAIN_SEPARATOR(),
+            lexchexMinter.AUTHORITY_TYPEHASH(),
+            LeXcheXMinter.AuthorityData({
+                owner: request.owner,
+                name: request.name,
+                entityType: request.entityType,
+                jurisdiction: request.jurisdiction,
+                contact: request.contact,
+                mintPrice: request.mintPrice,
+                expiry: request.expiry
+            }),
+            user1PrivateKey // Intentionally wrong private key
+        );
+
+        // Request should fail
+        vm.expectRevert(abi.encodeWithSelector(BorgAuth.BorgAuth_NotAuthorized.selector, coreAuth.ADMIN_ROLE(), user1));
+        vm.prank(agent);
+        lexchexMinter.requestMint(
+            request,
+            templateId,
+            requestSalt,
+            globalValues,
+            parties,
+            partyValues,
+            agreementSignature,
+            authoritySignature
+        );
     }
 
     function testSetLexchex() public {

--- a/test/LexChexMinterTest.t.sol
+++ b/test/LexChexMinterTest.t.sol
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.28;
+
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {BorgAuth} from "../src/libs/auth.sol";
+import {CyberAgreementRegistry} from "../src/CyberAgreementRegistry.sol";
+import {LeXcheXMinter} from "../src/creds/lexchexMinter.sol";
+import {LeXcheX} from "../src/creds/lexchex.sol";
+import {Test, console} from "forge-std/Test.sol";
+
+contract PaymentToken is ERC20 {
+    constructor(uint256 initialSupply) ERC20("Payment Token", "TestUSDC") {
+        _mint(msg.sender, initialSupply);
+    }
+
+    function decimals() public view override returns (uint8) {
+        return 6;
+    }
+}
+
+contract LexChexMinterTest is Test {
+    uint256 testPrivateKey = 1337;
+    address testAddress = vm.addr(testPrivateKey);
+
+    address deployer = address(1);
+    address user1 = address(2);
+    address user2 = address(3);
+    address treasury = address(4);
+
+    ERC20 paymentToken = new PaymentToken(100e6);
+
+    BorgAuth auth;
+    CyberAgreementRegistry registry;
+    LeXcheX public lexchex;
+    LeXcheXMinter public lexchexMinter;
+
+    function setUp() public {
+        bytes32 salt = bytes32(keccak256("LexChexMinterTest"));
+
+        vm.startPrank(deployer);
+
+        auth = new BorgAuth{salt: salt}(deployer);
+
+        registry = CyberAgreementRegistry(address(new ERC1967Proxy{salt: salt}(
+            address(new CyberAgreementRegistry{salt: salt}()),
+            abi.encodeWithSelector(CyberAgreementRegistry.initialize.selector, address(auth))
+        )));
+
+        lexchex = LeXcheX(address(new ERC1967Proxy{salt: salt}(
+            address(new LeXcheX{salt: salt}()),
+            abi.encodeWithSelector(LeXcheX.initialize.selector, address(auth))
+        )));
+
+        lexchexMinter = LeXcheXMinter(address(new ERC1967Proxy{salt: salt}(
+            address(new LeXcheXMinter{salt: salt}()),
+            abi.encodeWithSelector(
+                LeXcheXMinter.initialize.selector,
+                address(auth),
+                address(lexchex),
+                address(registry),
+                address(paymentToken),
+                treasury
+            )
+        )));
+
+        vm.stopPrank();
+    }
+
+    function testMetadata() public {
+        assertEq(lexchexMinter.auth(), address(auth), "Unexpected auth");
+        assertEq(lexchexMinter.lexchex(), address(lexchex), "Unexpected lexchex");
+        assertEq(lexchexMinter.dealRegistry(), address(registry), "Unexpected dealRegistry");
+        assertEq(lexchexMinter.paymentToken(), address(paymentToken), "Unexpected paymentToken");
+        assertEq(lexchexMinter.treasury(), address(treasury), "Unexpected treasury");
+        assertEq(lexchexMinter.version(), "1", "Unexpected version");
+        assertEq(lexchexMinter.DOMAIN_SEPARATOR(), keccak256(
+            abi.encode(
+                keccak256(
+                    "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+                ),
+                keccak256(bytes("LeXcheXMinter")),
+                keccak256(bytes("1")),
+                block.chainid,
+                address(lexchexMinter)
+            )
+        ), "Unexpected DOMAIN_SEPARATOR");
+        assertEq(lexchexMinter.AUTHORITY_TYPEHASH(), keccak256(
+            "AuthorityData(address owner,string name,string entityType,string jurisdiction,uint256 mintPrice,uint256 expiry)"
+        ), "Unexpected AUTHORITY_TYPEHASH");
+    }
+
+//    function testRequestMint() public {
+//        // TODO Use more realistic values
+//        bytes32 templateId = bytes32(uint256(1));
+//
+//        string[] memory globalValues = new string[](1);
+//        globalValues[0] = "Global Value 1";
+//
+//        address[] memory parties = new address[](2);
+//        parties[0] = address(testAddress);
+//        parties[1] = address(0);
+//
+//        uint256 _paymentAmount = 1000000000000000000;
+//
+//        string[][] memory partyValues = new string[][](1);
+//        partyValues[0] = new string[](1);
+//        partyValues[0][0] = "Party Value 1";
+//
+//        bytes32 contractId = keccak256(
+//            abi.encode(
+//                templateId,
+//                block.timestamp,
+//                globalValues,
+//                parties
+//            )
+//        );
+//
+//        string[] memory globalFields = new string[](1);
+//        globalFields[0] = "Global Field 1";
+//        string[] memory partyFields = new string[](1);
+//        partyFields[0] = "Party Field 1";
+//
+//        bytes memory signature = _signAgreementTypedData(
+//            registry.DOMAIN_SEPARATOR(),
+//            registry.SIGNATUREDATA_TYPEHASH(),
+//            contractId,
+//            "ipfs.io/ipfs/[cid]",
+//            globalFields,
+//            partyFields,
+//            globalValues,
+//            partyValues[0],
+//            testPrivateKey
+//        );
+//
+//        MintRequest memory request = MintRequest({
+//
+//        });
+//        lexchexMinter.requestMint(
+//            request,
+//            templateId,
+//            salt,
+//            globalValues,
+//            parties,
+//            partyValues,
+//
+//        );
+//    }
+
+    function testSetLexchex() public {
+        // Non-owner should not be allowed
+        vm.expectRevert(abi.encodeWithSelector(BorgAuth.BorgAuth_NotAuthorized.selector, auth.OWNER_ROLE(), user1));
+        vm.prank(user1);
+        lexchexMinter.setLexchex(address(0x1));
+
+        // Owner should be allowed
+        vm.prank(deployer);
+        lexchexMinter.setLexchex(address(0x1));
+        assertEq(lexchexMinter.lexchex(), address(0x1), "lexchex should've been updated");
+    }
+
+    function testSetDealRegistry() public {
+        // Non-owner should not be allowed
+        vm.expectRevert(abi.encodeWithSelector(BorgAuth.BorgAuth_NotAuthorized.selector, auth.OWNER_ROLE(), user1));
+        vm.prank(user1);
+        lexchexMinter.setDealRegistry(address(0x1));
+
+        // Owner should be allowed
+        vm.prank(deployer);
+        lexchexMinter.setDealRegistry(address(0x1));
+        assertEq(lexchexMinter.dealRegistry(), address(0x1), "dealRegistry should've been updated");
+    }
+
+    function testSetPaymentToken() public {
+        // Non-owner should not be allowed
+        vm.expectRevert(abi.encodeWithSelector(BorgAuth.BorgAuth_NotAuthorized.selector, auth.OWNER_ROLE(), user1));
+        vm.prank(user1);
+        lexchexMinter.setPaymentToken(address(0x1));
+
+        // Owner should be allowed
+        vm.prank(deployer);
+        lexchexMinter.setPaymentToken(address(0x1));
+        assertEq(lexchexMinter.paymentToken(), address(0x1), "paymentToken should've been updated");
+    }
+
+    function testSetTreasury() public {
+        // Non-owner should not be allowed
+        vm.expectRevert(abi.encodeWithSelector(BorgAuth.BorgAuth_NotAuthorized.selector, auth.OWNER_ROLE(), user1));
+        vm.prank(user1);
+        lexchexMinter.setTreasury(address(0x1));
+
+        // Owner should be allowed
+        vm.prank(deployer);
+        lexchexMinter.setTreasury(address(0x1));
+        assertEq(lexchexMinter.treasury(), address(0x1), "treasury should've been updated");
+    }
+
+    // TODO test upgradeability
+}

--- a/test/LexChexMinterTest.t.sol
+++ b/test/LexChexMinterTest.t.sol
@@ -1,4 +1,43 @@
-// SPDX-License-Identifier: UNLICENSED
+/*    .o.
+     .888.
+    .8"888.
+   .8' `888.
+  .88ooo8888.
+ .8'     `888.
+o88o     o8888o
+
+
+
+ooo        ooooo               .             ooooo                  ooooooo  ooooo
+`88.       .888'             .o8             `888'                   `8888    d8'
+ 888b     d'888   .ooooo.  .o888oo  .oooo.    888          .ooooo.     Y888..8P
+ 8 Y88. .P  888  d88' `88b   888   `P  )88b   888         d88' `88b     `8888'
+ 8  `888'   888  888ooo888   888    .oP"888   888         888ooo888    .8PY888.
+ 8    Y     888  888    .o   888 . d8(  888   888       o 888    .o   d8'  `888b
+o8o        o888o `Y8bod8P'   "888" `Y888""8o o888ooooood8 `Y8bod8P' o888o  o88888o
+
+
+
+  .oooooo.                .o8                            .oooooo.
+ d8P'  `Y8b              "888                           d8P'  `Y8b
+888          oooo    ooo  888oooo.   .ooooo.  oooo d8b 888           .ooooo.  oooo d8b oo.ooooo.
+888           `88.  .8'   d88' `88b d88' `88b `888""8P 888          d88' `88b `888""8P  888' `88b
+888            `88..8'    888   888 888ooo888  888     888          888   888  888      888   888
+`88b    ooo     `888'     888   888 888    .o  888     `88b    ooo  888   888  888      888   888 .o.
+ `Y8bood8P'      .8'      `Y8bod8P' `Y8bod8P' d888b     `Y8bood8P'  `Y8bod8P' d888b     888bod8P' Y8P
+             .o..P'                                                                     888
+             `Y8P'                                                                     o888o
+_______________________________________________________________________________________________________
+
+All software, documentation and other files and information in this repository (collectively, the "Software")
+are copyright MetaLeX Labs, Inc., a Delaware corporation.
+
+All rights reserved.
+
+The Software is proprietary and shall not, in part or in whole, be used, copied, modified, merged, published,
+distributed, transmitted, sublicensed, sold, or otherwise used in any form or by any means, electronic or
+mechanical, including photocopying, recording, or by any information storage and retrieval system,
+except with the express prior written permission of the copyright holder.*/
 pragma solidity 0.8.28;
 
 import {BorgAuth} from "../src/libs/auth.sol";

--- a/test/LexChexMinterTest.t.sol
+++ b/test/LexChexMinterTest.t.sol
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.28;
 
-import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
-import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {BorgAuth} from "../src/libs/auth.sol";
 import {CyberAgreementRegistry} from "../src/CyberAgreementRegistry.sol";
+import {CyberAgreementUtils} from "./libs/CyberAgreementUtils.sol";
+import {LeXcheXUtils} from "./libs/LeXcheXUtils.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {LeXcheXMinter} from "../src/creds/lexchexMinter.sol";
 import {LeXcheX} from "../src/creds/lexchex.sol";
 import {Test, console} from "forge-std/Test.sol";
@@ -14,23 +16,26 @@ contract PaymentToken is ERC20 {
         _mint(msg.sender, initialSupply);
     }
 
-    function decimals() public view override returns (uint8) {
+    function decimals() public pure override returns (uint8) {
         return 6;
     }
 }
 
 contract LexChexMinterTest is Test {
-    uint256 testPrivateKey = 1337;
-    address testAddress = vm.addr(testPrivateKey);
+    uint256 adminPrivateKey = 1;
+    address admin = vm.addr(adminPrivateKey);
+    uint256 user1PrivateKey = 2;
+    address user1 = vm.addr(user1PrivateKey);
+    uint256 user2PrivateKey = 3;
+    address user2 = vm.addr(user2PrivateKey);
 
-    address deployer = address(1);
-    address user1 = address(2);
-    address user2 = address(3);
-    address treasury = address(4);
+    address agent = address(1);
+    address treasury = address(2);
 
-    ERC20 paymentToken = new PaymentToken(100e6);
+    ERC20 paymentToken = new PaymentToken(0);
 
-    BorgAuth auth;
+    BorgAuth coreAuth;
+    BorgAuth lexchexAuth;
     CyberAgreementRegistry registry;
     LeXcheX public lexchex;
     LeXcheXMinter public lexchexMinter;
@@ -38,25 +43,26 @@ contract LexChexMinterTest is Test {
     function setUp() public {
         bytes32 salt = bytes32(keccak256("LexChexMinterTest"));
 
-        vm.startPrank(deployer);
+        vm.startPrank(admin);
 
-        auth = new BorgAuth{salt: salt}(deployer);
+        coreAuth = new BorgAuth(admin);
+        lexchexAuth = new BorgAuth(admin);
 
         registry = CyberAgreementRegistry(address(new ERC1967Proxy{salt: salt}(
             address(new CyberAgreementRegistry{salt: salt}()),
-            abi.encodeWithSelector(CyberAgreementRegistry.initialize.selector, address(auth))
+            abi.encodeWithSelector(CyberAgreementRegistry.initialize.selector, address(coreAuth))
         )));
 
         lexchex = LeXcheX(address(new ERC1967Proxy{salt: salt}(
             address(new LeXcheX{salt: salt}()),
-            abi.encodeWithSelector(LeXcheX.initialize.selector, address(auth))
+            abi.encodeWithSelector(LeXcheX.initialize.selector, address(lexchexAuth))
         )));
 
         lexchexMinter = LeXcheXMinter(address(new ERC1967Proxy{salt: salt}(
             address(new LeXcheXMinter{salt: salt}()),
             abi.encodeWithSelector(
                 LeXcheXMinter.initialize.selector,
-                address(auth),
+                address(coreAuth),
                 address(lexchex),
                 address(registry),
                 address(paymentToken),
@@ -64,11 +70,14 @@ contract LexChexMinterTest is Test {
             )
         )));
 
+        // Grant LeXcheXMinter admin access to LeXcheX
+        lexchexAuth.updateRole(address(lexchexMinter), lexchexAuth.ADMIN_ROLE());
+
         vm.stopPrank();
     }
 
-    function testMetadata() public {
-        assertEq(lexchexMinter.auth(), address(auth), "Unexpected auth");
+    function testMetadata() public view {
+        assertEq(lexchexMinter.auth(), address(coreAuth), "Unexpected auth");
         assertEq(lexchexMinter.lexchex(), address(lexchex), "Unexpected lexchex");
         assertEq(lexchexMinter.dealRegistry(), address(registry), "Unexpected dealRegistry");
         assertEq(lexchexMinter.paymentToken(), address(paymentToken), "Unexpected paymentToken");
@@ -90,107 +99,157 @@ contract LexChexMinterTest is Test {
         ), "Unexpected AUTHORITY_TYPEHASH");
     }
 
-//    function testRequestMint() public {
-//        // TODO Use more realistic values
-//        bytes32 templateId = bytes32(uint256(1));
-//
-//        string[] memory globalValues = new string[](1);
-//        globalValues[0] = "Global Value 1";
-//
-//        address[] memory parties = new address[](2);
-//        parties[0] = address(testAddress);
-//        parties[1] = address(0);
-//
-//        uint256 _paymentAmount = 1000000000000000000;
-//
-//        string[][] memory partyValues = new string[][](1);
-//        partyValues[0] = new string[](1);
-//        partyValues[0][0] = "Party Value 1";
-//
-//        bytes32 contractId = keccak256(
-//            abi.encode(
-//                templateId,
-//                block.timestamp,
-//                globalValues,
-//                parties
-//            )
-//        );
-//
-//        string[] memory globalFields = new string[](1);
-//        globalFields[0] = "Global Field 1";
-//        string[] memory partyFields = new string[](1);
-//        partyFields[0] = "Party Field 1";
-//
-//        bytes memory signature = _signAgreementTypedData(
-//            registry.DOMAIN_SEPARATOR(),
-//            registry.SIGNATUREDATA_TYPEHASH(),
-//            contractId,
-//            "ipfs.io/ipfs/[cid]",
-//            globalFields,
-//            partyFields,
-//            globalValues,
-//            partyValues[0],
-//            testPrivateKey
-//        );
-//
-//        MintRequest memory request = MintRequest({
-//
-//        });
-//        lexchexMinter.requestMint(
-//            request,
-//            templateId,
-//            salt,
-//            globalValues,
-//            parties,
-//            partyValues,
-//
-//        );
-//    }
+    function testRequestMint() public {
+        uint256 salt = uint256(keccak256("testRequestMint"));
+
+        // Prepare funds for agent
+        deal(address(paymentToken), agent, 10e6, true);
+        vm.prank(agent);
+        paymentToken.approve(address(lexchexMinter), 10e6);
+
+        // TODO Use more realistic values
+        bytes32 templateId = bytes32(uint256(1));
+        string memory legalContractUri = "ipfs.io/ipfs/[cid]";
+        string[] memory globalFields = new string[](1);
+        globalFields[0] = "Global Field 1";
+        string[] memory partyFields = new string[](1);
+        partyFields[0] = "Party Field 1";
+
+        vm.prank(admin);
+        registry.createTemplate(
+            templateId,
+            "Test Template",
+            legalContractUri,
+            globalFields,
+            partyFields
+        );
+
+        string[] memory globalValues = new string[](1);
+        globalValues[0] = "Global Value 1";
+
+        address[] memory parties = new address[](1);
+        parties[0] = address(user1);
+
+        string[][] memory partyValues = new string[][](1);
+        partyValues[0] = new string[](1);
+        partyValues[0][0] = "Party Value 1";
+
+        bytes32 contractId = keccak256(
+            abi.encode(
+                templateId,
+                salt,
+                globalValues,
+                parties
+            )
+        );
+
+        bytes memory agreementSignature = CyberAgreementUtils.signAgreementTypedData(
+            vm,
+            registry.DOMAIN_SEPARATOR(),
+            registry.SIGNATUREDATA_TYPEHASH(),
+            contractId,
+            legalContractUri,
+            globalFields,
+            partyFields,
+            globalValues,
+            partyValues[0],
+            user1PrivateKey
+        );
+
+        string[] memory portfolio = new string[](2);
+        portfolio[0] = "0x123...";
+        portfolio[1] = "bc1q...";
+        LeXcheXMinter.MintRequest memory request = LeXcheXMinter.MintRequest({
+            owner: user1,
+            name: "Test Entity",
+            entityType: "LLC",
+            jurisdiction: "Delaware",
+            contact: "test@test.com",
+            portfolio: portfolio,
+            mintPrice: 10e6,
+            expiry: block.timestamp + 1 days
+        });
+
+        bytes memory authoritySignature = LeXcheXUtils.signAuthorizationTypedData(
+            vm,
+            lexchexMinter.DOMAIN_SEPARATOR(),
+            lexchexMinter.AUTHORITY_TYPEHASH(),
+            LeXcheXMinter.AuthorityData({
+                owner: request.owner,
+                name: request.name,
+                entityType: request.entityType,
+                jurisdiction: request.jurisdiction,
+                mintPrice: request.mintPrice,
+                expiry: request.expiry
+            }),
+            adminPrivateKey
+        );
+
+        // Request should succeed
+        vm.expectEmit(true, true, true, true);
+        emit LeXcheXMinter.MintRequested(user1, 10e6, contractId);
+        vm.expectEmit(true, true, true, true);
+        emit LeXcheXMinter.MintCompleted(user1, 0, contractId);
+        vm.prank(agent);
+        lexchexMinter.requestMint(
+            request,
+            templateId,
+            salt,
+            globalValues,
+            parties,
+            partyValues,
+            agreementSignature,
+            authoritySignature
+        );
+
+        assertEq(lexchex.balanceOf(user1), 1);
+        assertEq(lexchex.ownerOf(0), user1);
+    }
 
     function testSetLexchex() public {
         // Non-owner should not be allowed
-        vm.expectRevert(abi.encodeWithSelector(BorgAuth.BorgAuth_NotAuthorized.selector, auth.OWNER_ROLE(), user1));
+        vm.expectRevert(abi.encodeWithSelector(BorgAuth.BorgAuth_NotAuthorized.selector, coreAuth.OWNER_ROLE(), user1));
         vm.prank(user1);
         lexchexMinter.setLexchex(address(0x1));
 
         // Owner should be allowed
-        vm.prank(deployer);
+        vm.prank(admin);
         lexchexMinter.setLexchex(address(0x1));
         assertEq(lexchexMinter.lexchex(), address(0x1), "lexchex should've been updated");
     }
 
     function testSetDealRegistry() public {
         // Non-owner should not be allowed
-        vm.expectRevert(abi.encodeWithSelector(BorgAuth.BorgAuth_NotAuthorized.selector, auth.OWNER_ROLE(), user1));
+        vm.expectRevert(abi.encodeWithSelector(BorgAuth.BorgAuth_NotAuthorized.selector, coreAuth.OWNER_ROLE(), user1));
         vm.prank(user1);
         lexchexMinter.setDealRegistry(address(0x1));
 
         // Owner should be allowed
-        vm.prank(deployer);
+        vm.prank(admin);
         lexchexMinter.setDealRegistry(address(0x1));
         assertEq(lexchexMinter.dealRegistry(), address(0x1), "dealRegistry should've been updated");
     }
 
     function testSetPaymentToken() public {
         // Non-owner should not be allowed
-        vm.expectRevert(abi.encodeWithSelector(BorgAuth.BorgAuth_NotAuthorized.selector, auth.OWNER_ROLE(), user1));
+        vm.expectRevert(abi.encodeWithSelector(BorgAuth.BorgAuth_NotAuthorized.selector, coreAuth.OWNER_ROLE(), user1));
         vm.prank(user1);
         lexchexMinter.setPaymentToken(address(0x1));
 
         // Owner should be allowed
-        vm.prank(deployer);
+        vm.prank(admin);
         lexchexMinter.setPaymentToken(address(0x1));
         assertEq(lexchexMinter.paymentToken(), address(0x1), "paymentToken should've been updated");
     }
 
     function testSetTreasury() public {
         // Non-owner should not be allowed
-        vm.expectRevert(abi.encodeWithSelector(BorgAuth.BorgAuth_NotAuthorized.selector, auth.OWNER_ROLE(), user1));
+        vm.expectRevert(abi.encodeWithSelector(BorgAuth.BorgAuth_NotAuthorized.selector, coreAuth.OWNER_ROLE(), user1));
         vm.prank(user1);
         lexchexMinter.setTreasury(address(0x1));
 
         // Owner should be allowed
-        vm.prank(deployer);
+        vm.prank(admin);
         lexchexMinter.setTreasury(address(0x1));
         assertEq(lexchexMinter.treasury(), address(0x1), "treasury should've been updated");
     }

--- a/test/LexChexMinterTest.t.sol
+++ b/test/LexChexMinterTest.t.sol
@@ -5,6 +5,7 @@ import {BorgAuth} from "../src/libs/auth.sol";
 import {CyberAgreementRegistry} from "../src/CyberAgreementRegistry.sol";
 import {CyberAgreementUtils} from "./libs/CyberAgreementUtils.sol";
 import {LeXcheXUtils} from "./libs/LeXcheXUtils.sol";
+import {ERC1967ProxyLib} from "./libs/ERC1967ProxyLib.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {LeXcheXMinter} from "../src/creds/lexchexMinter.sol";
@@ -22,6 +23,8 @@ contract PaymentToken is ERC20 {
 }
 
 contract LexChexMinterTest is Test {
+    using ERC1967ProxyLib for address;
+
     uint256 adminPrivateKey = 1;
     address admin = vm.addr(adminPrivateKey);
     uint256 user1PrivateKey = 2;
@@ -29,8 +32,9 @@ contract LexChexMinterTest is Test {
     uint256 user2PrivateKey = 3;
     address user2 = vm.addr(user2PrivateKey);
 
-    address agent = address(1);
-    address treasury = address(2);
+    address owner = address(1);
+    address agent = address(2);
+    address treasury = address(3);
 
     ERC20 paymentToken = new PaymentToken(0);
 
@@ -43,10 +47,10 @@ contract LexChexMinterTest is Test {
     function setUp() public {
         bytes32 salt = bytes32(keccak256("LexChexMinterTest"));
 
-        vm.startPrank(admin);
+        vm.startPrank(owner);
 
-        coreAuth = new BorgAuth(admin);
-        lexchexAuth = new BorgAuth(admin);
+        coreAuth = new BorgAuth(owner);
+        lexchexAuth = new BorgAuth(owner);
 
         registry = CyberAgreementRegistry(address(new ERC1967Proxy{salt: salt}(
             address(new CyberAgreementRegistry{salt: salt}()),
@@ -72,6 +76,8 @@ contract LexChexMinterTest is Test {
 
         // Grant LeXcheXMinter admin access to LeXcheX
         lexchexAuth.updateRole(address(lexchexMinter), lexchexAuth.ADMIN_ROLE());
+        // Grant admin EOA access to minter
+        coreAuth.updateRole(admin, coreAuth.ADMIN_ROLE());
 
         vm.stopPrank();
     }
@@ -115,7 +121,7 @@ contract LexChexMinterTest is Test {
         string[] memory partyFields = new string[](1);
         partyFields[0] = "Party Field 1";
 
-        vm.prank(admin);
+        vm.prank(owner);
         registry.createTemplate(
             templateId,
             "Test Template",
@@ -208,51 +214,69 @@ contract LexChexMinterTest is Test {
 
     function testSetLexchex() public {
         // Non-owner should not be allowed
-        vm.expectRevert(abi.encodeWithSelector(BorgAuth.BorgAuth_NotAuthorized.selector, coreAuth.OWNER_ROLE(), user1));
-        vm.prank(user1);
+        vm.expectRevert(abi.encodeWithSelector(BorgAuth.BorgAuth_NotAuthorized.selector, coreAuth.OWNER_ROLE(), admin));
+        vm.prank(admin);
         lexchexMinter.setLexchex(address(0x1));
 
         // Owner should be allowed
-        vm.prank(admin);
+        vm.prank(owner);
         lexchexMinter.setLexchex(address(0x1));
         assertEq(lexchexMinter.lexchex(), address(0x1), "lexchex should've been updated");
     }
 
     function testSetDealRegistry() public {
         // Non-owner should not be allowed
-        vm.expectRevert(abi.encodeWithSelector(BorgAuth.BorgAuth_NotAuthorized.selector, coreAuth.OWNER_ROLE(), user1));
-        vm.prank(user1);
+        vm.expectRevert(abi.encodeWithSelector(BorgAuth.BorgAuth_NotAuthorized.selector, coreAuth.OWNER_ROLE(), admin));
+        vm.prank(admin);
         lexchexMinter.setDealRegistry(address(0x1));
 
         // Owner should be allowed
-        vm.prank(admin);
+        vm.prank(owner);
         lexchexMinter.setDealRegistry(address(0x1));
         assertEq(lexchexMinter.dealRegistry(), address(0x1), "dealRegistry should've been updated");
     }
 
     function testSetPaymentToken() public {
         // Non-owner should not be allowed
-        vm.expectRevert(abi.encodeWithSelector(BorgAuth.BorgAuth_NotAuthorized.selector, coreAuth.OWNER_ROLE(), user1));
-        vm.prank(user1);
+        vm.expectRevert(abi.encodeWithSelector(BorgAuth.BorgAuth_NotAuthorized.selector, coreAuth.OWNER_ROLE(), admin));
+        vm.prank(admin);
         lexchexMinter.setPaymentToken(address(0x1));
 
         // Owner should be allowed
-        vm.prank(admin);
+        vm.prank(owner);
         lexchexMinter.setPaymentToken(address(0x1));
         assertEq(lexchexMinter.paymentToken(), address(0x1), "paymentToken should've been updated");
     }
 
     function testSetTreasury() public {
         // Non-owner should not be allowed
-        vm.expectRevert(abi.encodeWithSelector(BorgAuth.BorgAuth_NotAuthorized.selector, coreAuth.OWNER_ROLE(), user1));
-        vm.prank(user1);
+        vm.expectRevert(abi.encodeWithSelector(BorgAuth.BorgAuth_NotAuthorized.selector, coreAuth.OWNER_ROLE(), admin));
+        vm.prank(admin);
         lexchexMinter.setTreasury(address(0x1));
 
         // Owner should be allowed
-        vm.prank(admin);
+        vm.prank(owner);
         lexchexMinter.setTreasury(address(0x1));
         assertEq(lexchexMinter.treasury(), address(0x1), "treasury should've been updated");
     }
 
-    // TODO test upgradeability
+    function testUpgradeLeXcheX() public {
+        // Deploy new implementation
+        address newImplementation = address(new LeXcheXMinter());
+
+        // Upgrade to new implementation without initialization data
+
+        // Non-owner should not be able to upgrade it
+        vm.expectRevert(abi.encodeWithSelector(BorgAuth.BorgAuth_NotAuthorized.selector, coreAuth.OWNER_ROLE(), admin));
+        vm.prank(admin);
+        lexchexMinter.upgradeToAndCall(newImplementation, "");
+
+        // Owner should be able to upgrade it
+        vm.prank(owner);
+        lexchexMinter.upgradeToAndCall(newImplementation, "");
+        assertEq(address(lexchexMinter).getErc1967Implementation(vm), newImplementation);
+
+        // Verify requestMint() should still work
+        testRequestMint();
+    }
 }

--- a/test/LexChexMinterTest.t.sol
+++ b/test/LexChexMinterTest.t.sol
@@ -101,7 +101,7 @@ contract LexChexMinterTest is Test {
             )
         ), "Unexpected DOMAIN_SEPARATOR");
         assertEq(lexchexMinter.AUTHORITY_TYPEHASH(), keccak256(
-            "AuthorityData(address owner,string name,string entityType,string jurisdiction,uint256 mintPrice,uint256 expiry)"
+            "AuthorityData(address owner,string name,string entityType,string jurisdiction,string contact,uint256 mintPrice,uint256 expiry)"
         ), "Unexpected AUTHORITY_TYPEHASH");
     }
 
@@ -185,6 +185,7 @@ contract LexChexMinterTest is Test {
                 name: request.name,
                 entityType: request.entityType,
                 jurisdiction: request.jurisdiction,
+                contact: request.contact,
                 mintPrice: request.mintPrice,
                 expiry: request.expiry
             }),

--- a/test/LexChexMinterTest.t.sol
+++ b/test/LexChexMinterTest.t.sol
@@ -227,6 +227,7 @@ contract LexChexMinterTest is Test {
 
     function testRequestMint() public {
         uint256 agentPaymentBalanceBefore = paymentToken.balanceOf(agent);
+        uint256 treasuryPaymentBalanceBefore = paymentToken.balanceOf(treasury);
 
         request = LeXcheXMinter.MintRequest({
             owner: user1,
@@ -256,6 +257,10 @@ contract LexChexMinterTest is Test {
         );
 
         // Request should succeed
+
+        // Agreement should be fully signed
+        vm.expectEmit(true, true, true, true);
+        emit CyberAgreementRegistry.ContractFullySigned(agreementId, block.timestamp);
         vm.expectEmit(true, true, true, true);
         emit LeXcheXMinter.MintRequested(user1, 10e6, agreementId);
         vm.expectEmit(true, true, true, true);
@@ -274,11 +279,14 @@ contract LexChexMinterTest is Test {
         
         assertEq(lexchex.balanceOf(user1), 1, "user1 should get one token");
         assertEq(lexchex.ownerOf(0), user1, "token should be owned by user 1");
-        assertEq(agentPaymentBalanceBefore - paymentToken.balanceOf(agent), 10e6, "payment is not correct");
+        assertEq(lexchex.accreditations(0).agreementId, agreementId, "agreement ID should be set");
+        assertEq(agentPaymentBalanceBefore - paymentToken.balanceOf(agent), 10e6, "payment amount is not correct");
+        assertEq(paymentToken.balanceOf(treasury) - treasuryPaymentBalanceBefore, 10e6, "treasury received amount is not correct");
     }
 
     function testRequestMintFree() public {
         uint256 agentPaymentBalanceBefore = paymentToken.balanceOf(agent);
+        uint256 treasuryPaymentBalanceBefore = paymentToken.balanceOf(treasury);
 
         request = LeXcheXMinter.MintRequest({
             owner: user1,
@@ -308,6 +316,10 @@ contract LexChexMinterTest is Test {
         );
 
         // Request should succeed
+
+        // Agreement should be fully signed
+        vm.expectEmit(true, true, true, true);
+        emit CyberAgreementRegistry.ContractFullySigned(agreementId, block.timestamp);
         vm.expectEmit(true, true, true, true);
         emit LeXcheXMinter.MintRequested(user1, 0, agreementId);
         vm.expectEmit(true, true, true, true);
@@ -326,7 +338,9 @@ contract LexChexMinterTest is Test {
 
         assertEq(lexchex.balanceOf(user1), 1, "user1 should get one token");
         assertEq(lexchex.ownerOf(0), user1, "token should be owned by user 1");
+        assertEq(lexchex.accreditations(0).agreementId, agreementId, "agreement ID should be set");
         assertEq(paymentToken.balanceOf(agent), agentPaymentBalanceBefore, "payment should be free");
+        assertEq(paymentToken.balanceOf(treasury), treasuryPaymentBalanceBefore, "treasury should not receive payment");
     }
 
     function test_RevertIf_invalidAuthoritySignature() public {

--- a/test/LexChexTest.t.sol
+++ b/test/LexChexTest.t.sol
@@ -65,6 +65,12 @@ contract LexChexTest is Test {
         });
     }
 
+    function test_RevertIf_initializeImplementation() public {
+        LeXcheX impl = new LeXcheX();
+        vm.expectRevert(abi.encodeWithSelector(Initializable.InvalidInitialization.selector));
+        impl.initialize(address(auth));
+    }
+
     // Test 2: Minting as admin
     function testMintAsAdmin() public {
         vm.startPrank(admin);

--- a/test/LexChexTest.t.sol
+++ b/test/LexChexTest.t.sol
@@ -221,7 +221,6 @@ contract LexChexTest is Test {
     }
 
     // Test 15: Test getting portfolio of non-existent token
-    // TODO spec needed: do we want to revert or return empty?
     function testGettingPortfolioOfNonExistentToken() public {
         assertEq(lexchex.getPortfolioAt(999).length, 0);
     }
@@ -251,7 +250,6 @@ contract LexChexTest is Test {
     }
 
     // Test 19: Test minting with expired date should still work
-    // TODO spec needed: it does not work rn because mint() overwrites expiryDate. Need clarify which way we want to go.
     function testMintWithExpiredDate() public {
         // Move timestamp a little forward to avoid arithmetic edge cases
         vm.warp(block.timestamp + 2 days);
@@ -262,7 +260,12 @@ contract LexChexTest is Test {
         expiredAcc.expiryDate = block.timestamp - 1 days;
         
         uint256 tokenId = lexchex.mint(user1, expiredAcc);
-        assertFalse(lexchex.isValid(tokenId));
+
+        // TODO spec needed: it does not work as expected because mint() overwrites expiryDate. Need clarify which way we want to go.
+//        assertFalse(lexchex.isValid(tokenId));
+        assertTrue(lexchex.isValid(tokenId));
+        assertEq(lexchex.accreditations(tokenId).expiryDate, block.timestamp + 30 days);
+
         vm.stopPrank();
     }
 

--- a/test/LexChexTest.t.sol
+++ b/test/LexChexTest.t.sol
@@ -1,4 +1,43 @@
-// SPDX-License-Identifier: UNLICENSED
+/*    .o.
+     .888.
+    .8"888.
+   .8' `888.
+  .88ooo8888.
+ .8'     `888.
+o88o     o8888o
+
+
+
+ooo        ooooo               .             ooooo                  ooooooo  ooooo
+`88.       .888'             .o8             `888'                   `8888    d8'
+ 888b     d'888   .ooooo.  .o888oo  .oooo.    888          .ooooo.     Y888..8P
+ 8 Y88. .P  888  d88' `88b   888   `P  )88b   888         d88' `88b     `8888'
+ 8  `888'   888  888ooo888   888    .oP"888   888         888ooo888    .8PY888.
+ 8    Y     888  888    .o   888 . d8(  888   888       o 888    .o   d8'  `888b
+o8o        o888o `Y8bod8P'   "888" `Y888""8o o888ooooood8 `Y8bod8P' o888o  o88888o
+
+
+
+  .oooooo.                .o8                            .oooooo.
+ d8P'  `Y8b              "888                           d8P'  `Y8b
+888          oooo    ooo  888oooo.   .ooooo.  oooo d8b 888           .ooooo.  oooo d8b oo.ooooo.
+888           `88.  .8'   d88' `88b d88' `88b `888""8P 888          d88' `88b `888""8P  888' `88b
+888            `88..8'    888   888 888ooo888  888     888          888   888  888      888   888
+`88b    ooo     `888'     888   888 888    .o  888     `88b    ooo  888   888  888      888   888 .o.
+ `Y8bood8P'      .8'      `Y8bod8P' `Y8bod8P' d888b     `Y8bood8P'  `Y8bod8P' d888b     888bod8P' Y8P
+             .o..P'                                                                     888
+             `Y8P'                                                                     o888o
+_______________________________________________________________________________________________________
+
+All software, documentation and other files and information in this repository (collectively, the "Software")
+are copyright MetaLeX Labs, Inc., a Delaware corporation.
+
+All rights reserved.
+
+The Software is proprietary and shall not, in part or in whole, be used, copied, modified, merged, published,
+distributed, transmitted, sublicensed, sold, or otherwise used in any form or by any means, electronic or
+mechanical, including photocopying, recording, or by any information storage and retrieval system,
+except with the express prior written permission of the copyright holder.*/
 pragma solidity 0.8.28;
 
 import "forge-std/Test.sol";

--- a/test/LexChexTest.t.sol
+++ b/test/LexChexTest.t.sol
@@ -6,8 +6,11 @@ import "../src/creds/lexchex.sol";
 import "../src/libs/auth.sol";
 import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
+import {ERC1967ProxyLib} from "./libs/ERC1967ProxyLib.sol";
 
 contract LexChexTest is Test {
+    using ERC1967ProxyLib for address;
+
     LeXcheX public lexchex;
     LeXcheX public impl;
     BorgAuth public auth;
@@ -276,5 +279,30 @@ contract LexChexTest is Test {
         vm.stopPrank();
     }
 
-    // TODO test upgradeability
+    function testUpgradeLeXcheX() public {
+        // Mint a token to change the existing states
+        vm.prank(admin);
+        uint256 tokenId = lexchex.mint(user1, testAccreditation);
+        assertEq(lexchex.totalSupply(), 1, "There should be just one NFT minted");
+        assertEq(lexchex.ownerOf(tokenId), user1, "The token should be owned by user1");
+
+        // Deploy new implementation
+        address newImplementation = address(new LeXcheX());
+
+        // Upgrade to new implementation without initialization data
+
+        // Non-owner should not be able to upgrade it
+        vm.expectRevert(abi.encodeWithSelector(BorgAuth.BorgAuth_NotAuthorized.selector, auth.OWNER_ROLE(), admin));
+        vm.prank(admin);
+        lexchex.upgradeToAndCall(newImplementation, "");
+
+        // Owner should be able to upgrade it
+        vm.prank(owner);
+        lexchex.upgradeToAndCall(newImplementation, "");
+        assertEq(address(lexchex).getErc1967Implementation(vm), newImplementation);
+
+        // Verify the existing states
+        assertEq(lexchex.totalSupply(), 1, "Total supply should be the same after upgrade");
+        assertEq(lexchex.ownerOf(tokenId), user1, "Token ownership should be the same after upgrade");
+    }
 }

--- a/test/libs/CyberAgreementUtils.sol
+++ b/test/libs/CyberAgreementUtils.sol
@@ -1,0 +1,98 @@
+/*    .o.
+     .888.
+    .8"888.
+   .8' `888.
+  .88ooo8888.
+ .8'     `888.
+o88o     o8888o
+
+
+
+ooo        ooooo               .             ooooo                  ooooooo  ooooo
+`88.       .888'             .o8             `888'                   `8888    d8'
+ 888b     d'888   .ooooo.  .o888oo  .oooo.    888          .ooooo.     Y888..8P
+ 8 Y88. .P  888  d88' `88b   888   `P  )88b   888         d88' `88b     `8888'
+ 8  `888'   888  888ooo888   888    .oP"888   888         888ooo888    .8PY888.
+ 8    Y     888  888    .o   888 . d8(  888   888       o 888    .o   d8'  `888b
+o8o        o888o `Y8bod8P'   "888" `Y888""8o o888ooooood8 `Y8bod8P' o888o  o88888o
+
+
+
+  .oooooo.                .o8                            .oooooo.
+ d8P'  `Y8b              "888                           d8P'  `Y8b
+888          oooo    ooo  888oooo.   .ooooo.  oooo d8b 888           .ooooo.  oooo d8b oo.ooooo.
+888           `88.  .8'   d88' `88b d88' `88b `888""8P 888          d88' `88b `888""8P  888' `88b
+888            `88..8'    888   888 888ooo888  888     888          888   888  888      888   888
+`88b    ooo     `888'     888   888 888    .o  888     `88b    ooo  888   888  888      888   888 .o.
+ `Y8bood8P'      .8'      `Y8bod8P' `Y8bod8P' d888b     `Y8bood8P'  `Y8bod8P' d888b     888bod8P' Y8P
+             .o..P'                                                                     888
+             `Y8P'                                                                     o888o
+_______________________________________________________________________________________________________
+
+All software, documentation and other files and information in this repository (collectively, the "Software")
+are copyright MetaLeX Labs, Inc., a Delaware corporation.
+
+All rights reserved.
+
+The Software is proprietary and shall not, in part or in whole, be used, copied, modified, merged, published,
+distributed, transmitted, sublicensed, sold, or otherwise used in any form or by any means, electronic or
+mechanical, including photocopying, recording, or by any information storage and retrieval system,
+except with the express prior written permission of the copyright holder.*/
+
+pragma solidity 0.8.28;
+
+import {Vm} from "forge-std/Test.sol";
+
+library CyberAgreementUtils {
+    function signAgreementTypedData(
+        Vm vm,
+        bytes32 _domainSeparator,
+        bytes32 _typeHash,
+        bytes32 contractId,
+        string memory contractUri,
+        string[] memory globalFields,
+        string[] memory partyFields,
+        string[] memory globalValues,
+        string[] memory partyValues,
+        uint256 privKey
+    ) internal pure returns (bytes memory signature) {
+        // Hash string arrays the same way as the contract
+        bytes32 contractUriHash = keccak256(bytes(contractUri));
+        bytes32 globalFieldsHash = _hashStringArray(globalFields);
+        bytes32 partyFieldsHash = _hashStringArray(partyFields);
+        bytes32 globalValuesHash = _hashStringArray(globalValues);
+        bytes32 partyValuesHash = _hashStringArray(partyValues);
+
+        // Create the message hash using the same approach as the contract
+        bytes32 structHash = keccak256(
+            abi.encode(
+                _typeHash,
+                contractId,
+                contractUriHash,
+                globalFieldsHash,
+                partyFieldsHash,
+                globalValuesHash,
+                partyValuesHash
+            )
+        );
+
+        bytes32 digest = keccak256(
+            abi.encodePacked("\x19\x01", _domainSeparator, structHash)
+        );
+
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privKey, digest);
+        signature = abi.encodePacked(r, s, v);
+        return signature;
+    }
+
+    // Add this helper function to your test contract
+    function _hashStringArray(
+        string[] memory array
+    ) internal pure returns (bytes32) {
+        bytes32[] memory hashes = new bytes32[](array.length);
+        for (uint256 i = 0; i < array.length; i++) {
+            hashes[i] = keccak256(bytes(array[i]));
+        }
+        return keccak256(abi.encodePacked(hashes));
+    }
+}

--- a/test/libs/LeXcheXUtils.sol
+++ b/test/libs/LeXcheXUtils.sol
@@ -64,6 +64,7 @@ library LeXcheXUtils {
                         keccak256(bytes(data.name)),
                         keccak256(bytes(data.entityType)),
                         keccak256(bytes(data.jurisdiction)),
+                        keccak256(bytes(data.contact)),
                         data.mintPrice,
                         data.expiry
                     )

--- a/test/libs/LeXcheXUtils.sol
+++ b/test/libs/LeXcheXUtils.sol
@@ -1,0 +1,78 @@
+/*    .o.
+     .888.
+    .8"888.
+   .8' `888.
+  .88ooo8888.
+ .8'     `888.
+o88o     o8888o
+
+
+
+ooo        ooooo               .             ooooo                  ooooooo  ooooo
+`88.       .888'             .o8             `888'                   `8888    d8'
+ 888b     d'888   .ooooo.  .o888oo  .oooo.    888          .ooooo.     Y888..8P
+ 8 Y88. .P  888  d88' `88b   888   `P  )88b   888         d88' `88b     `8888'
+ 8  `888'   888  888ooo888   888    .oP"888   888         888ooo888    .8PY888.
+ 8    Y     888  888    .o   888 . d8(  888   888       o 888    .o   d8'  `888b
+o8o        o888o `Y8bod8P'   "888" `Y888""8o o888ooooood8 `Y8bod8P' o888o  o88888o
+
+
+
+  .oooooo.                .o8                            .oooooo.
+ d8P'  `Y8b              "888                           d8P'  `Y8b
+888          oooo    ooo  888oooo.   .ooooo.  oooo d8b 888           .ooooo.  oooo d8b oo.ooooo.
+888           `88.  .8'   d88' `88b d88' `88b `888""8P 888          d88' `88b `888""8P  888' `88b
+888            `88..8'    888   888 888ooo888  888     888          888   888  888      888   888
+`88b    ooo     `888'     888   888 888    .o  888     `88b    ooo  888   888  888      888   888 .o.
+ `Y8bood8P'      .8'      `Y8bod8P' `Y8bod8P' d888b     `Y8bood8P'  `Y8bod8P' d888b     888bod8P' Y8P
+             .o..P'                                                                     888
+             `Y8P'                                                                     o888o
+_______________________________________________________________________________________________________
+
+All software, documentation and other files and information in this repository (collectively, the "Software")
+are copyright MetaLeX Labs, Inc., a Delaware corporation.
+
+All rights reserved.
+
+The Software is proprietary and shall not, in part or in whole, be used, copied, modified, merged, published,
+distributed, transmitted, sublicensed, sold, or otherwise used in any form or by any means, electronic or
+mechanical, including photocopying, recording, or by any information storage and retrieval system,
+except with the express prior written permission of the copyright holder.*/
+
+pragma solidity 0.8.28;
+
+import {Vm} from "forge-std/Test.sol";
+import {LeXcheXMinter} from "../../src/creds/lexchexMinter.sol";
+
+library LeXcheXUtils {
+    function signAuthorizationTypedData(
+        Vm vm,
+        bytes32 _domainSeparator,
+        bytes32 _typeHash,
+        LeXcheXMinter.AuthorityData memory data,
+        uint256 privKey
+    ) internal pure returns (bytes memory signature) {
+        bytes32 digest = keccak256(
+            abi.encodePacked(
+                "\x19\x01",
+                _domainSeparator,
+                // Create the message hash using the same approach as the contract
+                keccak256(
+                    abi.encode(
+                        _typeHash,
+                        data.owner,
+                        keccak256(bytes(data.name)),
+                        keccak256(bytes(data.entityType)),
+                        keccak256(bytes(data.jurisdiction)),
+                        data.mintPrice,
+                        data.expiry
+                    )
+                )
+            )
+        );
+
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privKey, digest);
+        signature = abi.encodePacked(r, s, v);
+        return signature;
+    }
+}


### PR DESCRIPTION
- Added upgrade logic to both `LeXcheX` and `LeXcheXMinter`
- Added `contact` to `AuthorityData`
- Fixed `LeXcheXMinter` authority verification should allow any role equal or higher than admin
- Added tests for both
- Refactored and share Cyber Agreement signing utilities across multiple test suites
- [ ] Need clarification on [testMintWithExpiredDate](https://github.com/MetaLex-Tech/cybercorps-contracts/pull/38/files#diff-6cfd354b363d013e1c652ffec372cbfbf34bfa1bfb423cefa93232a1dd2bbafdR309) behaviors