### PR TITLE
feat: add fees to RoundManager (simplified)

### DIFF
--- a/src/DealManager.sol
+++ b/src/DealManager.sol
@@ -48,6 +48,7 @@ import "./interfaces/IIssuanceManager.sol";
 import "./libs/LexScroWLite.sol";
 import "./libs/auth.sol";
 import "./storage/DealManagerStorage.sol";
+import "./storage/DealManagerFactoryStorage.sol";
 import "./storage/BorgAuthStorage.sol";
 import "./interfaces/ICyberCorp.sol";
 import "./interfaces/IDealManagerFactory.sol";
@@ -183,11 +184,11 @@ contract DealManager is Initializable, UUPSUpgradeable, ReentrancyGuard, BorgAut
         certIds = new uint256[](_certDetails.length);
         for(uint256 i = 0; i < _certDetails.length; i++) {
             certIds[i] = DealManagerStorage.getIssuanceManager().createCert(_certPrinterAddress[i], address(this), _certDetails[i]);
-            corpAssets[i] = Token(TokenType.ERC721, _certPrinterAddress[i], certIds[i], 1);
+            corpAssets[i] = Token(TokenType.ERC721, _certPrinterAddress[i], certIds[i], 1, false);
         }
 
         Token[] memory buyerAssets = new Token[](1);
-        buyerAssets[0] = Token(TokenType.ERC20, _paymentToken, 0, _paymentAmount);
+        buyerAssets[0] = Token(TokenType.ERC20, _paymentToken, 0, _paymentAmount, true); // Will be used as fee token
 
         Escrow memory newEscrow = Escrow({
             agreementId: agreementId,
@@ -580,6 +581,21 @@ contract DealManager is Initializable, UUPSUpgradeable, ReentrancyGuard, BorgAut
             secretHash,
             expiry
         );
+    }
+
+    /// @notice Compute fee based on ticket size
+    /// @dev Currently the factory owner (MetaLeX) unilaterally set the fee ratio;
+    /// in the future, it could be determined through a governance process.
+    /// @return Fee amount
+    function computeFee(uint256 size) public override view returns (uint256) {
+        return size * IDealManagerFactory(DealManagerStorage.getUpgradeFactory()).getDefaultFeeRatio() / DealManagerFactoryStorage.BASIS_POINTS;
+    }
+
+    /// @notice Gets the payable address for the fees
+    /// @dev The factory owner (MetaLeX) unilaterally set the payable address
+    /// @return Payable address for the fees
+    function getPlatformPayable() public override view returns (address) {
+        return IDealManagerFactory(DealManagerStorage.getUpgradeFactory()).getPlatformPayable();
     }
 
     /// @notice UUPS upgrade authorization

--- a/src/DealManagerFactory.sol
+++ b/src/DealManagerFactory.sol
@@ -58,6 +58,7 @@ contract DealManagerFactory is UUPSUpgradeable, BorgAuthACL {
     error InvalidFeeRatio();
 
     event DealManagerDeployed(address dealManager, string version);
+    event RefImplementationSet(address refImplementation, string version);
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -116,6 +117,7 @@ contract DealManagerFactory is UUPSUpgradeable, BorgAuthACL {
     /// @param _newImplementation Address of the new implementation
     function setRefImplementation(address _newImplementation) public onlyOwner {
         DealManagerFactoryStorage.setRefImplementation(_newImplementation);
+        emit RefImplementationSet(_newImplementation, DealManager(_newImplementation).DEPLOY_VERSION());
     }
 
     /// @notice Get the payable address for the fees

--- a/src/DealManagerFactory.sol
+++ b/src/DealManagerFactory.sol
@@ -55,6 +55,7 @@ contract DealManagerFactory is UUPSUpgradeable, BorgAuthACL {
     error InvalidSalt();
     error DeploymentFailed();
     error ZeroAddress();
+    error InvalidFeeRatio();
 
     event DealManagerDeployed(address dealManager, string version);
 
@@ -106,7 +107,7 @@ contract DealManagerFactory is UUPSUpgradeable, BorgAuthACL {
 
     /// @notice Get the reference implementation contract for the next deployments
     /// @return Current reference implementation contract address
-    function getRefImplementation() public returns(address) {
+    function getRefImplementation() public view returns(address) {
         return DealManagerFactoryStorage.getRefImplementation();
     }
 
@@ -115,6 +116,36 @@ contract DealManagerFactory is UUPSUpgradeable, BorgAuthACL {
     /// @param _newImplementation Address of the new implementation
     function setRefImplementation(address _newImplementation) public onlyOwner {
         DealManagerFactoryStorage.setRefImplementation(_newImplementation);
+    }
+
+    /// @notice Get the payable address for the fees
+    /// @return Payable address for the fees
+    function getPlatformPayable() external view returns (address) {
+        return DealManagerFactoryStorage.getPlatformPayable();
+    }
+
+    /// @notice Set the payable address for the fees
+    /// @dev Only callable by addresses with the admin role
+    /// @param platformPayable New payable address
+    function setPlatformPayable(address platformPayable) external onlyOwner {
+        DealManagerFactoryStorage.setPlatformPayable(platformPayable);
+    }
+
+    /// @notice Get the fee ratio
+    /// @return Fee ratio (same unit as BASIS_POINTS
+    function getDefaultFeeRatio() external view returns (uint256) {
+        return DealManagerFactoryStorage.getDefaultFeeRatio();
+    }
+
+    /// @notice Set the fee ratio
+    /// @dev Only callable by addresses with the admin role. Will check validity of the new value
+    /// @param feeRatio New fee ratio
+    function setDefaultFeeRatio(uint256 feeRatio) external onlyOwner {
+        if (feeRatio > DealManagerFactoryStorage.BASIS_POINTS) {
+            revert InvalidFeeRatio(); // fee ratio should not exceed 100%
+        }
+
+        DealManagerFactoryStorage.setDefaultFeeRatio(feeRatio);
     }
 
     function _authorizeUpgrade(

--- a/src/RoundManager.sol
+++ b/src/RoundManager.sol
@@ -49,6 +49,7 @@ import "./interfaces/IIssuanceManager.sol";
 import "./libs/LexScroWLite.sol";
 import "./libs/auth.sol";
 import "./storage/RoundManagerStorage.sol";
+import "./storage/RoundManagerFactoryStorage.sol";
 import "./storage/BorgAuthStorage.sol";
 import "./interfaces/ICyberCorp.sol";
 import "./interfaces/ICyberCertPrinter.sol";
@@ -563,7 +564,8 @@ contract RoundManager is
             TokenType.ERC20,
             round.paymentToken,
             0,
-            eoi.maxAmount
+            eoi.maxAmount,
+            true // Will be used as fee token
         );
 
         createEscrow(agreementId, msg.sender, corpAssets, buyerAssets, eoi.expiry);
@@ -738,7 +740,7 @@ contract RoundManager is
         // loop through certPrinter and add to escrow
         for (uint256 i = 0; i < round.certPrinter.length; i++) {
             escrow.corpAssets.push(
-                Token(TokenType.ERC721, round.certPrinter[i], certIds[i], 1)
+                Token(TokenType.ERC721, round.certPrinter[i], certIds[i], 1, false)
             );
         }
 
@@ -862,6 +864,21 @@ contract RoundManager is
     /// @return IIssuanceManager The issuance manager
     function issuanceManager() public view returns (IIssuanceManager) {
         return RoundManagerStorage.getIssuanceManager();
+    }
+
+    /// @notice Compute fee based on ticket size
+    /// @dev Currently the factory owner (MetaLeX) unilaterally set the fee ratio;
+    /// in the future, it could be determined through a governance process.
+    /// @return Fee amount
+    function computeFee(uint256 size) public override view returns (uint256) {
+        return size * IRoundManagerFactory(RoundManagerStorage.getUpgradeFactory()).getDefaultFeeRatio() / RoundManagerFactoryStorage.BASIS_POINTS;
+    }
+
+    /// @notice Gets the payable address for the fees
+    /// @dev The factory owner (MetaLeX) unilaterally set the payable address
+    /// @return Payable address for the fees
+    function getPlatformPayable() public override view returns (address) {
+        return IRoundManagerFactory(RoundManagerStorage.getUpgradeFactory()).getPlatformPayable();
     }
 
     /// @notice UUPS upgrade authorization

--- a/src/RoundManagerFactory.sol
+++ b/src/RoundManagerFactory.sol
@@ -46,7 +46,7 @@ import "openzeppelin-contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import "openzeppelin-contracts/utils/Create2.sol";
 import "openzeppelin-contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "./libs/auth.sol";
-import {RoundManagerFactoryStorage} from "./storage/RoundManagerFactoryStorage.sol";
+import "./storage/RoundManagerFactoryStorage.sol";
 
 /// @title RoundManagerFactory
 /// @notice Factory contract for deploying RoundManager instances
@@ -55,6 +55,7 @@ contract RoundManagerFactory is UUPSUpgradeable, BorgAuthACL {
     error InvalidSalt();
     error DeploymentFailed();
     error ZeroAddress();
+    error InvalidFeeRatio();
 
     event RoundManagerDeployed(address roundManager, string version);
 
@@ -109,7 +110,7 @@ contract RoundManagerFactory is UUPSUpgradeable, BorgAuthACL {
 
     /// @notice Get the reference implementation contract for the next deployments
     /// @return Current reference implementation contract address
-    function getRefImplementation() public returns(address) {
+    function getRefImplementation() public view returns(address) {
         return RoundManagerFactoryStorage.getRefImplementation();
     }
 
@@ -118,6 +119,36 @@ contract RoundManagerFactory is UUPSUpgradeable, BorgAuthACL {
     /// @param _newImplementation Address of the new implementation
     function setRefImplementation(address _newImplementation) public onlyOwner {
         RoundManagerFactoryStorage.setRefImplementation(_newImplementation);
+    }
+
+    /// @notice Get the payable address for the fees
+    /// @return Payable address for the fees
+    function getPlatformPayable() external view returns (address) {
+        return RoundManagerFactoryStorage.getPlatformPayable();
+    }
+
+    /// @notice Set the payable address for the fees
+    /// @dev Only callable by addresses with the admin role
+    /// @param platformPayable New payable address
+    function setPlatformPayable(address platformPayable) external onlyOwner {
+        RoundManagerFactoryStorage.setPlatformPayable(platformPayable);
+    }
+
+    /// @notice Get the fee ratio
+    /// @return Fee ratio (same unit as BASIS_POINTS
+    function getDefaultFeeRatio() external view returns (uint256) {
+        return RoundManagerFactoryStorage.getDefaultFeeRatio();
+    }
+
+    /// @notice Set the fee ratio
+    /// @dev Only callable by addresses with the admin role. Will check validity of the new value
+    /// @param feeRatio New fee ratio
+    function setDefaultFeeRatio(uint256 feeRatio) external onlyOwner {
+        if (feeRatio > RoundManagerFactoryStorage.BASIS_POINTS) {
+            revert InvalidFeeRatio(); // fee ratio should not exceed 100%
+        }
+
+        RoundManagerFactoryStorage.setDefaultFeeRatio(feeRatio);
     }
 
     function _authorizeUpgrade(

--- a/src/RoundManagerFactory.sol
+++ b/src/RoundManagerFactory.sol
@@ -58,6 +58,7 @@ contract RoundManagerFactory is UUPSUpgradeable, BorgAuthACL {
     error InvalidFeeRatio();
 
     event RoundManagerDeployed(address roundManager, string version);
+    event RefImplementationSet(address refImplementation, string version);
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -119,6 +120,7 @@ contract RoundManagerFactory is UUPSUpgradeable, BorgAuthACL {
     /// @param _newImplementation Address of the new implementation
     function setRefImplementation(address _newImplementation) public onlyOwner {
         RoundManagerFactoryStorage.setRefImplementation(_newImplementation);
+        emit RefImplementationSet(_newImplementation, RoundManager(_newImplementation).DEPLOY_VERSION());
     }
 
     /// @notice Get the payable address for the fees

--- a/src/interfaces/IDealManagerFactory.sol
+++ b/src/interfaces/IDealManagerFactory.sol
@@ -46,5 +46,8 @@ interface IDealManagerFactory {
     function computeDealManagerAddress(bytes32 salt) external view returns (address);
     function initialize(address _auth) external;
 
-    function getRefImplementation() external returns (address);
+    function getRefImplementation() external view returns (address);
+
+    function getDefaultFeeRatio() external view returns (uint256);
+    function getPlatformPayable() external view returns (address);
 }

--- a/src/interfaces/IRoundManagerFactory.sol
+++ b/src/interfaces/IRoundManagerFactory.sol
@@ -44,5 +44,8 @@ pragma solidity 0.8.28;
 interface IRoundManagerFactory {
     function deployRoundManager(bytes32 _salt) external returns (address);
 
-    function getRefImplementation() external returns (address);
+    function getRefImplementation() external view returns (address);
+
+    function getDefaultFeeRatio() external view returns (uint256);
+    function getPlatformPayable() external view returns (address);
 }

--- a/src/libs/LexScroWLite.sol
+++ b/src/libs/LexScroWLite.sol
@@ -71,6 +71,7 @@ abstract contract LexScroWLite is Initializable {
     event DealVoidedAt(bytes32 indexed agreementId, address agreementRegistry, uint256 timestamp);
     event DealPaidAt(bytes32 indexed agreementId, address agreementRegistry, uint256 timestamp);
     event DealFinalizedAt(bytes32 indexed agreementId, address agreementRegistry, uint256 timestamp);
+    event FeeDistributed(bytes32 indexed agreementId, address indexed feeToken, uint256 totalFe);
 
     constructor() {
     }
@@ -171,10 +172,28 @@ abstract contract LexScroWLite is Initializable {
         escrow.status = EscrowStatus.FINALIZED;
         emit DealFinalizedAt(agreementId, LexScrowStorage.getDealRegistry(), block.timestamp);
 
-        // Interaction: Transfer buyer assets to company
+        // Interaction: Transfer buyer assets to company and collect fees
         for(uint256 i = 0; i < escrow.buyerAssets.length; i++) {
             if(escrow.buyerAssets[i].tokenType == TokenType.ERC20) {
-                IERC20(escrow.buyerAssets[i].tokenAddress).safeTransfer(ICyberCorp(LexScrowStorage.getCorp()).companyPayable(), escrow.buyerAssets[i].amount);
+                uint256 amountToCompany = escrow.buyerAssets[i].amount;
+                uint256 fee = 0;
+
+                // Check: if the asset is fee token
+                if (escrow.buyerAssets[i].isFee) {
+                    // Effect: Calculate fees
+                    fee = computeFee(escrow.buyerAssets[i].amount);
+                    amountToCompany -= fee;
+
+                    emit FeeDistributed(agreementId, escrow.buyerAssets[i].tokenAddress, fee);
+                }
+
+                // Interaction: Distribute payment and fees
+                if (amountToCompany > 0) {
+                    IERC20(escrow.buyerAssets[i].tokenAddress).safeTransfer(ICyberCorp(LexScrowStorage.getCorp()).companyPayable(), amountToCompany);
+                }
+                if (fee > 0) {
+                    IERC20(escrow.buyerAssets[i].tokenAddress).safeTransfer(getPlatformPayable(), fee);
+                }
             }
             else if(escrow.buyerAssets[i].tokenType == TokenType.ERC721) {
                 IERC721(escrow.buyerAssets[i].tokenAddress).safeTransferFrom(address(this), ICyberCorp(LexScrowStorage.getCorp()).companyPayable(), escrow.buyerAssets[i].tokenId);
@@ -219,6 +238,16 @@ abstract contract LexScroWLite is Initializable {
     function getEscrowDetails(bytes32 agreementId) public view returns (Escrow memory) {
         return LexScrowStorage.getEscrow(agreementId);
     }
+
+    /// @notice Compute fee based on ticket size
+    /// @dev Child contract should implement the actual logic
+    /// @return Fee amount
+    function computeFee(uint256 size) public virtual view returns (uint256);
+
+    /// @notice Get the payable address for the fees
+    /// @dev Child contract should implement the actual logic
+    /// @return Payable address for the fees
+    function getPlatformPayable() public virtual view returns (address);
 
     //receiver erc721s
     function onERC721Received(address operator, address from, uint256 tokenId, bytes calldata data) external returns (bytes4) {

--- a/src/storage/DealManagerFactoryStorage.sol
+++ b/src/storage/DealManagerFactoryStorage.sol
@@ -49,10 +49,15 @@ library DealManagerFactoryStorage {
     // Storage slot for our struct
     bytes32 constant STORAGE_POSITION = keccak256("cybercorp.deal.manager.factory.storage.v1");
 
+    uint256 public constant BASIS_POINTS = 10000; // 100%
+
     /// @notice Main storage layout struct that holds all persisted data
     /// @dev Uses unstructured storage pattern to avoid storage collisions
     struct DealManagerFactoryData {
         address refImplementation; // implementation contract to use for new deployments
+
+        address platformPayable; // Recipient of platform fees
+        uint256 defaultFeeRatio; // total fee as % of ticket size (BASIS_POINTS = 100%)
     }
 
     /// @notice Retrieves the storage reference for the DealManagerFactoryData struct
@@ -69,7 +74,23 @@ library DealManagerFactoryStorage {
         return dealManagerFactoryStorage().refImplementation;
     }
 
+    function getPlatformPayable() internal view returns (address) {
+        return dealManagerFactoryStorage().platformPayable;
+    }
+
+    function getDefaultFeeRatio() internal view returns (uint256) {
+        return dealManagerFactoryStorage().defaultFeeRatio;
+    }
+
     function setRefImplementation(address newImplementation) internal {
         dealManagerFactoryStorage().refImplementation = newImplementation;
+    }
+
+    function setPlatformPayable(address platformPayable) internal {
+        dealManagerFactoryStorage().platformPayable = platformPayable;
+    }
+
+    function setDefaultFeeRatio(uint256 feeRatio) internal {
+        dealManagerFactoryStorage().defaultFeeRatio = feeRatio;
     }
 }

--- a/src/storage/LexScrowStorage.sol
+++ b/src/storage/LexScrowStorage.sol
@@ -61,6 +61,7 @@ struct Token {
     address tokenAddress;
     uint256 tokenId;
     uint256 amount;
+    bool isFee;
 }
 
 struct Escrow {

--- a/src/storage/RoundManagerFactoryStorage.sol
+++ b/src/storage/RoundManagerFactoryStorage.sol
@@ -49,10 +49,15 @@ library RoundManagerFactoryStorage {
     // Storage slot for our struct
     bytes32 constant STORAGE_POSITION = keccak256("cybercorp.round.manager.factory.storage.v1");
 
+    uint256 public constant BASIS_POINTS = 10000; // 100%
+
     /// @notice Main storage layout struct that holds all persisted data
     /// @dev Uses unstructured storage pattern to avoid storage collisions
     struct RoundManagerFactoryData {
         address refImplementation; // implementation contract to use for new deployments
+
+        address platformPayable; // Recipient of platform fees
+        uint256 defaultFeeRatio; // total fee as % of ticket size (BASIS_POINTS = 100%)
     }
 
     /// @notice Retrieves the storage reference for the RoundManagerFactoryData struct
@@ -69,7 +74,23 @@ library RoundManagerFactoryStorage {
         return roundManagerFactoryStorage().refImplementation;
     }
 
+    function getPlatformPayable() internal view returns (address) {
+        return roundManagerFactoryStorage().platformPayable;
+    }
+
+    function getDefaultFeeRatio() internal view returns (uint256) {
+        return roundManagerFactoryStorage().defaultFeeRatio;
+    }
+
     function setRefImplementation(address newImplementation) internal {
         roundManagerFactoryStorage().refImplementation = newImplementation;
+    }
+
+    function setPlatformPayable(address platformPayable) internal {
+        roundManagerFactoryStorage().platformPayable = platformPayable;
+    }
+
+    function setDefaultFeeRatio(uint256 feeRatio) internal {
+        roundManagerFactoryStorage().defaultFeeRatio = feeRatio;
     }
 }

--- a/test/DealManagerFactoryTest.t.sol
+++ b/test/DealManagerFactoryTest.t.sol
@@ -138,12 +138,14 @@ contract DealManagerFactoryTest is Test {
     }
 
     function test_SetRefImplementation() public  {
-        address newValue = address(0x123);
-        assertNotEq(dmFactory.getRefImplementation(), newValue, "Unexpected refImplementation before set");
+        address newImplementation = address(new MockDealManagerV2());
+        assertNotEq(dmFactory.getRefImplementation(), newImplementation, "Unexpected refImplementation before set");
 
+        vm.expectEmit(true, true, true, true);
+        emit DealManagerFactory.RefImplementationSet(newImplementation, "2");
         vm.prank(owner);
-        dmFactory.setRefImplementation(newValue);
-        assertEq(dmFactory.getRefImplementation(), newValue, "Unexpected refImplementation after set");
+        dmFactory.setRefImplementation(newImplementation);
+        assertEq(dmFactory.getRefImplementation(), newImplementation, "Unexpected refImplementation after set");
     }
 
     function test_RevertIf_SetRefImplementationNonOwner() public {

--- a/test/DealManagerFactoryTest.t.sol
+++ b/test/DealManagerFactoryTest.t.sol
@@ -70,8 +70,11 @@ contract DealManagerFactoryTest is Test {
 
     DealManagerFactory public dmFactory;
 
+    uint256 ownerRole;
+
     function setUp() public {
         bootstrapAuth = new BorgAuth(owner);
+        ownerRole = bootstrapAuth.OWNER_ROLE();
 
         dmFactory = DealManagerFactory(
             address(
@@ -132,5 +135,50 @@ contract DealManagerFactoryTest is Test {
         vm.expectRevert(abi.encodeWithSelector(BorgAuth.BorgAuth_NotAuthorized.selector, bootstrapAuth.OWNER_ROLE(), companyOwner));
         vm.prank(companyOwner);
         dmFactory.upgradeToAndCall(newFactoryImpl, "");
+    }
+
+    function test_SetRefImplementation() public  {
+        address newValue = address(0x123);
+        assertNotEq(dmFactory.getRefImplementation(), newValue, "Unexpected refImplementation before set");
+
+        vm.prank(owner);
+        dmFactory.setRefImplementation(newValue);
+        assertEq(dmFactory.getRefImplementation(), newValue, "Unexpected refImplementation after set");
+    }
+
+    function test_RevertIf_SetRefImplementationNonOwner() public {
+        vm.prank(companyOwner);
+        vm.expectRevert(abi.encodeWithSelector(BorgAuth.BorgAuth_NotAuthorized.selector, ownerRole, companyOwner));
+        dmFactory.setRefImplementation(address(0x123));
+    }
+
+    function test_SetPlatformPayable() public  {
+        address newValue = address(0x123);
+        assertNotEq(dmFactory.getPlatformPayable(), newValue, "Unexpected platformPayable before set");
+
+        vm.prank(owner);
+        dmFactory.setPlatformPayable(newValue);
+        assertEq(dmFactory.getPlatformPayable(), newValue, "Unexpected platformPayable after set");
+    }
+
+    function test_RevertIf_SetPlatformPayableNonOwner() public {
+        vm.prank(companyOwner);
+        vm.expectRevert(abi.encodeWithSelector(BorgAuth.BorgAuth_NotAuthorized.selector, ownerRole, companyOwner));
+        dmFactory.setPlatformPayable(address(0x123));
+    }
+
+    function test_SetDefaultFeeRatio() public  {
+        uint256 newValue = 123;
+        assertNotEq(dmFactory.getDefaultFeeRatio(), newValue, "Unexpected defaultFeeRatio before set");
+
+        vm.prank(owner);
+        dmFactory.setDefaultFeeRatio(newValue);
+        assertEq(dmFactory.getDefaultFeeRatio(), newValue, "Unexpected defaultFeeRatio after set");
+    }
+
+    function test_RevertIf_SetDefaultFeeRatioNonOwner() public {
+        vm.prank(companyOwner);
+        vm.expectRevert(abi.encodeWithSelector(BorgAuth.BorgAuth_NotAuthorized.selector, ownerRole, companyOwner));
+        dmFactory.setDefaultFeeRatio(123);
     }
 }

--- a/test/LexScroWLiteTest.t.sol
+++ b/test/LexScroWLiteTest.t.sol
@@ -145,6 +145,14 @@ contract LexScroWLiteMock is LexScroWLite {
             LexScrowStorage.addConditionToEscrow(agreementId, ICondition(conditions[i]));
         }
     }
+
+    function computeFee(uint256 size) public override view returns (uint256) {
+        return 0; // Not in use
+    }
+
+    function getPlatformPayable() public override view returns (address) {
+        return address(0); // Not in use
+    }
 }
 
 contract CyberAgreementRegistryMock {
@@ -445,13 +453,15 @@ contract LexScroWLiteTest is Test {
             tokenType: TokenType.ERC20,
             tokenAddress: address(corpTokenErc20),
             tokenId: 0,
-            amount: 10 ether
+            amount: 10 ether,
+            isFee: false
         });
         corpAssets[1] = Token({
             tokenType: TokenType.ERC1155,
             tokenAddress: address(corpTokenErc1155),
             tokenId: corpTokenErc1155Id,
-            amount: 10 ether
+            amount: 10 ether,
+            isFee: false
         });
         Token[] memory buyerAssets = _getBuyerAssets();
 
@@ -474,7 +484,8 @@ contract LexScroWLiteTest is Test {
             tokenType: TokenType.ERC721,
             tokenAddress: address(corpTokenErc721WithEndorsement),
             tokenId: corpTokenErc721Id,
-            amount: 1
+            amount: 1,
+            isFee: false
         });
         Token[] memory buyerAssets = _getBuyerAssets();
 
@@ -556,19 +567,22 @@ contract LexScroWLiteTest is Test {
             tokenType: TokenType.ERC20,
             tokenAddress: address(corpTokenErc20),
             tokenId: 0,
-            amount: 10 ether
+            amount: 10 ether,
+            isFee: false
         });
         corpAssets[1] = Token({
             tokenType: TokenType.ERC721,
             tokenAddress: address(corpTokenErc721),
             tokenId: corpTokenErc721Id,
-            amount: 1
+            amount: 1,
+            isFee: false
         });
         corpAssets[2] = Token({
             tokenType: TokenType.ERC1155,
             tokenAddress: address(corpTokenErc1155),
             tokenId: corpTokenErc1155Id,
-            amount: 10 ether
+            amount: 10 ether,
+            isFee: false
         });
         return corpAssets;
     }
@@ -579,19 +593,22 @@ contract LexScroWLiteTest is Test {
             tokenType: TokenType.ERC20,
             tokenAddress: address(buyerTokenErc20),
             tokenId: 0,
-            amount: 100 ether
+            amount: 100 ether,
+            isFee: false
         });
         buyerAssets[1] = Token({
             tokenType: TokenType.ERC721,
             tokenAddress: address(buyerTokenErc721),
             tokenId: buyerTokenErc721Id,
-            amount: 1
+            amount: 1,
+            isFee: false
         });
         buyerAssets[2] = Token({
             tokenType: TokenType.ERC1155,
             tokenAddress: address(buyerTokenErc1155),
             tokenId: buyerTokenErc1155Id,
-            amount: 100 ether
+            amount: 100 ether,
+            isFee: false
         });
         return buyerAssets;
     }

--- a/test/RoundManagerFactoryTest.t.sol
+++ b/test/RoundManagerFactoryTest.t.sol
@@ -138,12 +138,14 @@ contract RoundManagerFactoryTest is Test {
     }
 
     function test_SetRefImplementation() public  {
-        address newValue = address(0x123);
-        assertNotEq(rmFactory.getRefImplementation(), newValue, "Unexpected refImplementation before set");
+        address newImplementation = address(new MockRoundManagerV2());
+        assertNotEq(rmFactory.getRefImplementation(), newImplementation, "Unexpected refImplementation before set");
 
+        vm.expectEmit(true, true, true, true);
+        emit RoundManagerFactory.RefImplementationSet(newImplementation, "2");
         vm.prank(owner);
-        rmFactory.setRefImplementation(newValue);
-        assertEq(rmFactory.getRefImplementation(), newValue, "Unexpected refImplementation after set");
+        rmFactory.setRefImplementation(newImplementation);
+        assertEq(rmFactory.getRefImplementation(), newImplementation, "Unexpected refImplementation after set");
     }
 
     function test_RevertIf_SetRefImplementationNonOwner() public {

--- a/test/RoundManagerFactoryTest.t.sol
+++ b/test/RoundManagerFactoryTest.t.sol
@@ -70,8 +70,11 @@ contract RoundManagerFactoryTest is Test {
 
     RoundManagerFactory public rmFactory;
 
+    uint256 ownerRole;
+
     function setUp() public {
         bootstrapAuth = new BorgAuth(owner);
+        ownerRole = bootstrapAuth.OWNER_ROLE();
 
         rmFactory = RoundManagerFactory(
             address(
@@ -132,5 +135,50 @@ contract RoundManagerFactoryTest is Test {
         vm.expectRevert(abi.encodeWithSelector(BorgAuth.BorgAuth_NotAuthorized.selector, bootstrapAuth.OWNER_ROLE(), companyOwner));
         vm.prank(companyOwner);
         rmFactory.upgradeToAndCall(newFactoryImpl, "");
+    }
+
+    function test_SetRefImplementation() public  {
+        address newValue = address(0x123);
+        assertNotEq(rmFactory.getRefImplementation(), newValue, "Unexpected refImplementation before set");
+
+        vm.prank(owner);
+        rmFactory.setRefImplementation(newValue);
+        assertEq(rmFactory.getRefImplementation(), newValue, "Unexpected refImplementation after set");
+    }
+
+    function test_RevertIf_SetRefImplementationNonOwner() public {
+        vm.prank(companyOwner);
+        vm.expectRevert(abi.encodeWithSelector(BorgAuth.BorgAuth_NotAuthorized.selector, ownerRole, companyOwner));
+        rmFactory.setRefImplementation(address(0x123));
+    }
+
+    function test_SetPlatformPayable() public  {
+        address newValue = address(0x123);
+        assertNotEq(rmFactory.getPlatformPayable(), newValue, "Unexpected platformPayable before set");
+
+        vm.prank(owner);
+        rmFactory.setPlatformPayable(newValue);
+        assertEq(rmFactory.getPlatformPayable(), newValue, "Unexpected platformPayable after set");
+    }
+
+    function test_RevertIf_SetPlatformPayableNonOwner() public {
+        vm.prank(companyOwner);
+        vm.expectRevert(abi.encodeWithSelector(BorgAuth.BorgAuth_NotAuthorized.selector, ownerRole, companyOwner));
+        rmFactory.setPlatformPayable(address(0x123));
+    }
+
+    function test_SetDefaultFeeRatio() public  {
+        uint256 newValue = 123;
+        assertNotEq(rmFactory.getDefaultFeeRatio(), newValue, "Unexpected defaultFeeRatio before set");
+
+        vm.prank(owner);
+        rmFactory.setDefaultFeeRatio(newValue);
+        assertEq(rmFactory.getDefaultFeeRatio(), newValue, "Unexpected defaultFeeRatio after set");
+    }
+
+    function test_RevertIf_SetDefaultFeeRatioNonOwner() public {
+        vm.prank(companyOwner);
+        vm.expectRevert(abi.encodeWithSelector(BorgAuth.BorgAuth_NotAuthorized.selector, ownerRole, companyOwner));
+        rmFactory.setDefaultFeeRatio(123);
     }
 }


### PR DESCRIPTION
## Specs (simplified)

https://www.notion.so/RoundManager-Fees-27f5821ee76780fc8243cf820296a255?source=copy_link#2845821ee767803e98fffa4dd8619276

## Changes vs #51

- Reduced to a single fee parameter `defaultFeeRatio`
- No governance, all parameters set unilaterally by factory owner
- Simplified architectures so existing deployments are direct upgradeable without needs for explicit data migration