### PR TITLE
Per-Instance Fee Override for RoundManagers

### DIFF
--- a/src/RoundManager.sol
+++ b/src/RoundManager.sol
@@ -568,7 +568,7 @@ contract RoundManager is
     /// in the future, it could be determined through a governance process.
     /// @return Fee amount
     function computeFee(uint256 size) public override view returns (uint256) {
-        return size * IRoundManagerFactory(RoundManagerStorage.getUpgradeFactory()).getDefaultFeeRatio() / RoundManagerFactoryStorage.BASIS_POINTS;
+        return size * IRoundManagerFactory(RoundManagerStorage.getUpgradeFactory()).getFeeRatio() / RoundManagerFactoryStorage.BASIS_POINTS;
     }
 
     /// @notice Gets the payable address for the fees

--- a/src/RoundManager.sol
+++ b/src/RoundManager.sol
@@ -568,7 +568,7 @@ contract RoundManager is
     /// in the future, it could be determined through a governance process.
     /// @return Fee amount
     function computeFee(uint256 size) public override view returns (uint256) {
-        return size * IRoundManagerFactory(RoundManagerStorage.getUpgradeFactory()).getFeeRatio() / RoundManagerFactoryStorage.BASIS_POINTS;
+        return size * IRoundManagerFactory(RoundManagerStorage.getUpgradeFactory()).getDefaultFeeRatio() / RoundManagerFactoryStorage.BASIS_POINTS;
     }
 
     /// @notice Gets the payable address for the fees

--- a/src/RoundManagerFactory.sol
+++ b/src/RoundManagerFactory.sol
@@ -139,27 +139,35 @@ contract RoundManagerFactory is UUPSUpgradeable, BorgAuthACL {
         RoundManagerFactoryStorage.setPlatformPayable(platformPayable);
     }
 
-    /// @notice Get the fee ratio
-    /// @return Fee ratio (same unit as BASIS_POINTS
-    function getDefaultFeeRatio() external view returns (uint256) {
-        return RoundManagerFactoryStorage.getDefaultFeeRatio();
-    }
-
     /// @notice Get the effective fee ratio for the calling RoundManager instance.
     /// @dev Returns the instance-specific override if set, otherwise the global default.
     ///      Intended to be called by RoundManager instances (msg.sender = the RoundManager address).
+    ///      We intentionally name it `getDefaultFeeRatio` for backward compatibility so that older RoundManagers can
+    ///      still utilize the fee overrides.
     /// @return Fee ratio (same unit as BASIS_POINTS)
-    function getFeeRatio() external view returns (uint256) {
-        (bool enabled, uint256 ratio) = RoundManagerFactoryStorage.getInstanceFeeOverride(msg.sender);
-        if (enabled) return ratio;
-        return RoundManagerFactoryStorage.getDefaultFeeRatio();
+    function getDefaultFeeRatio() external view returns (uint256) {
+        RoundManagerFactoryStorage.RoundManagerFactoryData storage s = RoundManagerFactoryStorage.roundManagerFactoryStorage();
+        RoundManagerFactoryStorage.FeeOverride storage fo = s.instanceFeeOverrides[msg.sender];
+        return fo.enabled ? fo.ratio : s.defaultFeeRatio;
+    }
+
+    /// @notice Get the underlying default fee ratio without overrides
+    /// @return Fee ratio (same unit as BASIS_POINTS
+    function getUnderlyingDefaultFeeRatio() external view returns (uint256) {
+        return RoundManagerFactoryStorage.roundManagerFactoryStorage().defaultFeeRatio;
+    }
+
+    /// @notice Get the per-instance fee override for a specific RoundManager
+    /// @return Fee override configs
+    function getInstanceFeeOverride(address roundManager) external view returns (RoundManagerFactoryStorage.FeeOverride memory) {
+        return RoundManagerFactoryStorage.roundManagerFactoryStorage().instanceFeeOverrides[roundManager];
     }
 
     /// @notice Set a per-instance fee override for a specific RoundManager
     /// @dev Only callable by the factory owner. Pass has=false to remove the override.
     function setInstanceFeeOverride(address roundManager, bool enabled, uint256 ratio) external onlyOwner {
         if (ratio > RoundManagerFactoryStorage.BASIS_POINTS) revert InvalidFeeRatio();
-        RoundManagerFactoryStorage.setInstanceFeeOverride(roundManager, enabled, ratio);
+        RoundManagerFactoryStorage.roundManagerFactoryStorage().instanceFeeOverrides[roundManager] = RoundManagerFactoryStorage.FeeOverride(enabled, ratio);
         emit InstanceFeeOverrideSet(roundManager, enabled, ratio);
     }
 

--- a/src/RoundManagerFactory.sol
+++ b/src/RoundManagerFactory.sol
@@ -42,6 +42,7 @@ except with the express prior written permission of the copyright holder.*/
 pragma solidity 0.8.28;
 
 import "./RoundManager.sol";
+import {FeeOverride} from "./interfaces/IRoundManagerFactory.sol";
 import "openzeppelin-contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import "openzeppelin-contracts/utils/Create2.sol";
 import "openzeppelin-contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
@@ -60,7 +61,7 @@ contract RoundManagerFactory is UUPSUpgradeable, BorgAuthACL {
     event RoundManagerDeployed(address roundManager, string version);
     event RefImplementationSet(address refImplementation, string version);
     event TokenWhitelistUpdated(address token, bool isWhitelisted);
-    event InstanceFeeOverrideSet(address indexed roundManager, bool has, uint256 ratio);
+    event InstanceFeeOverrideSet(address indexed roundManager, bool enabled, uint256 ratio);
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -147,7 +148,7 @@ contract RoundManagerFactory is UUPSUpgradeable, BorgAuthACL {
     /// @return Fee ratio (same unit as BASIS_POINTS)
     function getDefaultFeeRatio() external view returns (uint256) {
         RoundManagerFactoryStorage.RoundManagerFactoryData storage s = RoundManagerFactoryStorage.roundManagerFactoryStorage();
-        RoundManagerFactoryStorage.FeeOverride storage fo = s.instanceFeeOverrides[msg.sender];
+        FeeOverride storage fo = s.instanceFeeOverrides[msg.sender];
         return fo.enabled ? fo.ratio : s.defaultFeeRatio;
     }
 
@@ -159,15 +160,15 @@ contract RoundManagerFactory is UUPSUpgradeable, BorgAuthACL {
 
     /// @notice Get the per-instance fee override for a specific RoundManager
     /// @return Fee override configs
-    function getInstanceFeeOverride(address roundManager) external view returns (RoundManagerFactoryStorage.FeeOverride memory) {
+    function getInstanceFeeOverride(address roundManager) external view returns (FeeOverride memory) {
         return RoundManagerFactoryStorage.roundManagerFactoryStorage().instanceFeeOverrides[roundManager];
     }
 
     /// @notice Set a per-instance fee override for a specific RoundManager
-    /// @dev Only callable by the factory owner. Pass has=false to remove the override.
+    /// @dev Only callable by the factory owner. Pass enabled=false to remove the override.
     function setInstanceFeeOverride(address roundManager, bool enabled, uint256 ratio) external onlyOwner {
         if (ratio > RoundManagerFactoryStorage.BASIS_POINTS) revert InvalidFeeRatio();
-        RoundManagerFactoryStorage.roundManagerFactoryStorage().instanceFeeOverrides[roundManager] = RoundManagerFactoryStorage.FeeOverride(enabled, ratio);
+        RoundManagerFactoryStorage.roundManagerFactoryStorage().instanceFeeOverrides[roundManager] = FeeOverride(enabled, ratio);
         emit InstanceFeeOverrideSet(roundManager, enabled, ratio);
     }
 

--- a/src/RoundManagerFactory.sol
+++ b/src/RoundManagerFactory.sol
@@ -60,6 +60,7 @@ contract RoundManagerFactory is UUPSUpgradeable, BorgAuthACL {
     event RoundManagerDeployed(address roundManager, string version);
     event RefImplementationSet(address refImplementation, string version);
     event TokenWhitelistUpdated(address token, bool isWhitelisted);
+    event InstanceFeeOverrideSet(address indexed roundManager, bool has, uint256 ratio);
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -142,6 +143,24 @@ contract RoundManagerFactory is UUPSUpgradeable, BorgAuthACL {
     /// @return Fee ratio (same unit as BASIS_POINTS
     function getDefaultFeeRatio() external view returns (uint256) {
         return RoundManagerFactoryStorage.getDefaultFeeRatio();
+    }
+
+    /// @notice Get the effective fee ratio for the calling RoundManager instance.
+    /// @dev Returns the instance-specific override if set, otherwise the global default.
+    ///      Intended to be called by RoundManager instances (msg.sender = the RoundManager address).
+    /// @return Fee ratio (same unit as BASIS_POINTS)
+    function getFeeRatio() external view returns (uint256) {
+        (bool enabled, uint256 ratio) = RoundManagerFactoryStorage.getInstanceFeeOverride(msg.sender);
+        if (enabled) return ratio;
+        return RoundManagerFactoryStorage.getDefaultFeeRatio();
+    }
+
+    /// @notice Set a per-instance fee override for a specific RoundManager
+    /// @dev Only callable by the factory owner. Pass has=false to remove the override.
+    function setInstanceFeeOverride(address roundManager, bool enabled, uint256 ratio) external onlyOwner {
+        if (ratio > RoundManagerFactoryStorage.BASIS_POINTS) revert InvalidFeeRatio();
+        RoundManagerFactoryStorage.setInstanceFeeOverride(roundManager, enabled, ratio);
+        emit InstanceFeeOverrideSet(roundManager, enabled, ratio);
     }
 
     /// @notice Set the fee ratio

--- a/src/interfaces/IRoundManagerFactory.sol
+++ b/src/interfaces/IRoundManagerFactory.sol
@@ -53,7 +53,7 @@ interface IRoundManagerFactory {
 
     function getDefaultFeeRatio() external view returns (uint256);
     function getUnderlyingDefaultFeeRatio() external view returns (uint256);
-    function getInstanceFeeOverride(address roundManager) external returns (FeeOverride);
+    function getInstanceFeeOverride(address roundManager) external view returns (FeeOverride);
     function setInstanceFeeOverride(address roundManager, bool has, uint256 ratio) external;
     function getPlatformPayable() external view returns (address);
     function isWhitelistedToken(address token) external view returns (bool);

--- a/src/interfaces/IRoundManagerFactory.sol
+++ b/src/interfaces/IRoundManagerFactory.sol
@@ -41,20 +41,20 @@ except with the express prior written permission of the copyright holder.*/
 
 pragma solidity 0.8.28;
 
-interface IRoundManagerFactory {
-    struct FeeOverride {
-        bool enabled;
-        uint256 ratio;
-    }
+struct FeeOverride {
+    bool enabled;
+    uint256 ratio;
+}
 
+interface IRoundManagerFactory {
     function deployRoundManager(bytes32 _salt) external returns (address);
 
     function getRefImplementation() external view returns (address);
 
     function getDefaultFeeRatio() external view returns (uint256);
     function getUnderlyingDefaultFeeRatio() external view returns (uint256);
-    function getInstanceFeeOverride(address roundManager) external view returns (FeeOverride);
-    function setInstanceFeeOverride(address roundManager, bool has, uint256 ratio) external;
+    function getInstanceFeeOverride(address roundManager) external view returns (FeeOverride memory);
+    function setInstanceFeeOverride(address roundManager, bool enabled, uint256 ratio) external;
     function getPlatformPayable() external view returns (address);
     function isWhitelistedToken(address token) external view returns (bool);
     function setWhitelistedToken(address token, bool isWhitelisted) external;

--- a/src/interfaces/IRoundManagerFactory.sol
+++ b/src/interfaces/IRoundManagerFactory.sol
@@ -47,6 +47,8 @@ interface IRoundManagerFactory {
     function getRefImplementation() external view returns (address);
 
     function getDefaultFeeRatio() external view returns (uint256);
+    function getFeeRatio() external view returns (uint256);
+    function setInstanceFeeOverride(address roundManager, bool has, uint256 ratio) external;
     function getPlatformPayable() external view returns (address);
     function isWhitelistedToken(address token) external view returns (bool);
     function setWhitelistedToken(address token, bool isWhitelisted) external;

--- a/src/interfaces/IRoundManagerFactory.sol
+++ b/src/interfaces/IRoundManagerFactory.sol
@@ -42,12 +42,18 @@ except with the express prior written permission of the copyright holder.*/
 pragma solidity 0.8.28;
 
 interface IRoundManagerFactory {
+    struct FeeOverride {
+        bool enabled;
+        uint256 ratio;
+    }
+
     function deployRoundManager(bytes32 _salt) external returns (address);
 
     function getRefImplementation() external view returns (address);
 
     function getDefaultFeeRatio() external view returns (uint256);
-    function getFeeRatio() external view returns (uint256);
+    function getUnderlyingDefaultFeeRatio() external view returns (uint256);
+    function getInstanceFeeOverride(address roundManager) external returns (FeeOverride);
     function setInstanceFeeOverride(address roundManager, bool has, uint256 ratio) external;
     function getPlatformPayable() external view returns (address);
     function isWhitelistedToken(address token) external view returns (bool);

--- a/src/storage/RoundManagerFactoryStorage.sol
+++ b/src/storage/RoundManagerFactoryStorage.sol
@@ -108,13 +108,4 @@ library RoundManagerFactoryStorage {
     function setWhitelistedToken(address token, bool status) internal {
         roundManagerFactoryStorage().whitelistedTokens[token] = status;
     }
-
-    function getInstanceFeeOverride(address roundManager) internal view returns (bool, uint256) {
-        FeeOverride storage fo = roundManagerFactoryStorage().instanceFeeOverrides[roundManager];
-        return (fo.enabled, fo.ratio);
-    }
-
-    function setInstanceFeeOverride(address roundManager, bool enabled, uint256 ratio) internal {
-        roundManagerFactoryStorage().instanceFeeOverrides[roundManager] = FeeOverride(enabled, ratio);
-    }
 }

--- a/src/storage/RoundManagerFactoryStorage.sol
+++ b/src/storage/RoundManagerFactoryStorage.sol
@@ -51,6 +51,11 @@ library RoundManagerFactoryStorage {
 
     uint256 public constant BASIS_POINTS = 10000; // 100%
 
+    struct FeeOverride {
+        bool enabled;
+        uint256 ratio;
+    }
+
     /// @notice Main storage layout struct that holds all persisted data
     /// @dev Uses unstructured storage pattern to avoid storage collisions
     struct RoundManagerFactoryData {
@@ -59,6 +64,7 @@ library RoundManagerFactoryStorage {
         address platformPayable; // Recipient of platform fees
         uint256 defaultFeeRatio; // total fee as % of ticket size (BASIS_POINTS = 100%)
         mapping(address => bool) whitelistedTokens;
+        mapping(address => FeeOverride) instanceFeeOverrides; // RoundManager -> FeeOverride
     }
 
     /// @notice Retrieves the storage reference for the RoundManagerFactoryData struct
@@ -101,5 +107,14 @@ library RoundManagerFactoryStorage {
 
     function setWhitelistedToken(address token, bool status) internal {
         roundManagerFactoryStorage().whitelistedTokens[token] = status;
+    }
+
+    function getInstanceFeeOverride(address roundManager) internal view returns (bool, uint256) {
+        FeeOverride storage fo = roundManagerFactoryStorage().instanceFeeOverrides[roundManager];
+        return (fo.enabled, fo.ratio);
+    }
+
+    function setInstanceFeeOverride(address roundManager, bool enabled, uint256 ratio) internal {
+        roundManagerFactoryStorage().instanceFeeOverrides[roundManager] = FeeOverride(enabled, ratio);
     }
 }

--- a/src/storage/RoundManagerFactoryStorage.sol
+++ b/src/storage/RoundManagerFactoryStorage.sol
@@ -42,6 +42,8 @@
 
 pragma solidity 0.8.28;
 
+import {FeeOverride} from "../interfaces/IRoundManagerFactory.sol";
+
 /// @title RoundManagerFactoryStorage
 /// @notice Storage library for the RoundManagerFactory contract that handles persistent data storage
 /// @dev Uses the unstructured storage pattern to manage factory-related data
@@ -50,11 +52,6 @@ library RoundManagerFactoryStorage {
     bytes32 constant STORAGE_POSITION = keccak256("cybercorp.round.manager.factory.storage.v1");
 
     uint256 public constant BASIS_POINTS = 10000; // 100%
-
-    struct FeeOverride {
-        bool enabled;
-        uint256 ratio;
-    }
 
     /// @notice Main storage layout struct that holds all persisted data
     /// @dev Uses unstructured storage pattern to avoid storage collisions

--- a/test/RoundManagerFactoryTest.t.sol
+++ b/test/RoundManagerFactoryTest.t.sol
@@ -188,11 +188,11 @@ contract RoundManagerFactoryTest is Test {
 
     function test_SetDefaultFeeRatio() public  {
         uint256 newValue = 123;
-        assertNotEq(rmFactory.getDefaultFeeRatio(), newValue, "Unexpected defaultFeeRatio before set");
+        assertNotEq(rmFactory.getUnderlyingDefaultFeeRatio(), newValue, "Unexpected defaultFeeRatio before set");
 
         vm.prank(owner);
         rmFactory.setDefaultFeeRatio(newValue);
-        assertEq(rmFactory.getDefaultFeeRatio(), newValue, "Unexpected defaultFeeRatio after set");
+        assertEq(rmFactory.getUnderlyingDefaultFeeRatio(), newValue, "Unexpected defaultFeeRatio after set");
     }
 
     function test_RevertIf_SetDefaultFeeRatioNonOwner() public {
@@ -213,7 +213,7 @@ contract RoundManagerFactoryTest is Test {
 
         // Any address with no instance override returns the global default
         vm.prank(address(0x1234));
-        assertEq(rmFactory.getFeeRatio(), 500);
+        assertEq(rmFactory.getDefaultFeeRatio(), 500);
     }
 
     function test_SetInstanceFeeOverride() public {
@@ -224,9 +224,9 @@ contract RoundManagerFactoryTest is Test {
         rmFactory.setInstanceFeeOverride(rm, true, 0);
         vm.stopPrank();
 
-        // getFeeRatio called from rm should return 0, not the global 500
+        // getDefaultFeeRatio called from rm should return 0, not the global 500
         vm.prank(rm);
-        assertEq(rmFactory.getFeeRatio(), 0);
+        assertEq(rmFactory.getDefaultFeeRatio(), 0);
     }
 
     function test_RevertIf_SetInstanceFeeOverrideNonOwner() public {
@@ -254,13 +254,13 @@ contract RoundManagerFactoryTest is Test {
         vm.stopPrank();
 
         vm.prank(rm);
-        assertEq(rmFactory.getFeeRatio(), 0, "override should be active");
+        assertEq(rmFactory.getDefaultFeeRatio(), 0, "override should be active");
 
         vm.prank(owner);
         rmFactory.setInstanceFeeOverride(rm, false, 0);
 
         vm.prank(rm);
-        assertEq(rmFactory.getFeeRatio(), 500, "should fall back to global default after override cleared");
+        assertEq(rmFactory.getDefaultFeeRatio(), 500, "should fall back to global default after override cleared");
     }
 
     function test_InstanceFeeOverrideSet_EventEmitted() public {

--- a/test/RoundManagerFactoryTest.t.sol
+++ b/test/RoundManagerFactoryTest.t.sol
@@ -206,4 +206,69 @@ contract RoundManagerFactoryTest is Test {
         vm.expectRevert(RoundManagerFactory.InvalidFeeRatio.selector);
         rmFactory.setDefaultFeeRatio(RoundManagerFactoryStorage.BASIS_POINTS + 1);
     }
+
+    function test_GetFeeRatio_FallsBackToGlobalDefault() public {
+        vm.prank(owner);
+        rmFactory.setDefaultFeeRatio(500);
+
+        // Any address with no instance override returns the global default
+        vm.prank(address(0x1234));
+        assertEq(rmFactory.getFeeRatio(), 500);
+    }
+
+    function test_SetInstanceFeeOverride() public {
+        address rm = rmFactory.deployRoundManager(keccak256("test_SetInstanceFeeOverride"));
+
+        vm.startPrank(owner);
+        rmFactory.setDefaultFeeRatio(500);
+        rmFactory.setInstanceFeeOverride(rm, true, 0);
+        vm.stopPrank();
+
+        // getFeeRatio called from rm should return 0, not the global 500
+        vm.prank(rm);
+        assertEq(rmFactory.getFeeRatio(), 0);
+    }
+
+    function test_RevertIf_SetInstanceFeeOverrideNonOwner() public {
+        address rm = rmFactory.deployRoundManager(keccak256("test_SetInstanceFeeOverrideNonOwner"));
+
+        vm.prank(companyOwner);
+        vm.expectRevert(abi.encodeWithSelector(BorgAuth.BorgAuth_NotAuthorized.selector, ownerRole, companyOwner));
+        rmFactory.setInstanceFeeOverride(rm, true, 0);
+    }
+
+    function test_RevertIf_SetInstanceFeeOverrideInvalid() public {
+        address rm = rmFactory.deployRoundManager(keccak256("test_SetInstanceFeeOverrideInvalid"));
+
+        vm.prank(owner);
+        vm.expectRevert(RoundManagerFactory.InvalidFeeRatio.selector);
+        rmFactory.setInstanceFeeOverride(rm, true, RoundManagerFactoryStorage.BASIS_POINTS + 1);
+    }
+
+    function test_ClearInstanceFeeOverride() public {
+        address rm = rmFactory.deployRoundManager(keccak256("test_ClearInstanceFeeOverride"));
+
+        vm.startPrank(owner);
+        rmFactory.setDefaultFeeRatio(500);
+        rmFactory.setInstanceFeeOverride(rm, true, 0);
+        vm.stopPrank();
+
+        vm.prank(rm);
+        assertEq(rmFactory.getFeeRatio(), 0, "override should be active");
+
+        vm.prank(owner);
+        rmFactory.setInstanceFeeOverride(rm, false, 0);
+
+        vm.prank(rm);
+        assertEq(rmFactory.getFeeRatio(), 500, "should fall back to global default after override cleared");
+    }
+
+    function test_InstanceFeeOverrideSet_EventEmitted() public {
+        address rm = rmFactory.deployRoundManager(keccak256("test_InstanceFeeOverrideSet_EventEmitted"));
+
+        vm.expectEmit(true, false, false, true);
+        emit RoundManagerFactory.InstanceFeeOverrideSet(rm, true, 0);
+        vm.prank(owner);
+        rmFactory.setInstanceFeeOverride(rm, true, 0);
+    }
 }


### PR DESCRIPTION
RoundManagerFactory fee configuration was global — all RoundManagers used the same `defaultFeeRatio`.
                                                                                                                                                                                        
Add per-instance fee overrides stored in RoundManagerFactory. The factory owner can set a fee ratio for a specific RoundManager independently of the global default. As a result, new corp factories could automatically sets zero fees on every RoundManager it deploys.
                                                                                                                                                                                        
Design Decisions

  - Overrides live in the factory, not the RoundManager — only the factory owner can set or change them; corp owners have no access                                                     
  - Updated `getDefaultFeeRatio()` so it is instance-aware: checks `instanceFeeOverrides[msg.sender]` first, then falls back to global default
  - Added `getUnderlyingDefaultFeeRatio()` so we have access to the global default as before
  - `RoundManager.computeFee()` remain unchanged: it still uses `getDefaultFeeRatio()` so the fee overrides applies to existing Round Managers, too