### PR TITLE
fix: reentrancy attack vectors

### DIFF
--- a/src/DealManager.sol
+++ b/src/DealManager.sol
@@ -42,6 +42,7 @@ except with the express prior written permission of the copyright holder.*/
 pragma solidity 0.8.28;
 
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import "./interfaces/IIssuanceManager.sol";
 import "./libs/LexScroWLite.sol";
 import "./libs/auth.sol";
@@ -53,7 +54,7 @@ import "./interfaces/IRoundManager.sol";
 /// @title DealManager
 /// @notice Manages the lifecycle of deals between parties, including creation, signing, payment, and finalization for a CyberCorp
 /// @dev Implements UUPS upgradeable pattern and integrates with BorgAuth for access control
-contract DealManager is Initializable, BorgAuthACL, LexScroWLite {
+contract DealManager is Initializable, ReentrancyGuard, BorgAuthACL, LexScroWLite {
     using DealManagerStorage for DealManagerStorage.DealManagerData;
 
     /// @notice Certificate data structure for creating new certificates
@@ -348,14 +349,18 @@ contract DealManager is Initializable, BorgAuthACL, LexScroWLite {
     /// @notice Finalizes a deal
     /// @dev Checks signatures, conditions and finalizes the agreement
     /// @param agreementId Unique identifier for the agreement
-    function finalizeDeal(bytes32 agreementId) public {
+    function finalizeDeal(bytes32 agreementId) public nonReentrant {
+        // Check: status
         if(ICyberAgreementRegistry(LexScrowStorage.getDealRegistry()).isVoided(agreementId)) revert DealVoided();
         if(LexScrowStorage.getEscrow(agreementId).status != EscrowStatus.PAID) revert DealNotPaid();
         if(ICyberAgreementRegistry(LexScrowStorage.getDealRegistry()).isFinalized(agreementId)) revert DealAlreadyFinalized();
         if(!ICyberAgreementRegistry(LexScrowStorage.getDealRegistry()).allPartiesSigned(agreementId)) revert DealNotFullySigned();
         if(!conditionCheck(agreementId)) revert AgreementConditionsNotMet();
-        
+
+        // Effect: update status
         ICyberAgreementRegistry(LexScrowStorage.getDealRegistry()).finalizeContract(agreementId);
+
+        // Interaction: payments
         finalizeEscrow(agreementId);
         emit DealFinalized(
             agreementId,
@@ -371,9 +376,12 @@ contract DealManager is Initializable, BorgAuthACL, LexScroWLite {
     /// @param agreementId Unique identifier for the agreement
     /// @param signer Address of the signer
     /// @param signature Signature of the signer
-    function voidExpiredDeal(bytes32 agreementId, address signer, bytes memory signature) public {
+    function voidExpiredDeal(bytes32 agreementId, address signer, bytes memory signature) public nonReentrant {
+        // Check: status
         Escrow storage deal = LexScrowStorage.getEscrow(agreementId);
         if (block.timestamp <= deal.expiry) revert DealNotExpired();
+
+        // Effect: update status
         ICyberAgreementRegistry(LexScrowStorage.getDealRegistry()).voidContractFor(agreementId, signer, signature);
         for(uint256 i = 0; i < deal.corpAssets.length; i++) {
             if(deal.corpAssets[i].tokenType == TokenType.ERC721) {
@@ -383,9 +391,12 @@ contract DealManager is Initializable, BorgAuthACL, LexScroWLite {
                 );
             }
         }
-        if(deal.status == EscrowStatus.PAID) 
+
+        if(deal.status == EscrowStatus.PAID)
+            // Interaction: payment
             voidAndRefund(agreementId);
         else if(deal.status == EscrowStatus.PENDING)
+            // Effect: update status
             voidEscrow(agreementId);
     }
 
@@ -407,10 +418,14 @@ contract DealManager is Initializable, BorgAuthACL, LexScroWLite {
     /// @param agreementId Unique identifier for the agreement
     /// @param signer Address of the signer
     /// @param signature Signature of the signer
-    function signToVoid(bytes32 agreementId, address signer, bytes memory signature) public {
+    function signToVoid(bytes32 agreementId, address signer, bytes memory signature) public nonReentrant {
+        // Check: status
         if(msg.sender != signer) revert CounterPartyValueMismatch();
+
+        // Effect: update status
         ICyberAgreementRegistry(LexScrowStorage.getDealRegistry()).voidContractFor(agreementId, signer, signature);
         if(ICyberAgreementRegistry(LexScrowStorage.getDealRegistry()).isVoided(agreementId) && LexScrowStorage.getEscrow(agreementId).status == EscrowStatus.PAID)
+            // Interaction: payment
             voidAndRefund(agreementId);
     }
 
@@ -418,8 +433,8 @@ contract DealManager is Initializable, BorgAuthACL, LexScroWLite {
     /// @dev Use this method to initiate refund if the deal agreement has been voided externally
     /// (e.g. directly to CyberAgreementRegistry without being processed by Deal Manager)
     /// @param agreementId Unique identifier for the agreement
-    function refundVoidedDeal(bytes32 agreementId) public {
-        // Re-sync Deal Manager internal escrow to VOIDED, then refund
+    function refundVoidedDeal(bytes32 agreementId) public nonReentrant {
+        // Interaction: Re-sync Deal Manager internal escrow to VOIDED, then refund
         voidAndRefund(agreementId);
     }
 

--- a/src/RoundManager.sol
+++ b/src/RoundManager.sol
@@ -44,6 +44,7 @@ pragma solidity ^0.8.28;
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import "./interfaces/IIssuanceManager.sol";
 import "./libs/LexScroWLite.sol";
 import "./libs/auth.sol";
@@ -59,6 +60,7 @@ import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 contract RoundManager is
     Initializable,
     UUPSUpgradeable,
+    ReentrancyGuard,
     BorgAuthACL,
     LexScroWLite
 {
@@ -592,15 +594,16 @@ contract RoundManager is
     function allocate(
         bytes32 agreementId,
         uint256 allocatedAmount
-    ) external onlyOwnerOrSelf {
+    ) external onlyOwnerOrSelf nonReentrant {
         bytes32 roundId = RoundManagerStorage.getAgreementToRound(agreementId);
         Round storage round = RoundManagerStorage.getRound(roundId);
         EOI storage eoi = RoundManagerStorage.getAgreementToEOI(agreementId);
         Escrow storage escrow = LexScrowStorage.getEscrow(agreementId);
 
+        // Check: round validity
         if (round.id == bytes32(0)) revert InvalidRound();
 
-        //check that the eoi has not expired
+        // Check: eoi has not expired
         if (eoi.expiry < block.timestamp) revert EOIExpired();
 
         uint256 remaining = round.raiseCap - round.raised;
@@ -616,11 +619,12 @@ contract RoundManager is
             revert InvalidAllocation();
         }
         allocatedAmount = candidate;
-        
+
+        // Check: status
         if (escrow.status != EscrowStatus.PAID) revert DealNotPaid();
         if (escrow.corpAssets.length > 0) revert AlreadyAllocated();
 
-        //sign the agreement with the escrow signer
+        // Effect: sign the agreement with the escrow signer
         if (
             !ICyberAgreementRegistry(LexScrowStorage.getDealRegistry())
                 .hasSigned(agreementId, round.authorityOfficer)
@@ -658,7 +662,7 @@ contract RoundManager is
         IIssuanceManager issuanceManager = RoundManagerStorage
             .getIssuanceManager();
 
-        //loop through certPrinter and create cert for each
+        // Effect: loop through certPrinter and create cert for each
         uint256[] memory certIds = new uint256[](round.certPrinter.length);
         for (uint256 i = 0; i < round.certPrinter.length; i++) {
             certIds[i] = issuanceManager.createCert(
@@ -681,7 +685,7 @@ contract RoundManager is
             endorseeName: eoi.name
         });
 
-        //loop through certPrinter and add endorsement to each
+        // Effect: loop through certPrinter and add endorsement to each
         for (uint256 i = 0; i < round.certPrinter.length; i++) {
             ICyberCertPrinter(round.certPrinter[i]).addEndorsement(
                 certIds[i],
@@ -689,86 +693,85 @@ contract RoundManager is
             );
         }
 
-        // Add to escrow
-        //loop through certPrinter and add to escrow
+        // Effect: Add to escrow
+        // loop through certPrinter and add to escrow
         for (uint256 i = 0; i < round.certPrinter.length; i++) {
             escrow.corpAssets.push(
                 Token(TokenType.ERC721, round.certPrinter[i], certIds[i], 1)
             );
         }
 
-        // Refund difference
+        // Effect: Calculate refund amount and update escrowed amount
         uint256 refund = escrow.buyerAssets[0].amount - allocatedAmount;
+        escrow.buyerAssets[0].amount = allocatedAmount;
+
+        // Check: Check conditions
+        if (!conditionCheck(agreementId)) revert AgreementConditionsNotMet();
+
+        // Effect: Finalize agreement
+        ICyberAgreementRegistry(LexScrowStorage.getDealRegistry())
+            .finalizeContract(agreementId);
+
+        // Effect: update raised amount
+        round.raised += allocatedAmount;
+
         if (refund > 0) {
+            // Interaction: Refund
             IERC20(round.paymentToken).safeTransfer(
                 escrow.counterParty,
                 refund
             );
         }
 
-        // Update escrowed amount
-        escrow.buyerAssets[0].amount = allocatedAmount;
-
-        // Check conditions
-        if (!conditionCheck(agreementId)) revert AgreementConditionsNotMet();
-
-        // Finalize agreement
-        ICyberAgreementRegistry(LexScrowStorage.getDealRegistry())
-            .finalizeContract(agreementId);
-
-        // Finalize escrow
+        // Interaction: Finalize escrow and payments
         finalizeEscrow(agreementId);
-
-        // Update raised
-        round.raised += allocatedAmount;
 
         emit AllocationMade(agreementId, roundId, escrow.counterParty, allocatedAmount, round.raised, certIds); 
     }
 
     /// @notice Rejects an EOI and voids the deal
     /// @param agreementId The agreement ID
-    function reject(bytes32 agreementId) external onlyOwner {
+    function reject(bytes32 agreementId) external onlyOwner nonReentrant {
         bytes32 roundId = RoundManagerStorage.getAgreementToRound(agreementId);
         Round storage round = RoundManagerStorage.getRound(roundId);
         Escrow storage escrow = LexScrowStorage.getEscrow(agreementId);
 
+        // Check: check status
         if (round.id == bytes32(0)) revert InvalidRound();
         if (escrow.status != EscrowStatus.PAID) revert DealNotPaid();
         if (escrow.corpAssets.length > 0) revert AlreadyAllocated();
 
-        // Refund all
+        // Effect: update status
+        voidEscrow(agreementId);
+        ICyberAgreementRegistry(LexScrowStorage.getDealRegistry()).voidContractFor(agreementId, escrow.counterParty, escrow.signature);
+
+        // Interaction: Refund all
         uint256 amount = escrow.buyerAssets[0].amount;
         IERC20(round.paymentToken).safeTransfer(escrow.counterParty, amount);
-
-        // Void escrow
-        voidEscrow(agreementId);
-
-        ICyberAgreementRegistry(LexScrowStorage.getDealRegistry()).voidContractFor(agreementId, escrow.counterParty, escrow.signature);
 
         emit EOIRejected(agreementId, escrow.counterParty, roundId);
     }
 
     //allow a eoi submitter to recall their eoi and get a refund after the eoi expiry
-    function recallEOI(bytes32 agreementId) external {
+    function recallEOI(bytes32 agreementId) external nonReentrant {
         bytes32 roundId = RoundManagerStorage.getAgreementToRound(agreementId);
         Round storage round = RoundManagerStorage.getRound(roundId);
         Escrow storage escrow = LexScrowStorage.getEscrow(agreementId);
-        
+
+        // Check: check status
         if (round.id == bytes32(0)) revert InvalidRound();
         if (msg.sender != escrow.counterParty) revert NotEOISubmitter();
         if (escrow.status != EscrowStatus.PAID) revert DealNotPaid();
         if (escrow.corpAssets.length > 0) revert AlreadyAllocated();
         if (block.timestamp < escrow.expiry && round.endTime > block.timestamp) revert EOINotExpired();
 
-        // Refund all
+        // Effect: update status
+        voidEscrow(agreementId);
+        ICyberAgreementRegistry(LexScrowStorage.getDealRegistry()).voidContractFor(agreementId, escrow.counterParty, escrow.signature);
+
+        // Interaction: Refund all
         uint256 amount = escrow.buyerAssets[0].amount;
         IERC20(round.paymentToken).safeTransfer(escrow.counterParty, amount);
-
-        // Void escrow
-        voidEscrow(agreementId);
-
-        //void agreement
-        ICyberAgreementRegistry(LexScrowStorage.getDealRegistry()).voidContractFor(agreementId, escrow.counterParty, escrow.signature);
 
         emit EOIRecalled(agreementId, escrow.counterParty, roundId);
     }

--- a/src/libs/LexScroWLite.sol
+++ b/src/libs/LexScroWLite.sol
@@ -50,11 +50,10 @@ import "../interfaces/ICyberCorp.sol";
 import "../interfaces/ICyberAgreementRegistry.sol";
 import "../interfaces/ICyberCertPrinter.sol";
 import "../interfaces/ICondition.sol";
-import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import {LexScrowStorage, Escrow, Token, TokenType, EscrowStatus} from "../storage/LexScrowStorage.sol";
 
 
-abstract contract LexScroWLite is Initializable, ReentrancyGuard {
+abstract contract LexScroWLite is Initializable {
     using LexScrowStorage for LexScrowStorage.LexScrowData;
     using SafeERC20 for IERC20;
 
@@ -136,12 +135,17 @@ abstract contract LexScroWLite is Initializable, ReentrancyGuard {
         escrow.status = EscrowStatus.PAID;
     }
 
-    function voidAndRefund(bytes32 agreementId) internal nonReentrant {
+    /// @dev: External functions who call this should implement their own reentrancy guards
+    function voidAndRefund(bytes32 agreementId) internal {
+        // Check: check status
         Escrow storage escrow = LexScrowStorage.getEscrow(agreementId);
         if(escrow.status != EscrowStatus.PAID) revert EscrowNotPaid();
         if(!ICyberAgreementRegistry(LexScrowStorage.getDealRegistry()).isVoided(agreementId)) revert DealNotVoided();
 
-        // Refund buyer assets first
+        // Effect: update status
+        voidEscrow(agreementId);
+
+        // Interaction: Refund buyer assets
         for(uint256 i = 0; i < escrow.buyerAssets.length; i++) {
             if(escrow.buyerAssets[i].tokenType == TokenType.ERC20) {
                 IERC20(escrow.buyerAssets[i].tokenAddress).safeTransfer(escrow.counterParty, escrow.buyerAssets[i].amount);
@@ -153,22 +157,21 @@ abstract contract LexScroWLite is Initializable, ReentrancyGuard {
                 IERC1155(escrow.buyerAssets[i].tokenAddress).safeTransferFrom(address(this), escrow.counterParty, escrow.buyerAssets[i].tokenId, escrow.buyerAssets[i].amount, "");
             }
         }
-
-        voidEscrow(agreementId);
     }
 
-    function finalizeEscrow(bytes32 agreementId) internal nonReentrant {
+    /// @dev: External functions who call this should implement their own reentrancy guards
+    function finalizeEscrow(bytes32 agreementId) internal {
         Escrow storage escrow = LexScrowStorage.getEscrow(agreementId);
 
-        // Check all conditions before proceeding
+        // Check: Check all conditions before proceeding
         if(block.timestamp > escrow.expiry) revert DealExpired();
         if(escrow.status != EscrowStatus.PAID) revert EscrowNotPaid();
 
-        // Update state before external calls
+        // Effect: Update state before external calls
         escrow.status = EscrowStatus.FINALIZED;
         emit DealFinalizedAt(agreementId, LexScrowStorage.getDealRegistry(), block.timestamp);
 
-        // Transfer buyer assets to company
+        // Interaction: Transfer buyer assets to company
         for(uint256 i = 0; i < escrow.buyerAssets.length; i++) {
             if(escrow.buyerAssets[i].tokenType == TokenType.ERC20) {
                 IERC20(escrow.buyerAssets[i].tokenAddress).safeTransfer(ICyberCorp(LexScrowStorage.getCorp()).companyPayable(), escrow.buyerAssets[i].amount);
@@ -181,7 +184,7 @@ abstract contract LexScroWLite is Initializable, ReentrancyGuard {
             }
         }
 
-        // Transfer corp assets to counter party
+        // Interaction: Transfer corp assets to counter party
         for(uint256 i = 0; i < escrow.corpAssets.length; i++) {
             if(escrow.corpAssets[i].tokenType == TokenType.ERC20) {
                 IERC20(escrow.corpAssets[i].tokenAddress).safeTransfer(escrow.counterParty, escrow.corpAssets[i].amount);


### PR DESCRIPTION
- Added: reentrancy guards to payment-critical external methods in `RoundManager` and `DealManager`
- Removed: reentrancy guards from internal functions in `LexScroWLite` because it should be implemented by external callers as they often have their own check-effect-interactions to protect anyways
- Updated: re-arranged codes to fit check-effect-interactions pattern better
- Test: all passed
