### PR TITLE
feat: individually upgradeable DealManager and RoundManager

### DIFF
--- a/remappings.txt
+++ b/remappings.txt
@@ -1,4 +1,5 @@
 openzeppelin-contracts/=dependencies/openzeppelin-contracts/contracts/
+openzeppelin-contracts-upgradeable/=dependencies/openzeppelin-contracts-upgradeable/contracts/
 erc721a/=dependencies/erc721a-4.3.0/
 forge-std/=dependencies/forge-std/src/
 ConditionManager=dependencies/ConditionManager/src/

--- a/script/deploy-metadao-factory.s.sol
+++ b/script/deploy-metadao-factory.s.sol
@@ -8,8 +8,8 @@ import {MetaDAOFactory} from "../src/MetaDAOFactory.sol";
 import {CyberAgreementRegistry} from "../src/CyberAgreementRegistry.sol";
 import {IssuanceManagerFactory} from "../src/IssuanceManagerFactory.sol";
 import {CyberCorpSingleFactory} from "../src/CyberCorpSingleFactory.sol";
-import {DealManagerFactory} from "../src/DealManagerFactory.sol";
-import {RoundManagerFactory} from "../src/RoundManagerFactory.sol";
+import {DealManagerFactory, DealManager} from "../src/DealManagerFactory.sol";
+import {RoundManagerFactory, RoundManager} from "../src/RoundManagerFactory.sol";
 import {CertificateUriBuilder} from "../src/CertificateUriBuilder.sol";
 import {CyberCertPrinter} from "../src/CyberCertPrinter.sol";
 import {CyberScrip} from "../src/CyberScrip.sol";
@@ -72,10 +72,24 @@ contract DeployMetaDAOFactoryScript is Script {
             new CyberCorpSingleFactory{salt: salt}(address(auth))
         );
         address dealManagerFactory = address(
-            new DealManagerFactory{salt: salt}(address(auth))
+            new ERC1967Proxy{salt: salt}(
+                address(new DealManagerFactory{salt: salt}()),
+                abi.encodeWithSelector(
+                    DealManagerFactory.initialize.selector,
+                    address(auth),
+                    address(new DealManager())
+                )
+            )
         );
         address roundManagerFactory = address(
-            new RoundManagerFactory{salt: salt}(address(auth))
+            new ERC1967Proxy{salt: salt}(
+                address(new RoundManagerFactory{salt: salt}()),
+                abi.encodeWithSelector(
+                    RoundManagerFactory.initialize.selector,
+                    address(auth),
+                    address(new RoundManager())
+                )
+            )
         );
 
         address cyberCertPrinterImplementation = address(

--- a/script/deploy.s.sol
+++ b/script/deploy.s.sol
@@ -9,7 +9,7 @@ import {IssuanceManagerFactory} from "../src/IssuanceManagerFactory.sol";
 import {CyberCorpSingleFactory} from "../src/CyberCorpSingleFactory.sol";
 import {BorgAuth} from "../src/libs/auth.sol";
 import {CyberAgreementRegistry} from "../src/CyberAgreementRegistry.sol";
-import {DealManagerFactory} from "../src/DealManagerFactory.sol";
+import {DealManagerFactory, DealManager} from "../src/DealManagerFactory.sol";
 import {IDealManager} from "../src/interfaces/IDealManager.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {CertificateDetails} from "../src/storage/CyberCertPrinterStorage.sol";
@@ -67,7 +67,14 @@ contract BaseScript is Script {
         );
 
         address dealManagerFactory = address(
-            new DealManagerFactory{salt: salt}(address(auth))
+            new ERC1967Proxy{salt: salt}(
+                address(new DealManagerFactory{salt: salt}()),
+                abi.encodeWithSelector(
+                    DealManagerFactory.initialize.selector,
+                    address(auth),
+                    address(new DealManager())
+                )
+            )
         );
 
         // Deploy upgradeable singletons

--- a/script/public-round-test-deploy.s.sol
+++ b/script/public-round-test-deploy.s.sol
@@ -9,8 +9,8 @@ import {CyberAgreementRegistry} from "../src/CyberAgreementRegistry.sol";
 import {CyberCorpFactory} from "../src/CyberCorpFactory.sol";
 import {IssuanceManagerFactory} from "../src/IssuanceManagerFactory.sol";
 import {CyberCorpSingleFactory} from "../src/CyberCorpSingleFactory.sol";
-import {DealManagerFactory} from "../src/DealManagerFactory.sol";
-import {RoundManagerFactory} from "../src/RoundManagerFactory.sol";
+import {DealManagerFactory, DealManager} from "../src/DealManagerFactory.sol";
+import {RoundManagerFactory, RoundManager} from "../src/RoundManagerFactory.sol";
 import {RoundManager} from "../src/RoundManager.sol";
 import {CyberCertPrinter} from "../src/CyberCertPrinter.sol";
 import {CyberScrip} from "../src/CyberScrip.sol";
@@ -61,10 +61,24 @@ contract PublicRoundTestDeploy is Script {
             new CyberCorpSingleFactory{salt: salt}(address(auth))
         );
         address dealManagerFactory = address(
-            new DealManagerFactory{salt: salt}(address(auth))
+            new ERC1967Proxy{salt: salt}(
+                address(new DealManagerFactory{salt: salt}()),
+                abi.encodeWithSelector(
+                    DealManagerFactory.initialize.selector,
+                    address(auth),
+                    address(new DealManager())
+                )
+            )
         );
         address roundManagerFactory = address(
-            new RoundManagerFactory{salt: salt}(address(auth))
+            new ERC1967Proxy{salt: salt}(
+                address(new RoundManagerFactory{salt: salt}()),
+                abi.encodeWithSelector(
+                    RoundManagerFactory.initialize.selector,
+                    address(auth),
+                    address(new RoundManager())
+                )
+            )
         );
 
         // Implementations

--- a/script/upgrade-dealmanager.s.sol
+++ b/script/upgrade-dealmanager.s.sol
@@ -42,8 +42,8 @@ contract BaseScript is Script {
        // CyberAgreementRegistry(registry).upgradeToAndCall(newRegistryImplementation, "");
 
         // Verify the upgrade was successful
-        address updatedImplementation = deployedFactory.getBeaconImplementation();
-        console.log("Updated DealManager beacon implementation:", updatedImplementation);
+        address updatedImplementation = address(deployedFactory.refImplementation());
+        console.log("Updated DealManager reference implementation:", updatedImplementation);
 
         address newDealManagerImplementation = address(new DealManager{salt: salt}());
 

--- a/script/upgrade-dealmanager.s.sol
+++ b/script/upgrade-dealmanager.s.sol
@@ -42,7 +42,7 @@ contract BaseScript is Script {
        // CyberAgreementRegistry(registry).upgradeToAndCall(newRegistryImplementation, "");
 
         // Verify the upgrade was successful
-        address updatedImplementation = address(deployedFactory.refImplementation());
+        address updatedImplementation = deployedFactory.getRefImplementation();
         console.log("Updated DealManager reference implementation:", updatedImplementation);
 
         address newDealManagerImplementation = address(new DealManager{salt: salt}());

--- a/script/upgrade-public-rounds.s.sol
+++ b/script/upgrade-public-rounds.s.sol
@@ -17,7 +17,8 @@ import {CyberCertData, RoundType} from "../src/interfaces/IRoundManager.sol";
 import {EOI} from "../src/storage/RoundManagerStorage.sol";
 import {CyberAgreementUtils} from "../test/libs/CyberAgreementUtils.sol";
 import {Vm} from "forge-std/Test.sol";
-import "../dependencies/openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
+import "openzeppelin-contracts/token/ERC20/ERC20.sol";
+import "openzeppelin-contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {CyberCertPrinter} from "../src/CyberCertPrinter.sol";
 import {CyberScrip} from "../src/CyberScrip.sol";
 
@@ -64,9 +65,16 @@ contract UpgradePublicRoundsScript is Script {
                 "Deployer is not AUTH owner; use the AUTH owner key to upgrade"
             );
         }
-        RoundManagerFactory roundManagerFactory = new RoundManagerFactory{
-            salt: salt
-        }(auth);
+        RoundManagerFactory roundManagerFactory = RoundManagerFactory(address(
+            new ERC1967Proxy{salt: salt}(
+                address(new RoundManagerFactory{salt: salt}()),
+                abi.encodeWithSelector(
+                    RoundManagerFactory.initialize.selector,
+                    address(auth),
+                    address(new RoundManager())
+                )
+            )
+        ));
         console.log(
             "RoundManagerFactory deployed:",
             address(roundManagerFactory)

--- a/script/warrant-deploy.s.sol
+++ b/script/warrant-deploy.s.sol
@@ -9,7 +9,7 @@ import {IssuanceManagerFactory} from "../src/IssuanceManagerFactory.sol";
 import {CyberCorpSingleFactory} from "../src/CyberCorpSingleFactory.sol";
 import {BorgAuth} from "../src/libs/auth.sol";
 import {CyberAgreementRegistry} from "../src/CyberAgreementRegistry.sol";
-import {DealManagerFactory} from "../src/DealManagerFactory.sol";
+import {DealManagerFactory, DealManager} from "../src/DealManagerFactory.sol";
 import {IDealManager} from "../src/interfaces/IDealManager.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {CertificateDetails} from "../src/storage/CyberCertPrinterStorage.sol";
@@ -74,7 +74,16 @@ contract BaseScript is Script {
 
         address cyberCorpSingleFactory = address(new CyberCorpSingleFactory{salt: salt}(address(auth)));
 
-        address dealManagerFactory = address(new DealManagerFactory{salt: salt}(address(auth)));
+        address dealManagerFactory = address(
+            new ERC1967Proxy{salt: salt}(
+                address(new DealManagerFactory{salt: salt}()),
+                abi.encodeWithSelector(
+                    DealManagerFactory.initialize.selector,
+                    address(auth),
+                    address(new DealManager())
+                )
+            )
+        );
 
         //address tokenWarrantExtension = address(new TokenWarrantExtension{salt: salt}());
 

--- a/src/DealManager.sol
+++ b/src/DealManager.sol
@@ -60,12 +60,12 @@ contract DealManager is Initializable, UUPSUpgradeable, ReentrancyGuard, BorgAut
 
     string public constant DEPLOY_VERSION = "1"; // For version-tracking on all deployment and future upgrades
 
-    // TODO take ReentrancyGuard into account
     // Upgrade notes: Reduced gap to account for new variables
     //  50
+    //   -1 (ReentrancyGuard)
     //   -1 (BorgAuthACL)
-    //  = 49
-    uint256[49] private __gap;
+    //  = 48
+    uint256[48] private __gap;
 
     /// @notice Certificate data structure for creating new certificates
     struct CyberCertData {

--- a/src/DealManager.sol
+++ b/src/DealManager.sol
@@ -42,19 +42,28 @@ except with the express prior written permission of the copyright holder.*/
 pragma solidity 0.8.28;
 
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "./interfaces/IIssuanceManager.sol";
 import "./libs/LexScroWLite.sol";
 import "./libs/auth.sol";
 import "./storage/DealManagerStorage.sol";
 import "./storage/BorgAuthStorage.sol";
 import "./interfaces/ICyberCorp.sol";
-import "./interfaces/IRoundManager.sol";
+import "./interfaces/IDealManagerFactory.sol";
 
 /// @title DealManager
 /// @notice Manages the lifecycle of deals between parties, including creation, signing, payment, and finalization for a CyberCorp
 /// @dev Implements UUPS upgradeable pattern and integrates with BorgAuth for access control
-contract DealManager is Initializable, BorgAuthACL, LexScroWLite {
+contract DealManager is Initializable, UUPSUpgradeable, BorgAuthACL, LexScroWLite {
     using DealManagerStorage for DealManagerStorage.DealManagerData;
+
+    string public constant DEPLOY_VERSION = "1"; // For version-tracking on all deployment and future upgrades
+
+    // Upgrade notes: Reduced gap to account for new variables
+    //  50
+    //   -1 (BorgAuthACL)
+    //  = 49
+    uint256[49] private __gap;
 
     /// @notice Certificate data structure for creating new certificates
     struct CyberCertData {
@@ -76,6 +85,7 @@ contract DealManager is Initializable, BorgAuthACL, LexScroWLite {
     error ConditionDoesNotExist();
     error NotUpgradeFactory();
     error DealNotExpired();
+    error NotRefImplementation();
 
     /// @notice Emitted when a new deal is proposed
     /// @param agreementId Unique identifier for the agreement
@@ -552,5 +562,16 @@ contract DealManager is Initializable, BorgAuthACL, LexScroWLite {
             secretHash,
             expiry
         );
+    }
+
+    /// @notice UUPS upgrade authorization
+    /// @dev MetaLeX releases new versions through the factory's reference implementation,
+    /// and the CyberCorp owner can decide if or when he wants to perform the upgrade
+    function _authorizeUpgrade(
+        address newImplementation
+    ) internal override onlyOwner {
+        if(IDealManagerFactory(DealManagerStorage.getUpgradeFactory()).refImplementation() != newImplementation) {
+            revert NotRefImplementation();
+        }
     }
 }

--- a/src/DealManager.sol
+++ b/src/DealManager.sol
@@ -60,13 +60,6 @@ contract DealManager is Initializable, UUPSUpgradeable, ReentrancyGuard, BorgAut
 
     string public constant DEPLOY_VERSION = "1"; // For version-tracking on all deployment and future upgrades
 
-    // Upgrade notes: Reduced gap to account for new variables
-    //  50
-    //   -1 (ReentrancyGuard)
-    //   -1 (BorgAuthACL)
-    //  = 48
-    uint256[48] private __gap;
-
     /// @notice Certificate data structure for creating new certificates
     struct CyberCertData {
         string name;
@@ -595,7 +588,7 @@ contract DealManager is Initializable, UUPSUpgradeable, ReentrancyGuard, BorgAut
     function _authorizeUpgrade(
         address newImplementation
     ) internal override onlyOwner {
-        if(IDealManagerFactory(DealManagerStorage.getUpgradeFactory()).refImplementation() != newImplementation) {
+        if(IDealManagerFactory(DealManagerStorage.getUpgradeFactory()).getRefImplementation() != newImplementation) {
             revert NotRefImplementation();
         }
     }

--- a/src/DealManagerFactory.sol
+++ b/src/DealManagerFactory.sol
@@ -46,6 +46,7 @@ import "openzeppelin-contracts/utils/Create2.sol";
 import "openzeppelin-contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "./DealManager.sol";
 import "./libs/auth.sol";
+import "./storage/DealManagerFactoryStorage.sol";
 
 /// @title DealManagerFactory
 /// @notice Factory contract for deploying DealManager instances
@@ -54,15 +55,6 @@ contract DealManagerFactory is UUPSUpgradeable, BorgAuthACL {
     error InvalidSalt();
     error DeploymentFailed();
     error ZeroAddress();
-
-    DealManager public refImplementation; // implementation contract to use for new deployments
-
-    // Upgrade notes: Reduced gap to account for new variables
-    //  50
-    //   -1 (BorgAuthACL)
-    //   -1 (self)
-    //  = 48
-    uint256[48] private __gap;
 
     event DealManagerDeployed(address dealManager, string version);
 
@@ -78,7 +70,7 @@ contract DealManagerFactory is UUPSUpgradeable, BorgAuthACL {
         // Initialize BorgAuthACL
         __BorgAuthACL_init(_auth);
 
-        refImplementation = DealManager(_refImplementation);
+        DealManagerFactoryStorage.setRefImplementation(_refImplementation);
     }
 
     function deployDealManager(bytes32 _salt) public returns (address) {
@@ -92,7 +84,7 @@ contract DealManagerFactory is UUPSUpgradeable, BorgAuthACL {
         
         if(dealManagerProxy == address(0)) revert DeploymentFailed();
         
-        emit DealManagerDeployed(dealManagerProxy, refImplementation.DEPLOY_VERSION());
+        emit DealManagerDeployed(dealManagerProxy, DealManager(DealManagerFactoryStorage.getRefImplementation()).DEPLOY_VERSION());
         return dealManagerProxy;
     }
 
@@ -109,14 +101,20 @@ contract DealManagerFactory is UUPSUpgradeable, BorgAuthACL {
     /// @return bytecode The proxy contract creation bytecode
     function _getBytecode() private view returns (bytes memory bytecode) {
         bytes memory sourceCodeBytes = type(ERC1967Proxy).creationCode;
-        bytecode = abi.encodePacked(sourceCodeBytes, abi.encode(refImplementation, ""));
+        bytecode = abi.encodePacked(sourceCodeBytes, abi.encode(DealManagerFactoryStorage.getRefImplementation(), ""));
+    }
+
+    /// @notice Get the reference implementation contract for the next deployments
+    /// @return Current reference implementation contract address
+    function getRefImplementation() public returns(address) {
+        return DealManagerFactoryStorage.getRefImplementation();
     }
 
     /// @notice Set the reference implementation contract for the next deployments
     /// @dev Only callable by addresses with the admin role
     /// @param _newImplementation Address of the new implementation
-    function setRefImplementation(DealManager _newImplementation) public onlyOwner {
-        refImplementation = _newImplementation;
+    function setRefImplementation(address _newImplementation) public onlyOwner {
+        DealManagerFactoryStorage.setRefImplementation(_newImplementation);
     }
 
     function _authorizeUpgrade(

--- a/src/DealManagerFactory.sol
+++ b/src/DealManagerFactory.sol
@@ -43,30 +43,42 @@ pragma solidity 0.8.28;
 
 import "openzeppelin-contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import "openzeppelin-contracts/utils/Create2.sol";
+import "openzeppelin-contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "./DealManager.sol";
 import "./libs/auth.sol";
 
 /// @title DealManagerFactory
 /// @notice Factory contract for deploying DealManager instances
 /// @dev Uses ERC1967Proxy+UUPSUpgradeable pattern for upgradeable DealManager instances
-contract DealManagerFactory is BorgAuthACL {
+contract DealManagerFactory is UUPSUpgradeable, BorgAuthACL {
     error InvalidSalt();
     error DeploymentFailed();
     error ZeroAddress();
 
     DealManager public refImplementation; // implementation contract to use for new deployments
 
+    // Upgrade notes: Reduced gap to account for new variables
+    //  50
+    //   -1 (BorgAuthACL)
+    //   -1 (self)
+    //  = 48
+    uint256[48] private __gap;
+
     event DealManagerDeployed(address dealManager, string version);
 
-    constructor(address _auth) {
-        // Deploy the reference implementation contract
-        refImplementation = new DealManager();
-        initialize(_auth);
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
     }
-    
-    function initialize(address _auth) public initializer {
+
+    /// @notice Initialize the factory with authentication and reference implementation
+    /// @param _auth Address of the BorgAuth contract
+    /// @param _refImplementation Address of the reference DealManager implementation
+    function initialize(address _auth, address _refImplementation) public initializer {
         // Initialize BorgAuthACL
         __BorgAuthACL_init(_auth);
+
+        refImplementation = DealManager(_refImplementation);
     }
 
     function deployDealManager(bytes32 _salt) public returns (address) {
@@ -106,4 +118,8 @@ contract DealManagerFactory is BorgAuthACL {
     function setRefImplementation(DealManager _newImplementation) public onlyOwner {
         refImplementation = _newImplementation;
     }
+
+    function _authorizeUpgrade(
+        address newImplementation
+    ) internal override onlyOwner {}
 }

--- a/src/DealManagerFactory.sol
+++ b/src/DealManagerFactory.sol
@@ -41,23 +41,26 @@ except with the express prior written permission of the copyright holder.*/
 
 pragma solidity 0.8.28;
 
-import "@openzeppelin/contracts/utils/Create2.sol";
-import "@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol";
-import "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
+import "openzeppelin-contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import "openzeppelin-contracts/utils/Create2.sol";
 import "./DealManager.sol";
 import "./libs/auth.sol";
 
+/// @title DealManagerFactory
+/// @notice Factory contract for deploying DealManager instances
+/// @dev Uses ERC1967Proxy+UUPSUpgradeable pattern for upgradeable DealManager instances
 contract DealManagerFactory is BorgAuthACL {
     error InvalidSalt();
     error DeploymentFailed();
     error ZeroAddress();
-    UpgradeableBeacon public beacon;
 
-    event DealManagerDeployed(address dealManager);
+    DealManager public refImplementation; // implementation contract to use for new deployments
+
+    event DealManagerDeployed(address dealManager, string version);
 
     constructor(address _auth) {
-        // Deploy the implementation contract
-        beacon = new UpgradeableBeacon(address(new DealManager()), address(this));
+        // Deploy the reference implementation contract
+        refImplementation = new DealManager();
         initialize(_auth);
     }
     
@@ -77,7 +80,7 @@ contract DealManagerFactory is BorgAuthACL {
         
         if(dealManagerProxy == address(0)) revert DeploymentFailed();
         
-        emit DealManagerDeployed(dealManagerProxy);
+        emit DealManagerDeployed(dealManagerProxy, refImplementation.DEPLOY_VERSION());
         return dealManagerProxy;
     }
 
@@ -93,16 +96,14 @@ contract DealManagerFactory is BorgAuthACL {
     /// @dev Internal function used by deployDealManager
     /// @return bytecode The proxy contract creation bytecode
     function _getBytecode() private view returns (bytes memory bytecode) {
-        bytes memory sourceCodeBytes = type(BeaconProxy).creationCode;
-        bytecode = abi.encodePacked(sourceCodeBytes, abi.encode(beacon, ""));
+        bytes memory sourceCodeBytes = type(ERC1967Proxy).creationCode;
+        bytecode = abi.encodePacked(sourceCodeBytes, abi.encode(refImplementation, ""));
     }
 
-    function upgradeImplementation(address _newImplementation) external onlyOwner {
-        UpgradeableBeacon(beacon).upgradeTo(_newImplementation);
-    }
-
-    function getBeaconImplementation() external view returns (address) {
-        return UpgradeableBeacon(beacon).implementation();
+    /// @notice Set the reference implementation contract for the next deployments
+    /// @dev Only callable by addresses with the admin role
+    /// @param _newImplementation Address of the new implementation
+    function setRefImplementation(DealManager _newImplementation) public onlyOwner {
+        refImplementation = _newImplementation;
     }
 }
-

--- a/src/RoundManager.sol
+++ b/src/RoundManager.sol
@@ -51,6 +51,7 @@ import "./storage/RoundManagerStorage.sol";
 import "./storage/BorgAuthStorage.sol";
 import "./interfaces/ICyberCorp.sol";
 import "./interfaces/ICyberCertPrinter.sol";
+import "./interfaces/IRoundManagerFactory.sol";
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 
 /// @title RoundManager
@@ -111,6 +112,7 @@ contract RoundManager is
     error EOINotExpired();
     error EOIExpired();
     error NotEOISubmitter();
+    error NotRefImplementation();
 
     event RoundCreated(bytes32 indexed roundId, address indexed corp, Round round, bool publicRound);
     event RoundSnapshotSet(
@@ -788,8 +790,14 @@ contract RoundManager is
         return RoundManagerStorage.getIssuanceManager();
     }
 
-    // UUPS upgrade authorization
+    /// @notice UUPS upgrade authorization
+    /// @dev MetaLeX releases new versions through the factory's reference implementation,
+    /// and the CyberCorp owner can decide if or when he wants to perform the upgrade
     function _authorizeUpgrade(
         address newImplementation
-    ) internal override onlyOwner {}
+    ) internal override onlyOwner {
+        if(IRoundManagerFactory(RoundManagerStorage.getUpgradeFactory()).refImplementation() != newImplementation) {
+            revert NotRefImplementation();
+        }
+    }
 }

--- a/src/RoundManager.sol
+++ b/src/RoundManager.sol
@@ -77,6 +77,14 @@ contract RoundManager is
         "EscrowedSignatureData(bytes32 roundId,uint8 seriesType,uint256 raiseCap,uint256 minTicket,uint256 maxTicket,uint8 roundType,uint256 startTime,uint256 endTime,bytes32 templateId,address paymentToken,uint256 pricePerUnit,uint256 valuation,address companyAddress)"
     );
 
+    string public constant DEPLOY_VERSION = "1"; // For version-tracking on all deployment and future upgrades
+
+    // Upgrade notes: Reduced gap to account for new variables
+    //  50
+    //   -1 (BorgAuthACL)
+    //  = 49
+    uint256[49] private __gap;
+
     /// @notice Certificate data structure for creating new certificates
     struct CyberCertData {
         string name;

--- a/src/RoundManager.sol
+++ b/src/RoundManager.sol
@@ -84,9 +84,10 @@ contract RoundManager is
 
     // Upgrade notes: Reduced gap to account for new variables
     //  50
+    //   -1 (ReentrancyGuard)
     //   -1 (BorgAuthACL)
-    //  = 49
-    uint256[49] private __gap;
+    //  = 48
+    uint256[48] private __gap;
 
     /// @notice Certificate data structure for creating new certificates
     struct CyberCertData {

--- a/src/RoundManager.sol
+++ b/src/RoundManager.sol
@@ -82,13 +82,6 @@ contract RoundManager is
 
     string public constant DEPLOY_VERSION = "1"; // For version-tracking on all deployment and future upgrades
 
-    // Upgrade notes: Reduced gap to account for new variables
-    //  50
-    //   -1 (ReentrancyGuard)
-    //   -1 (BorgAuthACL)
-    //  = 48
-    uint256[48] private __gap;
-
     /// @notice Certificate data structure for creating new certificates
     struct CyberCertData {
         string name;
@@ -831,7 +824,7 @@ contract RoundManager is
     function _authorizeUpgrade(
         address newImplementation
     ) internal override onlyOwner {
-        if(IRoundManagerFactory(RoundManagerStorage.getUpgradeFactory()).refImplementation() != newImplementation) {
+        if(IRoundManagerFactory(RoundManagerStorage.getUpgradeFactory()).getRefImplementation() != newImplementation) {
             revert NotRefImplementation();
         }
     }

--- a/src/RoundManagerFactory.sol
+++ b/src/RoundManagerFactory.sol
@@ -46,6 +46,7 @@ import "openzeppelin-contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import "openzeppelin-contracts/utils/Create2.sol";
 import "openzeppelin-contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "./libs/auth.sol";
+import {RoundManagerFactoryStorage} from "./storage/RoundManagerFactoryStorage.sol";
 
 /// @title RoundManagerFactory
 /// @notice Factory contract for deploying RoundManager instances
@@ -55,15 +56,6 @@ contract RoundManagerFactory is UUPSUpgradeable, BorgAuthACL {
     error DeploymentFailed();
     error ZeroAddress();
 
-    RoundManager public refImplementation; // implementation contract to use for new deployments
-
-    // Upgrade notes: Reduced gap to account for new variables
-    //  50
-    //   -1 (BorgAuthACL)
-    //   -1 (self)
-    //  = 48
-    uint256[48] private __gap;
-    
     event RoundManagerDeployed(address roundManager, string version);
 
     /// @custom:oz-upgrades-unsafe-allow constructor
@@ -78,7 +70,7 @@ contract RoundManagerFactory is UUPSUpgradeable, BorgAuthACL {
         // Initialize BorgAuthACL
         __BorgAuthACL_init(_auth);
 
-        refImplementation = RoundManager(_refImplementation);
+        RoundManagerFactoryStorage.setRefImplementation(_refImplementation);
     }
 
     /// @notice Deploys a new RoundManager instance
@@ -95,7 +87,7 @@ contract RoundManagerFactory is UUPSUpgradeable, BorgAuthACL {
 
         if(roundManagerProxy == address(0)) revert DeploymentFailed();
         
-        emit RoundManagerDeployed(roundManagerProxy, refImplementation.DEPLOY_VERSION());
+        emit RoundManagerDeployed(roundManagerProxy, RoundManager(RoundManagerFactoryStorage.getRefImplementation()).DEPLOY_VERSION());
         return roundManagerProxy;
     }
 
@@ -112,14 +104,20 @@ contract RoundManagerFactory is UUPSUpgradeable, BorgAuthACL {
     /// @return bytecode The proxy contract creation bytecode
     function _getBytecode() private view returns (bytes memory bytecode) {
         bytes memory sourceCodeBytes = type(ERC1967Proxy).creationCode;
-        bytecode = abi.encodePacked(sourceCodeBytes, abi.encode(refImplementation, ""));
+        bytecode = abi.encodePacked(sourceCodeBytes, abi.encode(RoundManagerFactoryStorage.getRefImplementation(), ""));
+    }
+
+    /// @notice Get the reference implementation contract for the next deployments
+    /// @return Current reference implementation contract address
+    function getRefImplementation() public returns(address) {
+        return RoundManagerFactoryStorage.getRefImplementation();
     }
 
     /// @notice Set the reference implementation contract for the next deployments
     /// @dev Only callable by addresses with the admin role
     /// @param _newImplementation Address of the new implementation
-    function setRefImplementation(RoundManager _newImplementation) public onlyOwner {
-        refImplementation = _newImplementation;
+    function setRefImplementation(address _newImplementation) public onlyOwner {
+        RoundManagerFactoryStorage.setRefImplementation(_newImplementation);
     }
 
     function _authorizeUpgrade(

--- a/src/RoundManagerFactory.sol
+++ b/src/RoundManagerFactory.sol
@@ -42,28 +42,26 @@ except with the express prior written permission of the copyright holder.*/
 pragma solidity 0.8.28;
 
 import "./RoundManager.sol";
-import "@openzeppelin/contracts/utils/Create2.sol";
-import "@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol";
-import "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
+import "openzeppelin-contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import "openzeppelin-contracts/utils/Create2.sol";
 import "./libs/auth.sol";
 
 /// @title RoundManagerFactory
 /// @notice Factory contract for deploying RoundManager instances
-/// @dev Uses BeaconProxy pattern for upgradeable RoundManager instances
+/// @dev Uses ERC1967Proxy+UUPSUpgradeable pattern for upgradeable RoundManager instances
 contract RoundManagerFactory is BorgAuthACL {
     error InvalidSalt();
     error DeploymentFailed();
     error ZeroAddress();
-    
-    UpgradeableBeacon public beacon;
 
-    event RoundManagerDeployed(address roundManager);
+    RoundManager public refImplementation; // implementation contract to use for new deployments
+    
+    event RoundManagerDeployed(address roundManager, string version);
 
     /// @notice Constructor that deploys the implementation and beacon
     /// @param _auth Address of the BorgAuth contract
     constructor(address _auth) {
-        // Deploy the implementation contract and beacon
-        beacon = new UpgradeableBeacon(address(new RoundManager()), address(this));
+        refImplementation = new RoundManager();
         initialize(_auth);
     }
 
@@ -85,10 +83,10 @@ contract RoundManagerFactory is BorgAuthACL {
         
         // Deploy using CREATE2
         address roundManagerProxy = Create2.deploy(0, _salt, proxyBytecode);
-        
+
         if(roundManagerProxy == address(0)) revert DeploymentFailed();
         
-        emit RoundManagerDeployed(roundManagerProxy);
+        emit RoundManagerDeployed(roundManagerProxy, refImplementation.DEPLOY_VERSION());
         return roundManagerProxy;
     }
 
@@ -104,20 +102,14 @@ contract RoundManagerFactory is BorgAuthACL {
     /// @dev Internal function used by deployRoundManager
     /// @return bytecode The proxy contract creation bytecode
     function _getBytecode() private view returns (bytes memory bytecode) {
-        bytes memory sourceCodeBytes = type(BeaconProxy).creationCode;
-        bytecode = abi.encodePacked(sourceCodeBytes, abi.encode(beacon, ""));
+        bytes memory sourceCodeBytes = type(ERC1967Proxy).creationCode;
+        bytecode = abi.encodePacked(sourceCodeBytes, abi.encode(refImplementation, ""));
     }
 
-    /// @notice Upgrades the implementation contract
+    /// @notice Set the reference implementation contract for the next deployments
     /// @dev Only callable by addresses with the admin role
     /// @param _newImplementation Address of the new implementation
-    function upgradeImplementation(address _newImplementation) external onlyOwner {
-        UpgradeableBeacon(beacon).upgradeTo(_newImplementation);
-    }
-
-    /// @notice Gets the current implementation address
-    /// @return The address of the current implementation contract
-    function getBeaconImplementation() external view returns (address) {
-        return UpgradeableBeacon(beacon).implementation();
+    function setRefImplementation(RoundManager _newImplementation) public onlyOwner {
+        refImplementation = _newImplementation;
     }
 }

--- a/src/RoundManagerFactory.sol
+++ b/src/RoundManagerFactory.sol
@@ -44,32 +44,41 @@ pragma solidity 0.8.28;
 import "./RoundManager.sol";
 import "openzeppelin-contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import "openzeppelin-contracts/utils/Create2.sol";
+import "openzeppelin-contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "./libs/auth.sol";
 
 /// @title RoundManagerFactory
 /// @notice Factory contract for deploying RoundManager instances
 /// @dev Uses ERC1967Proxy+UUPSUpgradeable pattern for upgradeable RoundManager instances
-contract RoundManagerFactory is BorgAuthACL {
+contract RoundManagerFactory is UUPSUpgradeable, BorgAuthACL {
     error InvalidSalt();
     error DeploymentFailed();
     error ZeroAddress();
 
     RoundManager public refImplementation; // implementation contract to use for new deployments
+
+    // Upgrade notes: Reduced gap to account for new variables
+    //  50
+    //   -1 (BorgAuthACL)
+    //   -1 (self)
+    //  = 48
+    uint256[48] private __gap;
     
     event RoundManagerDeployed(address roundManager, string version);
 
-    /// @notice Constructor that deploys the implementation and beacon
-    /// @param _auth Address of the BorgAuth contract
-    constructor(address _auth) {
-        refImplementation = new RoundManager();
-        initialize(_auth);
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
     }
 
-    /// @notice Initializes the factory with auth
+    /// @notice Initialize the factory with authentication and reference implementation
     /// @param _auth Address of the BorgAuth contract
-    function initialize(address _auth) public initializer {
+    /// @param _refImplementation Address of the reference RoundManager implementation
+    function initialize(address _auth, address _refImplementation) public initializer {
         // Initialize BorgAuthACL
         __BorgAuthACL_init(_auth);
+
+        refImplementation = RoundManager(_refImplementation);
     }
 
     /// @notice Deploys a new RoundManager instance
@@ -112,4 +121,8 @@ contract RoundManagerFactory is BorgAuthACL {
     function setRefImplementation(RoundManager _newImplementation) public onlyOwner {
         refImplementation = _newImplementation;
     }
+
+    function _authorizeUpgrade(
+        address newImplementation
+    ) internal override onlyOwner {}
 }

--- a/src/interfaces/IDealManagerFactory.sol
+++ b/src/interfaces/IDealManagerFactory.sol
@@ -46,5 +46,5 @@ interface IDealManagerFactory {
     function computeDealManagerAddress(bytes32 salt) external view returns (address);
     function initialize(address _auth) external;
 
-    function refImplementation() external returns (address);
+    function getRefImplementation() external returns (address);
 }

--- a/src/interfaces/IDealManagerFactory.sol
+++ b/src/interfaces/IDealManagerFactory.sol
@@ -45,4 +45,6 @@ interface IDealManagerFactory {
     function deployDealManager(bytes32 salt) external returns (address);
     function computeDealManagerAddress(bytes32 salt) external view returns (address);
     function initialize(address _auth) external;
+
+    function refImplementation() external returns (address);
 }

--- a/src/interfaces/IRoundManagerFactory.sol
+++ b/src/interfaces/IRoundManagerFactory.sol
@@ -44,5 +44,5 @@ pragma solidity 0.8.28;
 interface IRoundManagerFactory {
     function deployRoundManager(bytes32 _salt) external returns (address);
 
-    function refImplementation() external returns (address);
+    function getRefImplementation() external returns (address);
 }

--- a/src/interfaces/IRoundManagerFactory.sol
+++ b/src/interfaces/IRoundManagerFactory.sol
@@ -43,4 +43,6 @@ pragma solidity 0.8.28;
 
 interface IRoundManagerFactory {
     function deployRoundManager(bytes32 _salt) external returns (address);
+
+    function refImplementation() external returns (address);
 }

--- a/src/storage/DealManagerFactoryStorage.sol
+++ b/src/storage/DealManagerFactoryStorage.sol
@@ -1,0 +1,115 @@
+//
+///*    .o.
+//     .888.
+//    .8"888.
+//   .8' `888.
+//  .88ooo8888.
+// .8'     `888.
+// o88o     o8888o
+//
+//
+//
+// ooo        ooooo               .             ooooo                  ooooooo  ooooo
+// `88.       .888'             .o8             `888'                   `8888    d8'
+//  888b     d'888   .ooooo.  .o888oo  .oooo.    888          .ooooo.     Y888..8P
+//  8 Y88. .P  888  d88' `88b   888   `P  )88b   888         d88' `88b     `8888'
+//  8  `888'   888  888ooo888   888    .oP"888   888         888ooo888    .8PY888.
+//  8    Y     888  888    .o   888 . d8(  888   888       o 888    .o   d8'  `888b
+// o8o        o888o `Y8bod8P'   "888" `Y888""8o o888ooooood8 `Y8bod8P' o888o  o88888o
+//
+//
+//
+//   .oooooo.                .o8                            .oooooo.
+//  d8P'  `Y8b              "888                           d8P'  `Y8b
+// 888          oooo    ooo  888oooo.   .ooooo.  oooo d8b 888           .ooooo.  oooo d8b oo.ooooo.
+// 888           `88.  .8'   d88' `88b d88' `88b `888""8P 888          d88' `88b `888""8P  888' `88b
+// 888            `88..8'    888   888 888ooo888  888     888          888   888  888      888   888
+// `88b    ooo     `888'     888   888 888    .o  888     `88b    ooo  888   888  888      888   888 .o.
+//  `Y8bood8P'      .8'      `Y8bod8P' `Y8bod8P' d888b     `Y8bood8P'  `Y8bod8P' d888b     888bod8P' Y8P
+//              .o..P'                                                                     888
+//              `Y8P'                                                                     o888o
+// _______________________________________________________________________________________________________
+//
+// All software, documentation and other files and information in this repository (collectively, the "Software")
+// are copyright MetaLeX Labs, Inc., a Delaware corporation.
+//
+// All rights reserved.
+//
+// The Software is proprietary and shall not, in part or in whole, be used, copied, modified, merged, published,
+// distributed, transmitted, sublicensed, sold, or otherwise used in any form or by any means, electronic or
+// mechanical, including photocopying, recording, or by any information storage and retrieval system,
+// except with the express prior written permission of the copyright holder.*/
+
+pragma solidity 0.8.28;
+
+/// @title DealManagerFactoryStorage
+/// @notice Storage library for the DealManagerFactory contract that handles persistent data storage
+/// @dev Uses the unstructured storage pattern to manage factory-related data
+library DealManagerFactoryStorage {
+    // Storage slot for our struct
+    bytes32 constant STORAGE_POSITION = keccak256("cybercorp.deal.manager.factory.storage.v1");
+
+    uint256 public constant BASIS_POINTS = 10000; // 100%
+
+    /// @notice Main storage layout struct that holds all persisted data
+    /// @dev Uses unstructured storage pattern to avoid storage collisions
+    struct DealManagerFactoryData {
+        address refImplementation; // implementation contract to use for new deployments
+
+        address platformPayable; // Recipient of platform fees
+        uint256 defaultFeeRatio; // total fee as % of ticket size (BASIS_POINTS = 100%)
+        uint256 defaultFeeCorpCutRatio; // CyberCorp cut of total fee as % of ticket size (<= feeRatio, BASIS_POINTS = 100%)
+    }
+
+    /// @notice Retrieves the storage reference for the DealManagerFactoryData struct
+    /// @dev Uses assembly to compute the storage position
+    /// @return ds Reference to the DealManagerFactoryData struct in storage
+    function dealManagerFactoryStorage() internal pure returns (DealManagerFactoryData storage ds) {
+        bytes32 position = STORAGE_POSITION;
+        assembly {
+            ds.slot := position
+        }
+    }
+
+    function getRefImplementation() internal view returns (address) {
+        return dealManagerFactoryStorage().refImplementation;
+    }
+
+    function getPlatformPayable() internal view returns (address) {
+        return dealManagerFactoryStorage().platformPayable;
+    }
+
+    function getDefaultFeeRatio() internal view returns (uint256) {
+        return dealManagerFactoryStorage().defaultFeeRatio;
+    }
+
+    function getDefaultFeeCorpCutRatio() internal view returns (uint256) {
+        return dealManagerFactoryStorage().defaultFeeCorpCutRatio;
+    }
+
+    function setRefImplementation(address newImplementation) internal {
+        dealManagerFactoryStorage().refImplementation = newImplementation;
+    }
+
+    function setPlatformPayable(address platformPayable) internal {
+        dealManagerFactoryStorage().platformPayable = platformPayable;
+    }
+
+    function setDefaultFeeRatio(uint256 feeRatio) internal returns (bool) {
+        if (feeRatio > BASIS_POINTS) {
+            return false; // fee ratio should not exceed 100%
+        } else {
+            dealManagerFactoryStorage().defaultFeeRatio = feeRatio;
+            return true;
+        }
+    }
+
+    function setDefaultFeeCorpCutRatio(uint256 feeCorpCutRatio) internal returns (bool) {
+        if (feeCorpCutRatio > dealManagerFactoryStorage().defaultFeeCorpCutRatio) {
+            return false; // CyberCorp's cut should not exceed fee ratio
+        } else {
+            dealManagerFactoryStorage().defaultFeeCorpCutRatio = feeCorpCutRatio;
+            return true;
+        }
+    }
+}

--- a/src/storage/DealManagerFactoryStorage.sol
+++ b/src/storage/DealManagerFactoryStorage.sol
@@ -49,16 +49,10 @@ library DealManagerFactoryStorage {
     // Storage slot for our struct
     bytes32 constant STORAGE_POSITION = keccak256("cybercorp.deal.manager.factory.storage.v1");
 
-    uint256 public constant BASIS_POINTS = 10000; // 100%
-
     /// @notice Main storage layout struct that holds all persisted data
     /// @dev Uses unstructured storage pattern to avoid storage collisions
     struct DealManagerFactoryData {
         address refImplementation; // implementation contract to use for new deployments
-
-        address platformPayable; // Recipient of platform fees
-        uint256 defaultFeeRatio; // total fee as % of ticket size (BASIS_POINTS = 100%)
-        uint256 defaultFeeCorpCutRatio; // CyberCorp cut of total fee as % of ticket size (<= feeRatio, BASIS_POINTS = 100%)
     }
 
     /// @notice Retrieves the storage reference for the DealManagerFactoryData struct
@@ -75,41 +69,7 @@ library DealManagerFactoryStorage {
         return dealManagerFactoryStorage().refImplementation;
     }
 
-    function getPlatformPayable() internal view returns (address) {
-        return dealManagerFactoryStorage().platformPayable;
-    }
-
-    function getDefaultFeeRatio() internal view returns (uint256) {
-        return dealManagerFactoryStorage().defaultFeeRatio;
-    }
-
-    function getDefaultFeeCorpCutRatio() internal view returns (uint256) {
-        return dealManagerFactoryStorage().defaultFeeCorpCutRatio;
-    }
-
     function setRefImplementation(address newImplementation) internal {
         dealManagerFactoryStorage().refImplementation = newImplementation;
-    }
-
-    function setPlatformPayable(address platformPayable) internal {
-        dealManagerFactoryStorage().platformPayable = platformPayable;
-    }
-
-    function setDefaultFeeRatio(uint256 feeRatio) internal returns (bool) {
-        if (feeRatio > BASIS_POINTS) {
-            return false; // fee ratio should not exceed 100%
-        } else {
-            dealManagerFactoryStorage().defaultFeeRatio = feeRatio;
-            return true;
-        }
-    }
-
-    function setDefaultFeeCorpCutRatio(uint256 feeCorpCutRatio) internal returns (bool) {
-        if (feeCorpCutRatio > dealManagerFactoryStorage().defaultFeeCorpCutRatio) {
-            return false; // CyberCorp's cut should not exceed fee ratio
-        } else {
-            dealManagerFactoryStorage().defaultFeeCorpCutRatio = feeCorpCutRatio;
-            return true;
-        }
     }
 }

--- a/src/storage/RoundManagerFactoryStorage.sol
+++ b/src/storage/RoundManagerFactoryStorage.sol
@@ -49,16 +49,10 @@ library RoundManagerFactoryStorage {
     // Storage slot for our struct
     bytes32 constant STORAGE_POSITION = keccak256("cybercorp.round.manager.factory.storage.v1");
 
-    uint256 public constant BASIS_POINTS = 10000; // 100%
-
     /// @notice Main storage layout struct that holds all persisted data
     /// @dev Uses unstructured storage pattern to avoid storage collisions
     struct RoundManagerFactoryData {
         address refImplementation; // implementation contract to use for new deployments
-
-        address platformPayable; // Recipient of platform fees
-        uint256 defaultFeeRatio; // total fee as % of ticket size (BASIS_POINTS = 100%)
-        uint256 defaultFeeCorpCutRatio; // CyberCorp cut of total fee as % of ticket size (<= feeRatio, BASIS_POINTS = 100%)
     }
 
     /// @notice Retrieves the storage reference for the RoundManagerFactoryData struct
@@ -75,41 +69,7 @@ library RoundManagerFactoryStorage {
         return roundManagerFactoryStorage().refImplementation;
     }
 
-    function getPlatformPayable() internal view returns (address) {
-        return roundManagerFactoryStorage().platformPayable;
-    }
-
-    function getDefaultFeeRatio() internal view returns (uint256) {
-        return roundManagerFactoryStorage().defaultFeeRatio;
-    }
-
-    function getDefaultFeeCorpCutRatio() internal view returns (uint256) {
-        return roundManagerFactoryStorage().defaultFeeCorpCutRatio;
-    }
-
     function setRefImplementation(address newImplementation) internal {
         roundManagerFactoryStorage().refImplementation = newImplementation;
-    }
-
-    function setPlatformPayable(address platformPayable) internal {
-        roundManagerFactoryStorage().platformPayable = platformPayable;
-    }
-
-    function setDefaultFeeRatio(uint256 feeRatio) internal returns (bool) {
-        if (feeRatio > BASIS_POINTS) {
-            return false; // fee ratio should not exceed 100%
-        } else {
-            roundManagerFactoryStorage().defaultFeeRatio = feeRatio;
-            return true;
-        }
-    }
-
-    function setDefaultFeeCorpCutRatio(uint256 feeCorpCutRatio) internal returns (bool) {
-        if (feeCorpCutRatio > roundManagerFactoryStorage().defaultFeeCorpCutRatio) {
-            return false; // CyberCorp's cut should not exceed fee ratio
-        } else {
-            roundManagerFactoryStorage().defaultFeeCorpCutRatio = feeCorpCutRatio;
-            return true;
-        }
     }
 }

--- a/src/storage/RoundManagerFactoryStorage.sol
+++ b/src/storage/RoundManagerFactoryStorage.sol
@@ -1,0 +1,115 @@
+//
+///*    .o.
+//     .888.
+//    .8"888.
+//   .8' `888.
+//  .88ooo8888.
+// .8'     `888.
+// o88o     o8888o
+//
+//
+//
+// ooo        ooooo               .             ooooo                  ooooooo  ooooo
+// `88.       .888'             .o8             `888'                   `8888    d8'
+//  888b     d'888   .ooooo.  .o888oo  .oooo.    888          .ooooo.     Y888..8P
+//  8 Y88. .P  888  d88' `88b   888   `P  )88b   888         d88' `88b     `8888'
+//  8  `888'   888  888ooo888   888    .oP"888   888         888ooo888    .8PY888.
+//  8    Y     888  888    .o   888 . d8(  888   888       o 888    .o   d8'  `888b
+// o8o        o888o `Y8bod8P'   "888" `Y888""8o o888ooooood8 `Y8bod8P' o888o  o88888o
+//
+//
+//
+//   .oooooo.                .o8                            .oooooo.
+//  d8P'  `Y8b              "888                           d8P'  `Y8b
+// 888          oooo    ooo  888oooo.   .ooooo.  oooo d8b 888           .ooooo.  oooo d8b oo.ooooo.
+// 888           `88.  .8'   d88' `88b d88' `88b `888""8P 888          d88' `88b `888""8P  888' `88b
+// 888            `88..8'    888   888 888ooo888  888     888          888   888  888      888   888
+// `88b    ooo     `888'     888   888 888    .o  888     `88b    ooo  888   888  888      888   888 .o.
+//  `Y8bood8P'      .8'      `Y8bod8P' `Y8bod8P' d888b     `Y8bood8P'  `Y8bod8P' d888b     888bod8P' Y8P
+//              .o..P'                                                                     888
+//              `Y8P'                                                                     o888o
+// _______________________________________________________________________________________________________
+//
+// All software, documentation and other files and information in this repository (collectively, the "Software")
+// are copyright MetaLeX Labs, Inc., a Delaware corporation.
+//
+// All rights reserved.
+//
+// The Software is proprietary and shall not, in part or in whole, be used, copied, modified, merged, published,
+// distributed, transmitted, sublicensed, sold, or otherwise used in any form or by any means, electronic or
+// mechanical, including photocopying, recording, or by any information storage and retrieval system,
+// except with the express prior written permission of the copyright holder.*/
+
+pragma solidity 0.8.28;
+
+/// @title RoundManagerFactoryStorage
+/// @notice Storage library for the RoundManagerFactory contract that handles persistent data storage
+/// @dev Uses the unstructured storage pattern to manage factory-related data
+library RoundManagerFactoryStorage {
+    // Storage slot for our struct
+    bytes32 constant STORAGE_POSITION = keccak256("cybercorp.round.manager.factory.storage.v1");
+
+    uint256 public constant BASIS_POINTS = 10000; // 100%
+
+    /// @notice Main storage layout struct that holds all persisted data
+    /// @dev Uses unstructured storage pattern to avoid storage collisions
+    struct RoundManagerFactoryData {
+        address refImplementation; // implementation contract to use for new deployments
+
+        address platformPayable; // Recipient of platform fees
+        uint256 defaultFeeRatio; // total fee as % of ticket size (BASIS_POINTS = 100%)
+        uint256 defaultFeeCorpCutRatio; // CyberCorp cut of total fee as % of ticket size (<= feeRatio, BASIS_POINTS = 100%)
+    }
+
+    /// @notice Retrieves the storage reference for the RoundManagerFactoryData struct
+    /// @dev Uses assembly to compute the storage position
+    /// @return ds Reference to the RoundManagerFactoryData struct in storage
+    function roundManagerFactoryStorage() internal pure returns (RoundManagerFactoryData storage ds) {
+        bytes32 position = STORAGE_POSITION;
+        assembly {
+            ds.slot := position
+        }
+    }
+
+    function getRefImplementation() internal view returns (address) {
+        return roundManagerFactoryStorage().refImplementation;
+    }
+
+    function getPlatformPayable() internal view returns (address) {
+        return roundManagerFactoryStorage().platformPayable;
+    }
+
+    function getDefaultFeeRatio() internal view returns (uint256) {
+        return roundManagerFactoryStorage().defaultFeeRatio;
+    }
+
+    function getDefaultFeeCorpCutRatio() internal view returns (uint256) {
+        return roundManagerFactoryStorage().defaultFeeCorpCutRatio;
+    }
+
+    function setRefImplementation(address newImplementation) internal {
+        roundManagerFactoryStorage().refImplementation = newImplementation;
+    }
+
+    function setPlatformPayable(address platformPayable) internal {
+        roundManagerFactoryStorage().platformPayable = platformPayable;
+    }
+
+    function setDefaultFeeRatio(uint256 feeRatio) internal returns (bool) {
+        if (feeRatio > BASIS_POINTS) {
+            return false; // fee ratio should not exceed 100%
+        } else {
+            roundManagerFactoryStorage().defaultFeeRatio = feeRatio;
+            return true;
+        }
+    }
+
+    function setDefaultFeeCorpCutRatio(uint256 feeCorpCutRatio) internal returns (bool) {
+        if (feeCorpCutRatio > roundManagerFactoryStorage().defaultFeeCorpCutRatio) {
+            return false; // CyberCorp's cut should not exceed fee ratio
+        } else {
+            roundManagerFactoryStorage().defaultFeeCorpCutRatio = feeCorpCutRatio;
+            return true;
+        }
+    }
+}

--- a/test/CyberCorpTest.t.sol
+++ b/test/CyberCorpTest.t.sol
@@ -3304,22 +3304,22 @@ contract CyberCorpTest is Test {
         vm.stopPrank();
 
         // Deploy new implementation
-        address newImplementation = address(new DealManager());
+        DealManager newImplementation = new DealManager();
         address factoryaddr = cyberCorpFactory.dealManagerFactory();
         // Upgrade beacon implementation
         console.log(DealManagerFactory(factoryaddr).AUTH().userRoles(address(multisig)));
 
         // Non-owner should not be able to upgrade it
         vm.expectRevert(abi.encodeWithSelector(BorgAuth.BorgAuth_NotAuthorized.selector, 99, address(this)));
-        DealManagerFactory(factoryaddr).upgradeImplementation(newImplementation);
+        DealManagerFactory(factoryaddr).setRefImplementation(newImplementation);
 
         // Owner should be able to upgrade it
         console.log(
             DealManagerFactory(factoryaddr).AUTH().userRoles(address(multisig))
         );
         vm.prank(multisig);
-        DealManagerFactory(factoryaddr).upgradeImplementation(newImplementation);
-        assertEq(DealManagerFactory(factoryaddr).getBeaconImplementation(), newImplementation);
+        DealManagerFactory(factoryaddr).setRefImplementation(newImplementation);
+        assertEq(address(DealManagerFactory(factoryaddr).refImplementation()), address(newImplementation));
 
         // Verify the deal manager still works by checking the deal
         Escrow memory escrow = DealManager(dealManagerAddr).getEscrowDetails(
@@ -3327,10 +3327,6 @@ contract CyberCorpTest is Test {
         );
 
         console.log(escrow.counterParty);
-        assertEq(
-            DealManagerFactory(factoryaddr).getBeaconImplementation(),
-            newImplementation
-        );
     }
 
     function testUpgradeIssuanceManager() public {
@@ -4436,25 +4432,25 @@ contract CyberCorpTest is Test {
         DealManagerFactory deployedFactory = DealManagerFactory(deployedFactoryAddr);
 
         // Get the current beacon implementation
-        address currentImplementation = deployedFactory.getBeaconImplementation();
+        address currentImplementation = address(deployedFactory.refImplementation());
         console.log("Current beacon implementation:", currentImplementation);
 
         // Deploy a new DealManager implementation using CREATE2
         bytes32 implementationSalt = bytes32(keccak256("NewDealManagerImplementation"));
-        address newImplementation = address(new DealManager{salt: implementationSalt}());
-        console.log("New implementation deployed at:", newImplementation);
+        DealManager newImplementation = new DealManager{salt: implementationSalt}();
+        console.log("New implementation deployed at:", address(newImplementation));
 
         // Non-owner should not be able to upgrade it
         vm.expectRevert(abi.encodeWithSelector(BorgAuth.BorgAuth_NotAuthorized.selector, 99, address(this)));
-        deployedFactory.upgradeImplementation(newImplementation);
+        deployedFactory.setRefImplementation(newImplementation);
 
         // Owner should be able to upgrade it
         vm.prank(multisig);
-        deployedFactory.upgradeImplementation(newImplementation);
+        deployedFactory.setRefImplementation(newImplementation);
 
         // Verify the upgrade was successful
-        address updatedImplementation = deployedFactory.getBeaconImplementation();
-        assertEq(updatedImplementation, newImplementation, "Beacon implementation should be updated");
+        address updatedImplementation = address(deployedFactory.refImplementation());
+        assertEq(updatedImplementation, address(newImplementation), "Beacon implementation should be updated");
         console.log("Updated beacon implementation:", updatedImplementation);
 
         // Verify the existing DealManager still works by checking its state

--- a/test/CyberCorpTest.t.sol
+++ b/test/CyberCorpTest.t.sol
@@ -77,6 +77,7 @@ import {LexChexCondition} from "../src/libs/conditions/lexchexCondition.sol";
 import {LeXcheXUtils} from "./libs/LeXcheXUtils.sol";
 import {Accreditation} from "../src/creds/storage/lexchexStorage.sol";
 import {RoundManagerFactory} from "../src/RoundManagerFactory.sol";
+import {ILegacyDealManagerFactory} from "./interfaces/ILegacyDealManagerFactory.sol";
 
 contract CyberCorpTest is Test {
     using ERC1967ProxyLib for address;
@@ -240,8 +241,7 @@ contract CyberCorpTest is Test {
             )
         )));
         cyberCorpFactory.setStable(stable);
-        uint256 upgradePrivKey = vm.envUint("PRIVATE_KEY_MAIN");
-        address upgradeOwner = vm.addr(upgradePrivKey);
+        address upgradeOwner = 0x341Da9fb8F9bD9a775f6bD641091b24Dd9aA459B;
         address lxAuth = cyberCorpFactory.lexchexAuth();
         vm.stopPrank();
         vm.startPrank(upgradeOwner);
@@ -3227,7 +3227,7 @@ contract CyberCorpTest is Test {
         assertEq(uriBuilder.securityClassToString(SecurityClass.SAFT), "SAFT");
     }
 
-    function testUpgradeDealManagerBeacon() public {
+    function testUpgradeDealManagerViaRefImplementation() public {
         CertificateDetails[] memory _details = new CertificateDetails[](1);
         CertificateDetails memory _detailsA = CertificateDetails({
             signingOfficerName: "",
@@ -4405,7 +4405,7 @@ contract CyberCorpTest is Test {
         console.log("Created agreement ID:", vm.toString(id));
     }
 
-    function testUpgradeDealManagerBeaconViaDeployedFactory() public {
+    function testUpgradeLegacyDealManagersViaBeacon() public {
         // First deploy a CyberCorp which will create a DealManager
         CertificateDetails[] memory _details = new CertificateDetails[](1);
         CertificateDetails memory _detailsA = CertificateDetails({
@@ -4449,12 +4449,12 @@ contract CyberCorpTest is Test {
         assertTrue(dealManagerAddr != address(0), "DealManager should be deployed");
         console.log("Deployed DealManager at:", dealManagerAddr);
 
-        // Get the deployed DealManagerFactory address
+        // Get the deployed DealManagerFactory address (legacy Beacon-based)
         address deployedFactoryAddr = 0x975df8A99C895d04ae158F8C91Ba562Fce3ECDA3;
-        DealManagerFactory deployedFactory = DealManagerFactory(deployedFactoryAddr);
+        ILegacyDealManagerFactory deployedFactory = ILegacyDealManagerFactory(deployedFactoryAddr);
 
         // Get the current beacon implementation
-        address currentImplementation = deployedFactory.getRefImplementation();
+        address currentImplementation = deployedFactory.getBeaconImplementation();
         console.log("Current beacon implementation:", currentImplementation);
 
         // Deploy a new DealManager implementation using CREATE2
@@ -4464,14 +4464,14 @@ contract CyberCorpTest is Test {
 
         // Non-owner should not be able to upgrade it
         vm.expectRevert(abi.encodeWithSelector(BorgAuth.BorgAuth_NotAuthorized.selector, 99, address(this)));
-        deployedFactory.setRefImplementation(newImplementation);
+        deployedFactory.upgradeImplementation(newImplementation);
 
         // Owner should be able to upgrade it
         vm.prank(multisig);
-        deployedFactory.setRefImplementation(newImplementation);
+        deployedFactory.upgradeImplementation(newImplementation);
 
         // Verify the upgrade was successful
-        address updatedImplementation = deployedFactory.getRefImplementation();
+        address updatedImplementation = deployedFactory.getBeaconImplementation();
         assertEq(updatedImplementation, address(newImplementation), "Beacon implementation should be updated");
         console.log("Updated beacon implementation:", updatedImplementation);
 

--- a/test/CyberCorpTest.t.sol
+++ b/test/CyberCorpTest.t.sol
@@ -3319,7 +3319,7 @@ contract CyberCorpTest is Test {
         vm.stopPrank();
 
         // Deploy new implementation
-        DealManager newImplementation = new DealManager();
+        address newImplementation = address(new DealManager());
         address factoryaddr = cyberCorpFactory.dealManagerFactory();
         // Upgrade beacon implementation
         console.log(DealManagerFactory(factoryaddr).AUTH().userRoles(address(multisig)));
@@ -3334,7 +3334,7 @@ contract CyberCorpTest is Test {
         );
         vm.prank(multisig);
         DealManagerFactory(factoryaddr).setRefImplementation(newImplementation);
-        assertEq(address(DealManagerFactory(factoryaddr).refImplementation()), address(newImplementation));
+        assertEq(DealManagerFactory(factoryaddr).getRefImplementation(), newImplementation);
 
         // Verify the deal manager still works by checking the deal
         Escrow memory escrow = DealManager(dealManagerAddr).getEscrowDetails(
@@ -4447,12 +4447,12 @@ contract CyberCorpTest is Test {
         DealManagerFactory deployedFactory = DealManagerFactory(deployedFactoryAddr);
 
         // Get the current beacon implementation
-        address currentImplementation = address(deployedFactory.refImplementation());
+        address currentImplementation = deployedFactory.getRefImplementation();
         console.log("Current beacon implementation:", currentImplementation);
 
         // Deploy a new DealManager implementation using CREATE2
         bytes32 implementationSalt = bytes32(keccak256("NewDealManagerImplementation"));
-        DealManager newImplementation = new DealManager{salt: implementationSalt}();
+        address newImplementation = address(new DealManager{salt: implementationSalt}());
         console.log("New implementation deployed at:", address(newImplementation));
 
         // Non-owner should not be able to upgrade it
@@ -4464,7 +4464,7 @@ contract CyberCorpTest is Test {
         deployedFactory.setRefImplementation(newImplementation);
 
         // Verify the upgrade was successful
-        address updatedImplementation = address(deployedFactory.refImplementation());
+        address updatedImplementation = deployedFactory.getRefImplementation();
         assertEq(updatedImplementation, address(newImplementation), "Beacon implementation should be updated");
         console.log("Updated beacon implementation:", updatedImplementation);
 

--- a/test/CyberCorpTest.t.sol
+++ b/test/CyberCorpTest.t.sol
@@ -64,6 +64,7 @@ import {CertificateUriBuilder} from "../src/CertificateUriBuilder.sol";
 import "@openzeppelin/contracts/utils/Create2.sol";
 import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {DealManager} from "../src/DealManager.sol";
+import {RoundManager} from "../src/RoundManager.sol";
 import {Escrow} from "../src/storage/LexScrowStorage.sol";
 import {CyberCorp} from "../src/CyberCorp.sol";
 import {TokenWarrantExtension, TokenWarrantData} from "../src/storage/extensions/TokenWarrantExtension.sol";
@@ -184,7 +185,14 @@ contract CyberCorpTest is Test {
         );
 
         address dealManagerFactory = address(
-            new DealManagerFactory{salt: salt}(address(auth))
+            new ERC1967Proxy{salt: salt}(
+                address(new DealManagerFactory{salt: salt}()),
+                abi.encodeWithSelector(
+                    DealManagerFactory.initialize.selector,
+                    address(auth),
+                    address(new DealManager())
+                )
+            )
         );
 
         // Deploy upgradeable singletons
@@ -206,7 +214,14 @@ contract CyberCorpTest is Test {
 
         // RoundManager via factory and initialize
         address rmFactory = address(
-            new RoundManagerFactory{salt: salt}(address(auth))
+            new ERC1967Proxy{salt: salt}(
+                address(new RoundManagerFactory{salt: salt}()),
+                abi.encodeWithSelector(
+                    RoundManagerFactory.initialize.selector,
+                    address(auth),
+                    address(new RoundManager())
+                )
+            )
         );
 
         cyberCorpFactory = CyberCorpFactory(address(new ERC1967Proxy{salt: salt}(

--- a/test/DealManagerFactoryTest.t.sol
+++ b/test/DealManagerFactoryTest.t.sol
@@ -117,12 +117,12 @@ contract DealManagerFactoryTest is Test {
 
         // MetaLeX to release new DealManager v2
         vm.startPrank(owner);
-        DealManagerFactory(dmFactory).setRefImplementation(DealManager(address(new MockDealManagerV2())));
+        DealManagerFactory(dmFactory).setRefImplementation(address(new MockDealManagerV2()));
         vm.stopPrank();
 
         // Corp owner decided to accept the upgrade
         vm.startPrank(companyOwner);
-        dm.upgradeToAndCall(address(DealManagerFactory(dmFactory).refImplementation()), "");
+        dm.upgradeToAndCall(address(DealManagerFactory(dmFactory).getRefImplementation()), "");
         vm.stopPrank();
         assertEq(dm.DEPLOY_VERSION(), "2", "DealManager should be upgraded");
     }

--- a/test/DealManagerFactoryTest.t.sol
+++ b/test/DealManagerFactoryTest.t.sol
@@ -1,0 +1,136 @@
+/*    .o.
+     .888.
+    .8"888.
+   .8' `888.
+  .88ooo8888.
+ .8'     `888.
+o88o     o8888o
+
+
+
+ooo        ooooo               .             ooooo                  ooooooo  ooooo
+`88.       .888'             .o8             `888'                   `8888    d8'
+ 888b     d'888   .ooooo.  .o888oo  .oooo.    888          .ooooo.     Y888..8P
+ 8 Y88. .P  888  d88' `88b   888   `P  )88b   888         d88' `88b     `8888'
+ 8  `888'   888  888ooo888   888    .oP"888   888         888ooo888    .8PY888.
+ 8    Y     888  888    .o   888 . d8(  888   888       o 888    .o   d8'  `888b
+o8o        o888o `Y8bod8P'   "888" `Y888""8o o888ooooood8 `Y8bod8P' o888o  o88888o
+
+
+
+  .oooooo.                .o8                            .oooooo.
+ d8P'  `Y8b              "888                           d8P'  `Y8b
+888          oooo    ooo  888oooo.   .ooooo.  oooo d8b 888           .ooooo.  oooo d8b oo.ooooo.
+888           `88.  .8'   d88' `88b d88' `88b `888""8P 888          d88' `88b `888""8P  888' `88b
+888            `88..8'    888   888 888ooo888  888     888          888   888  888      888   888
+`88b    ooo     `888'     888   888 888    .o  888     `88b    ooo  888   888  888      888   888 .o.
+ `Y8bood8P'      .8'      `Y8bod8P' `Y8bod8P' d888b     `Y8bood8P'  `Y8bod8P' d888b     888bod8P' Y8P
+             .o..P'                                                                     888
+             `Y8P'                                                                     o888o
+_______________________________________________________________________________________________________
+
+All software, documentation and other files and information in this repository (collectively, the "Software")
+are copyright MetaLeX Labs, Inc., a Delaware corporation.
+
+All rights reserved.
+
+The Software is proprietary and shall not, in part or in whole, be used, copied, modified, merged, published,
+distributed, transmitted, sublicensed, sold, or otherwise used in any form or by any means, electronic or
+mechanical, including photocopying, recording, or by any information storage and retrieval system,
+except with the express prior written permission of the copyright holder.*/
+pragma solidity 0.8.28;
+
+import {Test, console} from "forge-std/Test.sol";
+import {ERC1967Proxy} from "openzeppelin-contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {UUPSUpgradeable} from "openzeppelin-contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {DealManager} from "../src/DealManager.sol";
+import {DealManagerFactory} from "../src/DealManagerFactory.sol";
+import {BorgAuth} from "../src/libs/auth.sol";
+
+contract MockDealManagerV2 is UUPSUpgradeable {
+    string public constant DEPLOY_VERSION = "2";
+
+    // UUPS upgrade authorization
+    function _authorizeUpgrade(
+        address newImplementation
+    ) internal override {}
+}
+
+contract DealManagerFactoryTest is Test {
+
+    bytes32 public salt = keccak256("DealManagerFactoryTest");
+
+    uint256 public ownerPrivateKey = uint256(salt) + 0;
+    address public owner = vm.addr(ownerPrivateKey);
+
+    address public companyPayable = address(1000);
+    address public companyOwner = address(1001);
+
+    BorgAuth public bootstrapAuth;
+
+    DealManagerFactory public dmFactory;
+
+    function setUp() public {
+        bootstrapAuth = new BorgAuth(owner);
+
+        dmFactory = DealManagerFactory(
+            address(
+                new ERC1967Proxy{salt: salt}(
+                    address(new DealManagerFactory{salt: salt}()),
+                    abi.encodeWithSelector(
+                        DealManagerFactory.initialize.selector,
+                        address(bootstrapAuth),
+                        address(new DealManager())
+                    )
+                )
+            )
+        );
+    }
+
+    function test_UpgradeFactory() public {
+        // Upgrading DealManagerFactory should not impact existing deployments,
+        // i.e. existing DealManager should still be able to find and upgrade to future releases
+
+        // Deploy existing DealManagers
+
+        BorgAuth corpAuth = new BorgAuth{salt: keccak256("test_UpgradeFactory")}(companyOwner);
+        address placeHolderAddr = 0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF;
+
+        DealManager dm = DealManager(
+            DealManagerFactory(dmFactory).deployDealManager(keccak256("test_UpgradeFactory"))
+        );
+        dm.initialize(
+            address(corpAuth),
+            placeHolderAddr,
+            placeHolderAddr,
+            placeHolderAddr,
+            address(dmFactory)
+        );
+
+        // Upgrade the factory
+
+        vm.startPrank(owner);
+        dmFactory.upgradeToAndCall(address(new DealManagerFactory()), "");
+        vm.stopPrank();
+
+        // Existing DealManager should still be able to upgrade to future releases
+
+        // MetaLeX to release new DealManager v2
+        vm.startPrank(owner);
+        DealManagerFactory(dmFactory).setRefImplementation(DealManager(address(new MockDealManagerV2())));
+        vm.stopPrank();
+
+        // Corp owner decided to accept the upgrade
+        vm.startPrank(companyOwner);
+        dm.upgradeToAndCall(address(DealManagerFactory(dmFactory).refImplementation()), "");
+        vm.stopPrank();
+        assertEq(dm.DEPLOY_VERSION(), "2", "DealManager should be upgraded");
+    }
+
+    function test_RevertIf_UpgradeFactoryNonOwner() public {
+        address newFactoryImpl = address(new DealManagerFactory());
+        vm.expectRevert(abi.encodeWithSelector(BorgAuth.BorgAuth_NotAuthorized.selector, bootstrapAuth.OWNER_ROLE(), companyOwner));
+        vm.prank(companyOwner);
+        dmFactory.upgradeToAndCall(newFactoryImpl, "");
+    }
+}

--- a/test/DealManagerTest.t.sol
+++ b/test/DealManagerTest.t.sol
@@ -1,0 +1,183 @@
+/*    .o.
+     .888.
+    .8"888.
+   .8' `888.
+  .88ooo8888.
+ .8'     `888.
+o88o     o8888o
+
+
+
+ooo        ooooo               .             ooooo                  ooooooo  ooooo
+`88.       .888'             .o8             `888'                   `8888    d8'
+ 888b     d'888   .ooooo.  .o888oo  .oooo.    888          .ooooo.     Y888..8P
+ 8 Y88. .P  888  d88' `88b   888   `P  )88b   888         d88' `88b     `8888'
+ 8  `888'   888  888ooo888   888    .oP"888   888         888ooo888    .8PY888.
+ 8    Y     888  888    .o   888 . d8(  888   888       o 888    .o   d8'  `888b
+o8o        o888o `Y8bod8P'   "888" `Y888""8o o888ooooood8 `Y8bod8P' o888o  o88888o
+
+
+
+  .oooooo.                .o8                            .oooooo.
+ d8P'  `Y8b              "888                           d8P'  `Y8b
+888          oooo    ooo  888oooo.   .ooooo.  oooo d8b 888           .ooooo.  oooo d8b oo.ooooo.
+888           `88.  .8'   d88' `88b d88' `88b `888""8P 888          d88' `88b `888""8P  888' `88b
+888            `88..8'    888   888 888ooo888  888     888          888   888  888      888   888
+`88b    ooo     `888'     888   888 888    .o  888     `88b    ooo  888   888  888      888   888 .o.
+ `Y8bood8P'      .8'      `Y8bod8P' `Y8bod8P' d888b     `Y8bood8P'  `Y8bod8P' d888b     888bod8P' Y8P
+             .o..P'                                                                     888
+             `Y8P'                                                                     o888o
+_______________________________________________________________________________________________________
+
+All software, documentation and other files and information in this repository (collectively, the "Software")
+are copyright MetaLeX Labs, Inc., a Delaware corporation.
+
+All rights reserved.
+
+The Software is proprietary and shall not, in part or in whole, be used, copied, modified, merged, published,
+distributed, transmitted, sublicensed, sold, or otherwise used in any form or by any means, electronic or
+mechanical, including photocopying, recording, or by any information storage and retrieval system,
+except with the express prior written permission of the copyright holder.*/
+pragma solidity 0.8.28;
+
+import {Test, console} from "forge-std/Test.sol";
+import {UUPSUpgradeable} from "../dependencies/openzeppelin-contracts-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
+import {ERC20} from "../dependencies/openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
+import {ERC721} from "../dependencies/openzeppelin-contracts/contracts/token/ERC721/ERC721.sol";
+import {ERC721Enumerable} from "../dependencies/openzeppelin-contracts/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
+import {ERC1967Proxy} from "../dependencies/openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {CyberAgreementRegistry} from "../src/CyberAgreementRegistry.sol";
+import {DealManager, LexScroWLite} from "../src/DealManager.sol";
+import {DealManagerFactory} from "../src/DealManagerFactory.sol";
+import {BorgAuth} from "../src/libs/auth.sol";
+import {CertificateDetails, Endorsement} from "../src/storage/CyberCertPrinterStorage.sol";
+
+contract MockDealManagerV2 is UUPSUpgradeable {
+    string public constant DEPLOY_VERSION = "2";
+
+    // UUPS upgrade authorization
+    function _authorizeUpgrade(
+        address newImplementation
+    ) internal override {}
+}
+
+contract DealManagerTest is Test {
+
+    bytes32 public salt = keccak256("DealManagerTest");
+
+    uint256 public ownerPrivateKey = uint256(salt) + 0;
+    address public owner = vm.addr(ownerPrivateKey);
+
+    address public companyPayable = address(1000);
+    address public companyOwner = address(1001);
+
+    BorgAuth public bootstrapAuth;
+    DealManagerFactory public dmFactory;
+
+    function setUp() public {
+        bootstrapAuth = new BorgAuth(owner);
+        dmFactory = new DealManagerFactory{salt: salt}(address(bootstrapAuth));
+    }
+
+    function test_UpgradeNextDealManager() public {
+        assertEq(DealManagerFactory(dmFactory).refImplementation().DEPLOY_VERSION(), "1", "reference impl version should not be changed yet");
+
+        vm.startPrank(owner);
+        DealManagerFactory(dmFactory).setRefImplementation(DealManager(address(new MockDealManagerV2())));
+        vm.stopPrank();
+        assertEq(DealManagerFactory(dmFactory).refImplementation().DEPLOY_VERSION(), "2", "reference impl version should have changed");
+
+        bytes32 salt = keccak256("test_UpgradeNextDealerManager");
+        // Next deployment should emit events with version so indexer could be informed
+        vm.expectEmit(true, true, true, true);
+        emit DealManagerFactory.DealManagerDeployed(
+            DealManagerFactory(dmFactory).computeDealManagerAddress(salt),
+            "2"
+        );
+        DealManager nextRm = DealManager(
+            DealManagerFactory(dmFactory).deployDealManager(salt)
+        );
+        assertEq(nextRm.DEPLOY_VERSION(), "2", "next deployment version should have changed");
+    }
+    
+    function test_UpgradeExistingDealManager() public {
+        BorgAuth corpAuth = new BorgAuth{salt: keccak256("testUpgradeExistingDealManager")}(companyOwner);
+        address placeHolderAddr = 0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF;
+
+        // Deploy existing DealManagers
+
+        DealManager dm1 = DealManager(
+            DealManagerFactory(dmFactory).deployDealManager(keccak256("testUpgradeExistingDealManager1"))
+        );
+        dm1.initialize(
+            address(corpAuth),
+            placeHolderAddr,
+            placeHolderAddr,
+            placeHolderAddr,
+            address(dmFactory)
+        );
+
+        DealManager dm2 = DealManager(
+            DealManagerFactory(dmFactory).deployDealManager(keccak256("testUpgradeExistingDealManager2"))
+        );
+        dm2.initialize(
+            address(corpAuth),
+            placeHolderAddr,
+            placeHolderAddr,
+            placeHolderAddr,
+            address(dmFactory)
+        );
+
+        // MetaLeX to release new DealManager v2
+
+        vm.startPrank(owner);
+        DealManagerFactory(dmFactory).setRefImplementation(DealManager(address(new MockDealManagerV2())));
+        vm.stopPrank();
+
+        // Corp2 owner decided to accept the upgrade
+
+        vm.startPrank(companyOwner);
+        dm2.upgradeToAndCall(address(DealManagerFactory(dmFactory).refImplementation()), "");
+        vm.stopPrank();
+
+        assertEq(dm2.DEPLOY_VERSION(), "2", "Target DealManager should be upgraded");
+        assertEq(dm1.DEPLOY_VERSION(), "1", "Other DealManager should not be upgraded");
+    }
+
+    function test_RevertIf_UpgradeNonFactoryOwner() public {
+        // Non-MetaLeX admin should not be able to set new reference implementation
+
+        DealManager newImplementation = DealManager(address(new MockDealManagerV2()));
+        vm.expectRevert(abi.encodeWithSelector(BorgAuth.BorgAuth_NotAuthorized.selector, bootstrapAuth.OWNER_ROLE(), companyOwner));
+        vm.prank(companyOwner);
+        DealManagerFactory(dmFactory).setRefImplementation(newImplementation);
+    }
+
+    function test_RevertIf_UpgradeExistingDealManagerNotRefImplementation() public {
+        BorgAuth corpAuth = new BorgAuth{salt: keccak256("testUpgradeExistingDealManager")}(companyOwner);
+        address placeHolderAddr = 0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF;
+
+        // Deploy existing DealManagers
+
+        DealManager rm = DealManager(
+            DealManagerFactory(dmFactory).deployDealManager(keccak256("testUpgradeExistingDealManager2"))
+        );
+        rm.initialize(
+            address(corpAuth),
+            placeHolderAddr,
+            placeHolderAddr,
+            placeHolderAddr,
+            address(dmFactory)
+        );
+
+        // Corp owner can't upgrade to v2 without MetaLeX releasing it first
+
+        vm.startPrank(companyOwner);
+        address nonOfficialDealManager = address(new MockDealManagerV2());
+        vm.expectRevert(
+            abi.encodeWithSelector(DealManager.NotRefImplementation.selector)
+        );
+        rm.upgradeToAndCall(nonOfficialDealManager, "");
+        vm.stopPrank();
+    }
+}

--- a/test/DealManagerTest.t.sol
+++ b/test/DealManagerTest.t.sol
@@ -235,7 +235,18 @@ contract DealManagerTest is Test {
         defaultCertPrinters = new address[](1);
         defaultCertPrinters[0] = address(new CyberCertPrinterMock{salt: salt}());
 
-        dmFactory = new DealManagerFactory{salt: salt}(address(bootstrapAuth));
+        dmFactory = DealManagerFactory(
+            address(
+                new ERC1967Proxy{salt: salt}(
+                    address(new DealManagerFactory{salt: salt}()),
+                    abi.encodeWithSelector(
+                        DealManagerFactory.initialize.selector,
+                        address(bootstrapAuth),
+                        address(new DealManager())
+                    )
+                )
+            )
+        );
         dm = DealManager(
             address(
                 new ERC1967Proxy{salt: salt}(
@@ -864,10 +875,10 @@ contract DealManagerTest is Test {
 
         // Deploy existing DealManagers
 
-        DealManager rm = DealManager(
+        DealManager dm = DealManager(
             DealManagerFactory(dmFactory).deployDealManager(keccak256("testUpgradeExistingDealManager2"))
         );
-        rm.initialize(
+        dm.initialize(
             address(corpAuth),
             placeHolderAddr,
             placeHolderAddr,
@@ -882,7 +893,7 @@ contract DealManagerTest is Test {
         vm.expectRevert(
             abi.encodeWithSelector(DealManager.NotRefImplementation.selector)
         );
-        rm.upgradeToAndCall(nonOfficialDealManager, "");
+        dm.upgradeToAndCall(nonOfficialDealManager, "");
         vm.stopPrank();
     }
 }

--- a/test/DealManagerTest.t.sol
+++ b/test/DealManagerTest.t.sol
@@ -796,12 +796,12 @@ contract DealManagerTest is Test {
     }
 
     function test_UpgradeNextDealManager() public {
-        assertEq(DealManagerFactory(dmFactory).refImplementation().DEPLOY_VERSION(), "1", "reference impl version should not be changed yet");
+        assertEq(DealManager(DealManagerFactory(dmFactory).getRefImplementation()).DEPLOY_VERSION(), "1", "reference impl version should not be changed yet");
 
         vm.startPrank(owner);
-        DealManagerFactory(dmFactory).setRefImplementation(DealManager(address(new MockDealManagerV2())));
+        DealManagerFactory(dmFactory).setRefImplementation(address(new MockDealManagerV2()));
         vm.stopPrank();
-        assertEq(DealManagerFactory(dmFactory).refImplementation().DEPLOY_VERSION(), "2", "reference impl version should have changed");
+        assertEq(DealManager(DealManagerFactory(dmFactory).getRefImplementation()).DEPLOY_VERSION(), "2", "reference impl version should have changed");
 
         bytes32 salt = keccak256("test_UpgradeNextDealerManager");
         // Next deployment should emit events with version so indexer could be informed
@@ -847,13 +847,13 @@ contract DealManagerTest is Test {
         // MetaLeX to release new DealManager v2
 
         vm.startPrank(owner);
-        DealManagerFactory(dmFactory).setRefImplementation(DealManager(address(new MockDealManagerV2())));
+        DealManagerFactory(dmFactory).setRefImplementation(address(new MockDealManagerV2()));
         vm.stopPrank();
 
         // Corp2 owner decided to accept the upgrade
 
         vm.startPrank(companyOwner);
-        dm2.upgradeToAndCall(address(DealManagerFactory(dmFactory).refImplementation()), "");
+        dm2.upgradeToAndCall(DealManagerFactory(dmFactory).getRefImplementation(), "");
         vm.stopPrank();
 
         assertEq(dm2.DEPLOY_VERSION(), "2", "Target DealManager should be upgraded");
@@ -863,7 +863,7 @@ contract DealManagerTest is Test {
     function test_RevertIf_UpgradeNonFactoryOwner() public {
         // Non-MetaLeX admin should not be able to set new reference implementation
 
-        DealManager newImplementation = DealManager(address(new MockDealManagerV2()));
+        address newImplementation = address(new MockDealManagerV2());
         vm.expectRevert(abi.encodeWithSelector(BorgAuth.BorgAuth_NotAuthorized.selector, bootstrapAuth.OWNER_ROLE(), companyOwner));
         vm.prank(companyOwner);
         DealManagerFactory(dmFactory).setRefImplementation(newImplementation);

--- a/test/MetaDAOTest.t.sol
+++ b/test/MetaDAOTest.t.sol
@@ -6,8 +6,8 @@ import {MetaDAOFactory} from "../src/MetaDAOFactory.sol";
 import {CyberAgreementRegistry} from "../src/CyberAgreementRegistry.sol";
 import {IssuanceManagerFactory} from "../src/IssuanceManagerFactory.sol";
 import {CyberCorpSingleFactory} from "../src/CyberCorpSingleFactory.sol";
-import {DealManagerFactory} from "../src/DealManagerFactory.sol";
-import {RoundManagerFactory} from "../src/RoundManagerFactory.sol";
+import {DealManagerFactory, DealManager} from "../src/DealManagerFactory.sol";
+import {RoundManagerFactory, RoundManager} from "../src/RoundManagerFactory.sol";
 import {CertificateUriBuilder} from "../src/CertificateUriBuilder.sol";
 import {CyberCertPrinter} from "../src/CyberCertPrinter.sol";
 import {CyberScrip} from "../src/CyberScrip.sol";
@@ -73,8 +73,26 @@ contract MetaDAOTest is Test {
         // Factories
         address issuanceManagerFactoryAddr = address(new IssuanceManagerFactory{salt: salt}(address(bootstrapAuth)));
         address cyberCorpSingleFactory = address(new CyberCorpSingleFactory{salt: salt}(address(bootstrapAuth)));
-        address dealManagerFactory = address(new DealManagerFactory{salt: salt}(address(bootstrapAuth)));
-        address roundManagerFactory = address(new RoundManagerFactory{salt: salt}(address(bootstrapAuth)));
+        address dealManagerFactory = address(
+            new ERC1967Proxy{salt: salt}(
+                address(new DealManagerFactory{salt: salt}()),
+                abi.encodeWithSelector(
+                    DealManagerFactory.initialize.selector,
+                    address(bootstrapAuth),
+                    address(new DealManager())
+                )
+            )
+        );
+        address roundManagerFactory = address(
+            new ERC1967Proxy{salt: salt}(
+                address(new RoundManagerFactory{salt: salt}()),
+                abi.encodeWithSelector(
+                    RoundManagerFactory.initialize.selector,
+                    address(bootstrapAuth),
+                    address(new RoundManager())
+                )
+            )
+        );
 
         // Implementations
         address certPrinterImpl = address(new CyberCertPrinter{salt: salt}());

--- a/test/RoundManagerFactoryTest.t.sol
+++ b/test/RoundManagerFactoryTest.t.sol
@@ -1,0 +1,136 @@
+/*    .o.
+     .888.
+    .8"888.
+   .8' `888.
+  .88ooo8888.
+ .8'     `888.
+o88o     o8888o
+
+
+
+ooo        ooooo               .             ooooo                  ooooooo  ooooo
+`88.       .888'             .o8             `888'                   `8888    d8'
+ 888b     d'888   .ooooo.  .o888oo  .oooo.    888          .ooooo.     Y888..8P
+ 8 Y88. .P  888  d88' `88b   888   `P  )88b   888         d88' `88b     `8888'
+ 8  `888'   888  888ooo888   888    .oP"888   888         888ooo888    .8PY888.
+ 8    Y     888  888    .o   888 . d8(  888   888       o 888    .o   d8'  `888b
+o8o        o888o `Y8bod8P'   "888" `Y888""8o o888ooooood8 `Y8bod8P' o888o  o88888o
+
+
+
+  .oooooo.                .o8                            .oooooo.
+ d8P'  `Y8b              "888                           d8P'  `Y8b
+888          oooo    ooo  888oooo.   .ooooo.  oooo d8b 888           .ooooo.  oooo d8b oo.ooooo.
+888           `88.  .8'   d88' `88b d88' `88b `888""8P 888          d88' `88b `888""8P  888' `88b
+888            `88..8'    888   888 888ooo888  888     888          888   888  888      888   888
+`88b    ooo     `888'     888   888 888    .o  888     `88b    ooo  888   888  888      888   888 .o.
+ `Y8bood8P'      .8'      `Y8bod8P' `Y8bod8P' d888b     `Y8bood8P'  `Y8bod8P' d888b     888bod8P' Y8P
+             .o..P'                                                                     888
+             `Y8P'                                                                     o888o
+_______________________________________________________________________________________________________
+
+All software, documentation and other files and information in this repository (collectively, the "Software")
+are copyright MetaLeX Labs, Inc., a Delaware corporation.
+
+All rights reserved.
+
+The Software is proprietary and shall not, in part or in whole, be used, copied, modified, merged, published,
+distributed, transmitted, sublicensed, sold, or otherwise used in any form or by any means, electronic or
+mechanical, including photocopying, recording, or by any information storage and retrieval system,
+except with the express prior written permission of the copyright holder.*/
+pragma solidity 0.8.28;
+
+import {Test, console} from "forge-std/Test.sol";
+import {ERC1967Proxy} from "openzeppelin-contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {UUPSUpgradeable} from "openzeppelin-contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {RoundManager} from "../src/RoundManager.sol";
+import {RoundManagerFactory} from "../src/RoundManagerFactory.sol";
+import {BorgAuth} from "../src/libs/auth.sol";
+
+contract MockRoundManagerV2 is UUPSUpgradeable {
+    string public constant DEPLOY_VERSION = "2";
+
+    // UUPS upgrade authorization
+    function _authorizeUpgrade(
+        address newImplementation
+    ) internal override {}
+}
+
+contract RoundManagerFactoryTest is Test {
+
+    bytes32 public salt = keccak256("RoundManagerFactoryTest");
+
+    uint256 public ownerPrivateKey = uint256(salt) + 0;
+    address public owner = vm.addr(ownerPrivateKey);
+
+    address public companyPayable = address(1000);
+    address public companyOwner = address(1001);
+
+    BorgAuth public bootstrapAuth;
+
+    RoundManagerFactory public rmFactory;
+
+    function setUp() public {
+        bootstrapAuth = new BorgAuth(owner);
+
+        rmFactory = RoundManagerFactory(
+            address(
+                new ERC1967Proxy{salt: salt}(
+                    address(new RoundManagerFactory{salt: salt}()),
+                    abi.encodeWithSelector(
+                        RoundManagerFactory.initialize.selector,
+                        address(bootstrapAuth),
+                        address(new RoundManager())
+                    )
+                )
+            )
+        );
+    }
+
+    function test_UpgradeFactory() public {
+        // Upgrading RoundManagerFactory should not impact existing deployments,
+        // i.e. existing RoundManager should still be able to find and upgrade to future releases
+
+        // Deploy existing RoundManagers
+
+        BorgAuth corpAuth = new BorgAuth{salt: keccak256("test_UpgradeFactory")}(companyOwner);
+        address placeHolderAddr = 0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF;
+
+        RoundManager rm = RoundManager(
+            RoundManagerFactory(rmFactory).deployRoundManager(keccak256("test_UpgradeFactory"))
+        );
+        rm.initialize(
+            address(corpAuth),
+            placeHolderAddr,
+            placeHolderAddr,
+            placeHolderAddr,
+            address(rmFactory)
+        );
+
+        // Upgrade the factory
+
+        vm.startPrank(owner);
+        rmFactory.upgradeToAndCall(address(new RoundManagerFactory()), "");
+        vm.stopPrank();
+
+        // Existing RoundManager should still be able to upgrade to future releases
+
+        // MetaLeX to release new RoundManager v2
+        vm.startPrank(owner);
+        RoundManagerFactory(rmFactory).setRefImplementation(RoundManager(address(new MockRoundManagerV2())));
+        vm.stopPrank();
+
+        // Corp owner decided to accept the upgrade
+        vm.startPrank(companyOwner);
+        rm.upgradeToAndCall(address(RoundManagerFactory(rmFactory).refImplementation()), "");
+        vm.stopPrank();
+        assertEq(rm.DEPLOY_VERSION(), "2", "RoundManager should be upgraded");
+    }
+
+    function test_RevertIf_UpgradeFactoryNonOwner() public {
+        address newFactoryImpl = address(new RoundManagerFactory());
+        vm.expectRevert(abi.encodeWithSelector(BorgAuth.BorgAuth_NotAuthorized.selector, bootstrapAuth.OWNER_ROLE(), companyOwner));
+        vm.prank(companyOwner);
+        rmFactory.upgradeToAndCall(newFactoryImpl, "");
+    }
+}

--- a/test/RoundManagerFactoryTest.t.sol
+++ b/test/RoundManagerFactoryTest.t.sol
@@ -117,12 +117,12 @@ contract RoundManagerFactoryTest is Test {
 
         // MetaLeX to release new RoundManager v2
         vm.startPrank(owner);
-        RoundManagerFactory(rmFactory).setRefImplementation(RoundManager(address(new MockRoundManagerV2())));
+        RoundManagerFactory(rmFactory).setRefImplementation(address(new MockRoundManagerV2()));
         vm.stopPrank();
 
         // Corp owner decided to accept the upgrade
         vm.startPrank(companyOwner);
-        rm.upgradeToAndCall(address(RoundManagerFactory(rmFactory).refImplementation()), "");
+        rm.upgradeToAndCall(RoundManagerFactory(rmFactory).getRefImplementation(), "");
         vm.stopPrank();
         assertEq(rm.DEPLOY_VERSION(), "2", "RoundManager should be upgraded");
     }

--- a/test/RoundManagerTest.t.sol
+++ b/test/RoundManagerTest.t.sol
@@ -1607,12 +1607,12 @@ contract RoundManagerTest is Test {
     }
 
     function test_UpgradeNextRoundManager() public {
-        assertEq(RoundManagerFactory(rmFactory).refImplementation().DEPLOY_VERSION(), "1", "reference impl version should not be changed yet");
+        assertEq(RoundManager(RoundManagerFactory(rmFactory).getRefImplementation()).DEPLOY_VERSION(), "1", "reference impl version should not be changed yet");
 
         vm.startPrank(owner);
-        RoundManagerFactory(rmFactory).setRefImplementation(RoundManager(address(new MockRoundManagerV2())));
+        RoundManagerFactory(rmFactory).setRefImplementation(address(new MockRoundManagerV2()));
         vm.stopPrank();
-        assertEq(RoundManagerFactory(rmFactory).refImplementation().DEPLOY_VERSION(), "2", "reference impl version should have changed");
+        assertEq(RoundManager(RoundManagerFactory(rmFactory).getRefImplementation()).DEPLOY_VERSION(), "2", "reference impl version should have changed");
 
         bytes32 salt = keccak256("test_UpgradeNextRounderManager");
         // Next deployment should emit events with version so indexer could be informed
@@ -1658,13 +1658,13 @@ contract RoundManagerTest is Test {
         // MetaLeX to release new RoundManager v2
 
         vm.startPrank(owner);
-        RoundManagerFactory(rmFactory).setRefImplementation(RoundManager(address(new MockRoundManagerV2())));
+        RoundManagerFactory(rmFactory).setRefImplementation(address(new MockRoundManagerV2()));
         vm.stopPrank();
 
         // Corp2 owner decided to accept the upgrade
 
         vm.startPrank(corpOwner);
-        rm2.upgradeToAndCall(address(RoundManagerFactory(rmFactory).refImplementation()), "");
+        rm2.upgradeToAndCall(address(RoundManagerFactory(rmFactory).getRefImplementation()), "");
         vm.stopPrank();
 
         assertEq(rm2.DEPLOY_VERSION(), "2", "Target RoundManager should be upgraded");
@@ -1674,7 +1674,7 @@ contract RoundManagerTest is Test {
     function test_RevertIf_UpgradeNonFactoryOwner() public {
         // Non-MetaLeX admin should not be able to set new reference implementation
 
-        RoundManager newImplementation = RoundManager(address(new MockRoundManagerV2()));
+        address newImplementation = address(new MockRoundManagerV2());
         vm.expectRevert(abi.encodeWithSelector(BorgAuth.BorgAuth_NotAuthorized.selector, BorgAuth(auth).OWNER_ROLE(), corpOwner));
         vm.prank(corpOwner);
         RoundManagerFactory(rmFactory).setRefImplementation(newImplementation);
@@ -1835,7 +1835,7 @@ contract RoundManagerFCFSTest is Test {
                 )
             )
         ));
-        rmFactory.setRefImplementation(new RoundManager());
+        rmFactory.setRefImplementation(address(new RoundManager()));
 
         IUUPS(address(corpFactory)).upgradeToAndCall(address(new CyberCorpFactory()), "");
 
@@ -1869,7 +1869,7 @@ contract RoundManagerFCFSTest is Test {
                 )
             )
         ));
-        rmFactory.setRefImplementation(new RoundManager());
+        rmFactory.setRefImplementation(address(new RoundManager()));
         IUUPS(address(corpFactory)).upgradeToAndCall(address(new CyberCorpFactory()), "");
         corpFactory.setRoundManagerFactory(address(rmFactory));
         CyberCorpSingleFactory(cyberCorpSingleFactory).upgradeImplementation(address(new CyberCorp()));

--- a/test/RoundManagerTest.t.sol
+++ b/test/RoundManagerTest.t.sol
@@ -1378,6 +1378,15 @@ contract RoundManagerTest is Test {
         assertEq(rm1.DEPLOY_VERSION(), "1", "Other RoundManager should not be upgraded");
     }
 
+    function test_RevertIf_UpgradeNonFactoryOwner() public {
+        // Non-MetaLeX admin should not be able to set new reference implementation
+
+        RoundManager newImplementation = RoundManager(address(new MockRoundManagerV2()));
+        vm.expectRevert(abi.encodeWithSelector(BorgAuth.BorgAuth_NotAuthorized.selector, BorgAuth(auth).OWNER_ROLE(), corpOwner));
+        vm.prank(corpOwner);
+        RoundManagerFactory(rmFactory).setRefImplementation(newImplementation);
+    }
+
     function test_RevertIf_UpgradeExistingRoundManagerNotRefImplementation() public {
         BorgAuth corpAuth = new BorgAuth{salt: keccak256("testUpgradeExistingRoundManager")}(corpOwner);
         address placeHolderAddr = 0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF;

--- a/test/RoundManagerTest.t.sol
+++ b/test/RoundManagerTest.t.sol
@@ -12,9 +12,9 @@ import "../dependencies/openzeppelin-contracts-upgradeable/contracts/proxy/utils
 import {CyberCorpFactory} from "../src/CyberCorpFactory.sol";
 import {IssuanceManagerFactory} from "../src/IssuanceManagerFactory.sol";
 import {CyberCorpSingleFactory} from "../src/CyberCorpSingleFactory.sol";
-import {DealManagerFactory} from "../src/DealManagerFactory.sol";
+import {DealManagerFactory, DealManager} from "../src/DealManagerFactory.sol";
 import {CyberAgreementRegistry} from "../src/CyberAgreementRegistry.sol";
-import {RoundManagerFactory} from "../src/RoundManagerFactory.sol";
+import {RoundManagerFactory, RoundManager} from "../src/RoundManagerFactory.sol";
 import {CertificateUriBuilder} from "../src/CertificateUriBuilder.sol";
 import {CyberScrip} from "../src/CyberScrip.sol";
 import {CyberCorp} from "../src/CyberCorp.sol";
@@ -256,15 +256,28 @@ contract RoundManagerTest is Test {
             new CyberCorpSingleFactory{salt: salt}(address(bootstrapAuth))
         );
         address dealManagerFactory = address(
-            new DealManagerFactory{salt: salt}(address(bootstrapAuth))
+            new ERC1967Proxy{salt: salt}(
+                address(new DealManagerFactory{salt: salt}()),
+                abi.encodeWithSelector(
+                    DealManagerFactory.initialize.selector,
+                    address(bootstrapAuth),
+                    address(new DealManager())
+                )
+            )
         );
 
         address certPrinterImpl = address(new CyberCertPrinter{salt: salt}());
         address cyberScripImpl = address(new CyberScrip{salt: salt}());
 
-                // RoundManager via factory and initialize
         rmFactory = address(
-            new RoundManagerFactory{salt: salt}(address(bootstrapAuth))
+            new ERC1967Proxy{salt: salt}(
+                address(new RoundManagerFactory{salt: salt}()),
+                abi.encodeWithSelector(
+                    RoundManagerFactory.initialize.selector,
+                    address(bootstrapAuth),
+                    address(new RoundManager())
+                )
+            )
         );
         /*address _auth,
         address _registryAddress,
@@ -1755,11 +1768,25 @@ contract RoundManagerFCFSTest is Test {
             new CyberCorpSingleFactory{salt: salt}(address(bootstrapAuth))
         );
         dealManagerFactory = address(
-            new DealManagerFactory{salt: salt}(address(bootstrapAuth))
+            new ERC1967Proxy{salt: salt}(
+                address(new DealManagerFactory{salt: salt}()),
+                abi.encodeWithSelector(
+                    DealManagerFactory.initialize.selector,
+                    address(bootstrapAuth),
+                    address(new DealManager())
+                )
+            )
         );
 
         address rmFactory = address(
-            new RoundManagerFactory{salt: salt}(address(bootstrapAuth))
+            new ERC1967Proxy{salt: salt}(
+                address(new RoundManagerFactory{salt: salt}()),
+                abi.encodeWithSelector(
+                    RoundManagerFactory.initialize.selector,
+                    address(bootstrapAuth),
+                    address(new RoundManager())
+                )
+            )
         );
 
         address certPrinterImpl = address(new CyberCertPrinter{salt: salt}());
@@ -1798,7 +1825,16 @@ contract RoundManagerFCFSTest is Test {
         ) = _deployRegistryAndFactories(me);
 
         address auth = address(corpFactory.AUTH());
-        RoundManagerFactory rmFactory = new RoundManagerFactory(auth);
+        RoundManagerFactory rmFactory = RoundManagerFactory(address(
+            new ERC1967Proxy(
+                address(new RoundManagerFactory()),
+                abi.encodeWithSelector(
+                    RoundManagerFactory.initialize.selector,
+                    address(auth),
+                    address(new RoundManager())
+                )
+            )
+        ));
         rmFactory.setRefImplementation(new RoundManager());
 
         IUUPS(address(corpFactory)).upgradeToAndCall(address(new CyberCorpFactory()), "");
@@ -1823,7 +1859,16 @@ contract RoundManagerFCFSTest is Test {
         _createTemplate(registry);
 
         // Apply upgrades
-        RoundManagerFactory rmFactory = new RoundManagerFactory(address(corpFactory.AUTH()));
+        RoundManagerFactory rmFactory = RoundManagerFactory(address(
+            new ERC1967Proxy(
+                address(new RoundManagerFactory()),
+                abi.encodeWithSelector(
+                    RoundManagerFactory.initialize.selector,
+                    address(corpFactory.AUTH()),
+                    address(new RoundManager())
+                )
+            )
+        ));
         rmFactory.setRefImplementation(new RoundManager());
         IUUPS(address(corpFactory)).upgradeToAndCall(address(new CyberCorpFactory()), "");
         corpFactory.setRoundManagerFactory(address(rmFactory));
@@ -2062,7 +2107,16 @@ contract RoundManagerFCFSTest is Test {
         address issuance
     ) internal returns (RoundManager rm) {
         // Deploy RoundManager via factory (BeaconProxy), then initialize
-        RoundManagerFactory rmFactory = new RoundManagerFactory(auth);
+        RoundManagerFactory rmFactory = RoundManagerFactory(address(
+            new ERC1967Proxy(
+                address(new RoundManagerFactory()),
+                abi.encodeWithSelector(
+                    RoundManagerFactory.initialize.selector,
+                    address(auth),
+                    address(new RoundManager())
+                )
+            )
+        ));
         address proxy = rmFactory.deployRoundManager(keccak256("rm-fcfs"));
         rm = RoundManager(payable(proxy));
         rm.initialize(auth, corp, registry, issuance, address(rmFactory));

--- a/test/RoundManagerTest.t.sol
+++ b/test/RoundManagerTest.t.sol
@@ -8,6 +8,7 @@ import "../src/CyberCertPrinter.sol";
 import "../src/storage/RoundManagerStorage.sol";
 import "../src/CyberCorpConstants.sol";
 import "../dependencies/openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
+import "../dependencies/openzeppelin-contracts-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
 import {CyberCorpFactory} from "../src/CyberCorpFactory.sol";
 import {IssuanceManagerFactory} from "../src/IssuanceManagerFactory.sol";
 import {CyberCorpSingleFactory} from "../src/CyberCorpSingleFactory.sol";
@@ -39,6 +40,15 @@ contract MockPaymentToken is ERC20 {
     function decimals() public pure override returns (uint8) {
         return 6;
     }
+}
+
+contract MockRoundManagerV2 is UUPSUpgradeable {
+    string public constant DEPLOY_VERSION = "2";
+
+    // UUPS upgrade authorization
+    function _authorizeUpgrade(
+        address newImplementation
+    ) internal override {}
 }
 
 // Mock condition that always fails
@@ -1225,6 +1235,62 @@ contract RoundManagerTest is Test {
         uint256 balAfterAllocate = paymentToken.balanceOf(investor);
         assertEq(balAfterAllocate - balAfterSubmit, 4_000 * 10 ** 6);
     }
+
+    function test_UpgradeNextRoundManager() public {
+        assertEq(RoundManagerFactory(rmFactory).refImplementation().DEPLOY_VERSION(), "1", "reference impl version should not be changed yet");
+
+        vm.startPrank(owner);
+        RoundManagerFactory(rmFactory).setRefImplementation(RoundManager(address(new MockRoundManagerV2())));
+        vm.stopPrank();
+        assertEq(RoundManagerFactory(rmFactory).refImplementation().DEPLOY_VERSION(), "2", "reference impl version should have changed");
+
+        bytes32 salt = keccak256("test_UpgradeNextRounderManager");
+        // Next deployment should emit events with version so indexer could be informed
+        vm.expectEmit(true, true, true, true);
+        emit RoundManagerFactory.RoundManagerDeployed(
+            RoundManagerFactory(rmFactory).computeRoundManagerAddress(salt),
+            "2"
+        );
+        RoundManager nextRm = RoundManager(
+            RoundManagerFactory(rmFactory).deployRoundManager(salt)
+        );
+        assertEq(nextRm.DEPLOY_VERSION(), "2", "next deployment version should have changed");
+    }
+
+    function testUpgradeExistingRoundManager() public {
+        BorgAuth testAuth = new BorgAuth{salt: keccak256("testUpgradeExistingRoundManager")}(owner);
+        address placeHolderAddr = 0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF;
+
+        RoundManager rm1 = RoundManager(
+            RoundManagerFactory(rmFactory).deployRoundManager(keccak256("testUpgradeExistingRoundManager1"))
+        );
+        rm1.initialize(
+            address(testAuth),
+            placeHolderAddr,
+            placeHolderAddr,
+            placeHolderAddr,
+            placeHolderAddr
+        );
+
+        RoundManager rm2 = RoundManager(
+            RoundManagerFactory(rmFactory).deployRoundManager(keccak256("testUpgradeExistingRoundManager2"))
+        );
+        rm2.initialize(
+            address(testAuth),
+            placeHolderAddr,
+            placeHolderAddr,
+            placeHolderAddr,
+            placeHolderAddr
+        );
+
+        vm.startPrank(owner);
+        // TODO WIP: Should have governance approval on upgrades
+        rm2.upgradeToAndCall(address(new MockRoundManagerV2()), "");
+        vm.stopPrank();
+
+        assertEq(rm2.DEPLOY_VERSION(), "2", "Target RoundManager should be upgraded");
+        assertEq(rm1.DEPLOY_VERSION(), "1", "Other RoundManager should not be upgraded");
+    }
 }
 
 // Separate FCFS tests in their own contract to avoid the original setUp()
@@ -1322,7 +1388,7 @@ contract RoundManagerFCFSTest is Test {
 
         address auth = address(corpFactory.AUTH());
         RoundManagerFactory rmFactory = new RoundManagerFactory(auth);
-        rmFactory.upgradeImplementation(address(new RoundManager()));
+        rmFactory.setRefImplementation(new RoundManager());
 
         IUUPS(address(corpFactory)).upgradeToAndCall(address(new CyberCorpFactory()), "");
 
@@ -1347,7 +1413,7 @@ contract RoundManagerFCFSTest is Test {
 
         // Apply upgrades
         RoundManagerFactory rmFactory = new RoundManagerFactory(address(corpFactory.AUTH()));
-        rmFactory.upgradeImplementation(address(new RoundManager()));
+        rmFactory.setRefImplementation(new RoundManager());
         IUUPS(address(corpFactory)).upgradeToAndCall(address(new CyberCorpFactory()), "");
         corpFactory.setRoundManagerFactory(address(rmFactory));
         CyberCorpSingleFactory(cyberCorpSingleFactory).upgradeImplementation(address(new CyberCorp()));

--- a/test/RoundManagerTest.t.sol
+++ b/test/RoundManagerTest.t.sol
@@ -75,6 +75,9 @@ contract AlwaysTrueCondition is ICondition {
 }
 
 contract RoundManagerTest is Test {
+    address public constant LEXCHEX_MINTER_ADDRESS = 0x0dD1a2a89eC172ac322B6a7a6c869180CBD0F960;
+    address public constant UPGRADE_OWNER = 0x341Da9fb8F9bD9a775f6bD641091b24Dd9aA459B;
+
    // RoundManager public roundManager;
     IssuanceManager public issuanceManager;
     CyberCertPrinter public certPrinter;
@@ -282,10 +285,8 @@ contract RoundManagerTest is Test {
         );
         // Perform an upgrade of the existing UUPS proxy at the known address
         address _lexchexMinterUpgraded = address(new LeXcheXMinter());  
-        uint256 upgradePrivKey = vm.envUint("PRIVATE_KEY_MAIN");
-        address upgradeOwner = vm.addr(upgradePrivKey);
-        vm.prank(upgradeOwner);
-        IUUPS(0x0dD1a2a89eC172ac322B6a7a6c869180CBD0F960).upgradeToAndCall(_lexchexMinterUpgraded, "");    
+        vm.prank(UPGRADE_OWNER);
+        IUUPS(LEXCHEX_MINTER_ADDRESS).upgradeToAndCall(_lexchexMinterUpgraded, "");
         /*address _auth,
         address _registryAddress,
         address _cyberCertPrinterImplementation,
@@ -315,12 +316,10 @@ contract RoundManagerTest is Test {
             )
         );
 
-        // Ensure CyberCorpFactory is OWNER of lexchexAuth using upgradeOwner from .env
+        // Ensure CyberCorpFactory is OWNER of lexchexAuth
         {
-            uint256 upgradePrivKey = vm.envUint("PRIVATE_KEY_MAIN");
-            address upgradeOwner = vm.addr(upgradePrivKey);
             address lxAuth = corpFactory.lexchexAuth();
-            vm.startPrank(upgradeOwner);
+            vm.startPrank(UPGRADE_OWNER);
             BorgAuth(lxAuth).updateRole(address(corpFactory), BorgAuth(lxAuth).OWNER_ROLE());
             vm.stopPrank();
         }
@@ -1788,17 +1787,17 @@ contract RoundManagerTest is Test {
 contract RoundManagerFCFSTest is Test {
     using RoundManagerStorage for RoundManagerStorage.RoundManagerData;
 
-    address public constant KNOWN_LEXCHEX_CONDITION_ADDRESS = 0x4a08547d57C8d01e59bA8F884aB90CEe0d6d5b42;
+    address public constant LEXCHEX_CONDITION_ADDRESS = 0x4a08547d57C8d01e59bA8F884aB90CEe0d6d5b42;
+    address public constant LEXCHEX_MINTER_ADDRESS = 0x0dD1a2a89eC172ac322B6a7a6c869180CBD0F960;
+    address public constant UPGRADE_OWNER = 0x341Da9fb8F9bD9a775f6bD641091b24Dd9aA459B;
 
     function setUp() public {
         // Mock LexChexCondition to always pass
         address alwaysTrueCondition = address(new AlwaysTrueCondition());
-        vm.etch(KNOWN_LEXCHEX_CONDITION_ADDRESS, alwaysTrueCondition.code);
+        vm.etch(LEXCHEX_CONDITION_ADDRESS, alwaysTrueCondition.code);
         address _lexchexMinterUpgraded = address(new LeXcheXMinter());  
-        uint256 upgradePrivKey = vm.envUint("PRIVATE_KEY_MAIN");
-        address upgradeOwner = vm.addr(upgradePrivKey);
-        vm.prank(upgradeOwner);
-        IUUPS(0x0dD1a2a89eC172ac322B6a7a6c869180CBD0F960).upgradeToAndCall(_lexchexMinterUpgraded, "");
+        vm.prank(UPGRADE_OWNER);
+        IUUPS(LEXCHEX_MINTER_ADDRESS).upgradeToAndCall(_lexchexMinterUpgraded, "");
     }
 
     // Infra helpers copied from above
@@ -1892,12 +1891,10 @@ contract RoundManagerFCFSTest is Test {
             )
         );
 
-                // Ensure CyberCorpFactory is OWNER of lexchexAuth using upgradeOwner from .env
+        // Ensure CyberCorpFactory is OWNER of lexchexAuth
         {
-            uint256 upgradePrivKey = vm.envUint("PRIVATE_KEY_MAIN");
-            address upgradeOwner = vm.addr(upgradePrivKey);
             address lxAuth = corpFactory.lexchexAuth();
-            vm.startPrank(upgradeOwner);
+            vm.startPrank(UPGRADE_OWNER);
             BorgAuth(lxAuth).updateRole(address(corpFactory), BorgAuth(lxAuth).OWNER_ROLE());
             vm.stopPrank();
         }
@@ -2213,9 +2210,7 @@ contract RoundManagerFCFSTest is Test {
         // Allow RoundManager to call IssuanceManager.onlyOwner
         BorgAuth(auth).updateRole(address(rm), 99);
         //add to lexchexAuth
-        uint256 upgradePrivKey = vm.envUint("PRIVATE_KEY_MAIN");
-        address upgradeOwner = vm.addr(upgradePrivKey);
-        vm.startPrank(upgradeOwner);
+        vm.startPrank(UPGRADE_OWNER);
         BorgAuth(0xeAdeaD5C4A6747D4959489742c143bCDb95a01c2).updateRole(address(rm), BorgAuth(0xeAdeaD5C4A6747D4959489742c143bCDb95a01c2).OWNER_ROLE());
         vm.stopPrank();
     }
@@ -3034,7 +3029,7 @@ contract RoundManagerFCFSTest is Test {
 
         // Mock LexChexCondition to always fail
         address alwaysFalseCondition = address(new AlwaysFalseCondition());
-        vm.etch(KNOWN_LEXCHEX_CONDITION_ADDRESS, alwaysFalseCondition.code);
+        vm.etch(LEXCHEX_CONDITION_ADDRESS, alwaysFalseCondition.code);
 
         vm.expectRevert(RoundManager.AgreementConditionsNotMet.selector);
         rm.submitEOI(

--- a/test/RoundManagerTest.t.sol
+++ b/test/RoundManagerTest.t.sol
@@ -72,6 +72,8 @@ contract RoundManagerTest is Test {
     uint256 private ownerPrivKey;
     address public investor;
     uint256 private investorPrivKey;
+    address public corpOwner;
+    uint256 private corpOwnerPrivKey;
 
     // Infra
     CyberAgreementRegistry private registry;
@@ -203,6 +205,8 @@ contract RoundManagerTest is Test {
         owner = vm.addr(ownerPrivKey);
         investorPrivKey = 0xA11CE;
         investor = vm.addr(investorPrivKey);
+        corpOwnerPrivKey = 0xB0B;
+        corpOwner = vm.addr(corpOwnerPrivKey);
 
         // Deploy infra (auth, registry, factories)
         bytes32 salt = keccak256(abi.encodePacked("roundmanager-infra", owner));
@@ -1257,39 +1261,76 @@ contract RoundManagerTest is Test {
         assertEq(nextRm.DEPLOY_VERSION(), "2", "next deployment version should have changed");
     }
 
-    function testUpgradeExistingRoundManager() public {
-        BorgAuth testAuth = new BorgAuth{salt: keccak256("testUpgradeExistingRoundManager")}(owner);
+    function test_UpgradeExistingRoundManager() public {
+        BorgAuth corpAuth = new BorgAuth{salt: keccak256("testUpgradeExistingRoundManager")}(corpOwner);
         address placeHolderAddr = 0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF;
+
+        // Deploy existing RoundManagers
 
         RoundManager rm1 = RoundManager(
             RoundManagerFactory(rmFactory).deployRoundManager(keccak256("testUpgradeExistingRoundManager1"))
         );
         rm1.initialize(
-            address(testAuth),
+            address(corpAuth),
             placeHolderAddr,
             placeHolderAddr,
             placeHolderAddr,
-            placeHolderAddr
+            rmFactory
         );
 
         RoundManager rm2 = RoundManager(
             RoundManagerFactory(rmFactory).deployRoundManager(keccak256("testUpgradeExistingRoundManager2"))
         );
         rm2.initialize(
-            address(testAuth),
+            address(corpAuth),
             placeHolderAddr,
             placeHolderAddr,
             placeHolderAddr,
-            placeHolderAddr
+            rmFactory
         );
 
+        // MetaLeX to release new RoundManager v2
+
         vm.startPrank(owner);
-        // TODO WIP: Should have governance approval on upgrades
-        rm2.upgradeToAndCall(address(new MockRoundManagerV2()), "");
+        RoundManagerFactory(rmFactory).setRefImplementation(RoundManager(address(new MockRoundManagerV2())));
+        vm.stopPrank();
+
+        // Corp2 owner decided to accept the upgrade
+
+        vm.startPrank(corpOwner);
+        rm2.upgradeToAndCall(address(RoundManagerFactory(rmFactory).refImplementation()), "");
         vm.stopPrank();
 
         assertEq(rm2.DEPLOY_VERSION(), "2", "Target RoundManager should be upgraded");
         assertEq(rm1.DEPLOY_VERSION(), "1", "Other RoundManager should not be upgraded");
+    }
+
+    function test_RevertIf_UpgradeExistingRoundManagerNotRefImplementation() public {
+        BorgAuth corpAuth = new BorgAuth{salt: keccak256("testUpgradeExistingRoundManager")}(corpOwner);
+        address placeHolderAddr = 0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF;
+
+        // Deploy existing RoundManagers
+
+        RoundManager rm = RoundManager(
+            RoundManagerFactory(rmFactory).deployRoundManager(keccak256("testUpgradeExistingRoundManager2"))
+        );
+        rm.initialize(
+            address(corpAuth),
+            placeHolderAddr,
+            placeHolderAddr,
+            placeHolderAddr,
+            rmFactory
+        );
+
+        // Corp owner can't upgrade to v2 without MetaLeX releasing it first
+
+        vm.startPrank(corpOwner);
+        address nonOfficialRoundManager = address(new MockRoundManagerV2());
+        vm.expectRevert(
+            abi.encodeWithSelector(RoundManager.NotRefImplementation.selector)
+        );
+        rm.upgradeToAndCall(nonOfficialRoundManager, "");
+        vm.stopPrank();
     }
 }
 

--- a/test/interfaces/ILegacyDealManagerFactory.sol
+++ b/test/interfaces/ILegacyDealManagerFactory.sol
@@ -1,0 +1,7 @@
+pragma solidity 0.8.28;
+
+interface ILegacyDealManagerFactory {
+    function getBeaconImplementation() external view returns (address);
+
+    function upgradeImplementation(address _newImplementation) external;
+}


### PR DESCRIPTION
## Specs
https://www.notion.so/RoundManager-DealManager-Upgradeability-Rug-ability-2795821ee76780689c3ff8e63ae3d764?source=copy_link

## Added
- `DealManagerFactoryStorage` and `RoundManagerFactoryStorage` for diamond storage pattern
- Tests for upgrading both `DealManager` and `RoundManager` as well as their factories

## Updated
- `DealManagerFactory` and `RoundManagerFactory` to be upgradeable so they have permanent addresses for looking up reference implementation
- `DealManager` and `RoundManager` to be company owner-initiated upgradeable to MetaLeX-released versions