### PR TITLE
fix: refund externally voided RoundManager deals

### DIFF
--- a/src/RoundManager.sol
+++ b/src/RoundManager.sol
@@ -44,6 +44,7 @@ pragma solidity ^0.8.28;
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import "./CyberAgreementRegistry.sol";
 import "./interfaces/IIssuanceManager.sol";
 import "./libs/LexScroWLite.sol";
 import "./libs/auth.sol";
@@ -310,6 +311,7 @@ contract RoundManager is
             )
         );
 
+        // TODO this is not used?
         /*if(!_verifyEscrowedSignature(
                 authorityOfficer,
                 EscrowedSignatureData({
@@ -728,6 +730,16 @@ contract RoundManager is
     /// @notice Rejects an EOI and voids the deal
     /// @param agreementId The agreement ID
     function reject(bytes32 agreementId) external onlyOwner {
+        reject(agreementId, true);
+    }
+
+    /// @notice Rejects an EOI and voids the deal if necessary
+    /// @dev The extra parameter allows handling the edge case where the party voided the agreement by
+    /// directly requesting to CyberAgreementRegistry and bypassing RoundManager.
+    /// In such case, we want to skip `voidContractFor()` so it does not attempt to void the contract again.
+    /// @param agreementId The agreement ID
+    /// @param isVoidAgreement True if voiding the deal
+    function reject(bytes32 agreementId, bool isVoidAgreement) public onlyOwner {
         bytes32 roundId = RoundManagerStorage.getAgreementToRound(agreementId);
         Round storage round = RoundManagerStorage.getRound(roundId);
         Escrow storage escrow = LexScrowStorage.getEscrow(agreementId);
@@ -743,13 +755,26 @@ contract RoundManager is
         // Void escrow
         voidEscrow(agreementId);
 
-        ICyberAgreementRegistry(LexScrowStorage.getDealRegistry()).voidContractFor(agreementId, escrow.counterParty, escrow.signature);
+        if (isVoidAgreement) {
+            ICyberAgreementRegistry(LexScrowStorage.getDealRegistry()).voidContractFor(agreementId, escrow.counterParty, escrow.signature);
+        }
 
         emit EOIRejected(agreementId, escrow.counterParty, roundId);
     }
 
-    //allow a eoi submitter to recall their eoi and get a refund after the eoi expiry
+    /// @notice Allow a eoi submitter to recall their eoi, get a refund and void the agreement after the eoi expiry
+    /// @param agreementId The agreement ID
     function recallEOI(bytes32 agreementId) external {
+        recallEOI(agreementId, true);
+    }
+
+    /// @notice Allow a eoi submitter to recall their eoi, get a refund and void the agreement if necessary after the eoi expiry
+    /// @dev The extra parameter allows handling the edge case where the party voided the agreement by
+    /// directly requesting to CyberAgreementRegistry and bypassing RoundManager.
+    /// In such case, we want to skip `voidContractFor()` so it does not attempt to void the contract again.
+    /// @param agreementId The agreement ID
+    /// @param isVoidAgreement True if voiding the deal
+    function recallEOI(bytes32 agreementId, bool isVoidAgreement) public {
         bytes32 roundId = RoundManagerStorage.getAgreementToRound(agreementId);
         Round storage round = RoundManagerStorage.getRound(roundId);
         Escrow storage escrow = LexScrowStorage.getEscrow(agreementId);
@@ -767,8 +792,10 @@ contract RoundManager is
         // Void escrow
         voidEscrow(agreementId);
 
-        //void agreement
-        ICyberAgreementRegistry(LexScrowStorage.getDealRegistry()).voidContractFor(agreementId, escrow.counterParty, escrow.signature);
+        // void agreement
+        if (isVoidAgreement) {
+            ICyberAgreementRegistry(LexScrowStorage.getDealRegistry()).voidContractFor(agreementId, escrow.counterParty, escrow.signature);
+        }
 
         emit EOIRecalled(agreementId, escrow.counterParty, roundId);
     }

--- a/test/RoundManagerTest.t.sol
+++ b/test/RoundManagerTest.t.sol
@@ -880,6 +880,65 @@ contract RoundManagerTest is Test {
         vm.stopPrank();
     }
 
+    function test_Allocate_IgnoreVoidRequest() public {
+        // Submit EOI
+        vm.startPrank(investor);
+
+        EOI memory eoi = EOI({
+            name: "Test Investor",
+            investorType: "Individual",
+            jurisdiction: "US",
+            contact: "test@example.com",
+            minAmount: 5000 * 10 ** 6,
+            maxAmount: 10000 * 10 ** 6,
+            expiry: block.timestamp + 7 days
+        });
+
+        bytes32 agreementId = RoundManager(roundManager).submitEOI(
+            roundId,
+            eoi,
+            new string[](1),
+            new string[](1),
+            _computeEOISignature(
+                templateId,
+                1,
+                new string[](1),
+                new string[](1),
+                owner,
+                investorPrivKey
+            ),
+            1,
+            new address[](0),
+            bytes32(0)
+        );
+
+        vm.stopPrank();
+
+        // Simulate deal being voided externally through the registry.
+        // This will not void the EOI and the owner should still be able to fill it.
+        registry.voidContractFor(
+            agreementId,
+            investor,
+            CyberAgreementUtils.signVoidAgreementTypedData(
+                vm,
+                registry.DOMAIN_SEPARATOR(),
+                registry.VOIDSIGNATUREDATA_TYPEHASH(),
+                agreementId,
+                investor,
+                investorPrivKey
+            )
+        );
+
+        // Verify the owner can fill the EOI
+        uint256 balBeforeAllocate = paymentToken.balanceOf(owner);
+
+        vm.prank(owner);
+        RoundManager(roundManager).allocate(agreementId, 5_000 * 10 ** 6);
+
+        uint256 balAfterAllocate = paymentToken.balanceOf(owner);
+        assertEq(balAfterAllocate - balBeforeAllocate, 5_000 * 10 ** 6);
+    }
+
     function test_RejectEOI_RefundsAndVoids() public {
         // Submit EOI
         vm.startPrank(investor);
@@ -920,6 +979,216 @@ contract RoundManagerTest is Test {
         Escrow memory escAfter = RoundManager(roundManager).getEscrowDetails(agreementId);
         assertEq(uint256(escAfter.status), uint256(EscrowStatus.VOIDED));
         assertEq(paymentToken.balanceOf(investor), balBefore);
+    }
+
+    function test_RejectEOI_RefundsVoidedDeal() public {
+        // Submit EOI
+        vm.startPrank(investor);
+        EOI memory eoi = EOI({
+            name: "Reject Me",
+            investorType: "Individual",
+            jurisdiction: "US",
+            contact: "reject@example.com",
+            minAmount: 2_000 * 10 ** 6,
+            maxAmount: 5_000 * 10 ** 6,
+            expiry: block.timestamp + 7 days
+        });
+        uint256 balBefore = paymentToken.balanceOf(investor);
+        bytes32 agreementId = RoundManager(roundManager).submitEOI(
+            roundId,
+            eoi,
+            new string[](1),
+            new string[](1),
+            _computeEOISignature(
+                templateId,
+                3,
+                new string[](1),
+                new string[](1),
+                owner,
+                investorPrivKey
+            ),
+            3,
+            new address[](0),
+            bytes32(0)
+        );
+        vm.stopPrank();
+        Escrow memory escBefore = RoundManager(roundManager).getEscrowDetails(agreementId);
+        assertEq(uint256(escBefore.status), uint256(EscrowStatus.PAID));
+
+        // Simulate deal being voided externally through the registry
+        registry.voidContractFor(
+            agreementId,
+            investor,
+            CyberAgreementUtils.signVoidAgreementTypedData(
+                vm,
+                registry.DOMAIN_SEPARATOR(),
+                registry.VOIDSIGNATUREDATA_TYPEHASH(),
+                agreementId,
+                investor,
+                investorPrivKey
+            )
+        );
+
+        // Owner can no longer call `reject()` because it would try to void the agreement again
+        vm.prank(owner);
+        vm.expectRevert(CyberAgreementRegistry.ContractAlreadyVoided.selector);
+        RoundManager(roundManager).reject(agreementId);
+
+        // Instead, he could choose to skip voiding the agreement
+        vm.prank(owner);
+        RoundManager(roundManager).reject(agreementId, false);
+        Escrow memory escAfter = RoundManager(roundManager).getEscrowDetails(agreementId);
+        assertEq(uint256(escAfter.status), uint256(EscrowStatus.VOIDED));
+        assertEq(paymentToken.balanceOf(investor), balBefore);
+    }
+
+    function test_RecallEOI_RefundsAndVoids() public {
+        // Submit EOI
+        vm.startPrank(investor);
+        EOI memory eoi = EOI({
+            name: "Recall Me",
+            investorType: "Individual",
+            jurisdiction: "US",
+            contact: "reject@example.com",
+            minAmount: 2_000 * 10 ** 6,
+            maxAmount: 5_000 * 10 ** 6,
+            expiry: block.timestamp + 7 days
+        });
+        uint256 balBefore = paymentToken.balanceOf(investor);
+        bytes32 agreementId = RoundManager(roundManager).submitEOI(
+            roundId,
+            eoi,
+            new string[](1),
+            new string[](1),
+            _computeEOISignature(
+                templateId,
+                3,
+                new string[](1),
+                new string[](1),
+                owner,
+                investorPrivKey
+            ),
+            3,
+            new address[](0),
+            bytes32(0)
+        );
+        vm.stopPrank();
+        Escrow memory escBefore = RoundManager(roundManager).getEscrowDetails(agreementId);
+        assertEq(uint256(escBefore.status), uint256(EscrowStatus.PAID));
+
+        // Simulate pass both EOI expiry and Round end time
+        vm.warp(block.timestamp + 30 days);
+
+        // Recall as investor after expiry -> refund and void
+        vm.prank(investor);
+        RoundManager(roundManager).recallEOI(agreementId);
+        Escrow memory escAfter = RoundManager(roundManager).getEscrowDetails(agreementId);
+        assertEq(uint256(escAfter.status), uint256(EscrowStatus.VOIDED));
+        assertEq(paymentToken.balanceOf(investor), balBefore);
+    }
+
+    function test_RecallEOI_RefundsVoidedDeal() public {
+        // Submit EOI
+        vm.startPrank(investor);
+        EOI memory eoi = EOI({
+            name: "Recall Me",
+            investorType: "Individual",
+            jurisdiction: "US",
+            contact: "reject@example.com",
+            minAmount: 2_000 * 10 ** 6,
+            maxAmount: 5_000 * 10 ** 6,
+            expiry: block.timestamp + 7 days
+        });
+        uint256 balBefore = paymentToken.balanceOf(investor);
+        bytes32 agreementId = RoundManager(roundManager).submitEOI(
+            roundId,
+            eoi,
+            new string[](1),
+            new string[](1),
+            _computeEOISignature(
+                templateId,
+                3,
+                new string[](1),
+                new string[](1),
+                owner,
+                investorPrivKey
+            ),
+            3,
+            new address[](0),
+            bytes32(0)
+        );
+        vm.stopPrank();
+        Escrow memory escBefore = RoundManager(roundManager).getEscrowDetails(agreementId);
+        assertEq(uint256(escBefore.status), uint256(EscrowStatus.PAID));
+
+        // Simulate pass both EOI expiry and Round end time
+        vm.warp(block.timestamp + 30 days);
+
+        // Simulate deal being voided externally through the registry
+        registry.voidContractFor(
+            agreementId,
+            investor,
+            CyberAgreementUtils.signVoidAgreementTypedData(
+                vm,
+                registry.DOMAIN_SEPARATOR(),
+                registry.VOIDSIGNATUREDATA_TYPEHASH(),
+                agreementId,
+                investor,
+                investorPrivKey
+            )
+        );
+
+        // Investor can no longer call `recall()` because it would try to void the agreement again
+        vm.prank(investor);
+        vm.expectRevert(CyberAgreementRegistry.ContractAlreadyVoided.selector);
+        RoundManager(roundManager).recallEOI(agreementId);
+
+        // Instead, he could choose to skip voiding the agreement
+        vm.prank(investor);
+        RoundManager(roundManager).recallEOI(agreementId, false);
+        Escrow memory escAfter = RoundManager(roundManager).getEscrowDetails(agreementId);
+        assertEq(uint256(escAfter.status), uint256(EscrowStatus.VOIDED));
+        assertEq(paymentToken.balanceOf(investor), balBefore);
+    }
+
+    function test_RevertIf_RecallEOI_NotExpired() public {
+        // Submit EOI
+        vm.startPrank(investor);
+        EOI memory eoi = EOI({
+            name: "Recall Me",
+            investorType: "Individual",
+            jurisdiction: "US",
+            contact: "reject@example.com",
+            minAmount: 2_000 * 10 ** 6,
+            maxAmount: 5_000 * 10 ** 6,
+            expiry: block.timestamp + 7 days
+        });
+        uint256 balBefore = paymentToken.balanceOf(investor);
+        bytes32 agreementId = RoundManager(roundManager).submitEOI(
+            roundId,
+            eoi,
+            new string[](1),
+            new string[](1),
+            _computeEOISignature(
+                templateId,
+                3,
+                new string[](1),
+                new string[](1),
+                owner,
+                investorPrivKey
+            ),
+            3,
+            new address[](0),
+            bytes32(0)
+        );
+        vm.stopPrank();
+        Escrow memory escBefore = RoundManager(roundManager).getEscrowDetails(agreementId);
+        assertEq(uint256(escBefore.status), uint256(EscrowStatus.PAID));
+
+        // Immediate recall should fail as the EOI isn't expired
+        vm.prank(investor);
+        vm.expectRevert(RoundManager.EOINotExpired.selector);
+        RoundManager(roundManager).recallEOI(agreementId);
     }
 
     function test_Allocate_WithFailingCondition_Reverts() public {

--- a/test/libs/CyberAgreementUtils.sol
+++ b/test/libs/CyberAgreementUtils.sol
@@ -76,6 +76,31 @@ library CyberAgreementUtils {
             )
         );
 
+        return _signTypedData(vm, _domainSeparator, structHash, privKey);
+    }
+
+    function signVoidAgreementTypedData(
+        Vm vm,
+        bytes32 _domainSeparator,
+        bytes32 _typeHash,
+        bytes32 contractId,
+        address party,
+        uint256 privKey
+    ) internal pure returns (bytes memory signature) {
+        // Create the message hash using the same approach as the contract
+        bytes32 structHash = keccak256(
+            abi.encode(_typeHash, contractId, party)
+        );
+
+        return _signTypedData(vm, _domainSeparator, structHash, privKey);
+    }
+
+    function _signTypedData(
+        Vm vm,
+        bytes32 _domainSeparator,
+        bytes32 structHash,
+        uint256 privKey
+    ) internal pure returns (bytes memory signature) {
         bytes32 digest = keccak256(
             abi.encodePacked("\x19\x01", _domainSeparator, structHash)
         );


### PR DESCRIPTION
Similar to #47 but for `RoundManager`.

- Added `reject()` and `recallEOI()` function overloads to handle the edge case when the agreement was voided outside the manager's reach
- Added related test cases