### PR TITLE
Feat/zkpassport condition founder override

### DIFF
--- a/script/deploy-non-us-zkpassport-condition.s.sol
+++ b/script/deploy-non-us-zkpassport-condition.s.sol
@@ -12,20 +12,31 @@ contract DeployNonUsZkPassportConditionScript is Script {
     function run() public returns (BorgAuth zkpassportAuth, NonUSNationalityCondition zkpassportCondition) {
         return runWithArgs(
             // Production
-            "MetaLexCyberCorp.NonUSNationalityZkpassport.V1.0.0",
+            "MetaLexCyberCorp.NonUSNationalityZkpassport.V1.1.0",
             vm.envUint("PRIVATE_KEY_MAIN"),
             "ace.metalex.tech",
             "non-us-non-sanctioned",
             2592000, // 3600 * 24 * 30 days
-            DeploymentConstants.BASE
+            DeploymentConstants.BASE,
+            false // ownedByDeployer
 
-//            // Staging
-//            "MetaLexCyberCorp.NonUSNationalityZkpassport.V1.0.0.staging.dev1",
+//            // Staging (localhost)
+//            "MetaLexCyberCorp.NonUSNationalityZkpassport.V1.1.0.staging.dev1",
+//            vm.envUint("PRIVATE_KEY_MAIN"),
+//            "localhost",
+//            "non-us-non-sanctioned",
+//            2592000, // 3600 * 24 * 30 days
+//            DeploymentConstants.BASE,
+//            true // ownedByDeployer
+
+//            // Staging (staging.ace.metalex.tech)
+//            "MetaLexCyberCorp.NonUSNationalityZkpassport.V1.1.0.staging.dev1-staging.ace.metalex.tech",
 //            vm.envUint("PRIVATE_KEY_MAIN"),
 //            "staging.ace.metalex.tech",
 //            "non-us-non-sanctioned",
 //            2592000, // 3600 * 24 * 30 days
-//            DeploymentConstants.BASE
+//            DeploymentConstants.BASE,
+//            true // ownedByDeployer
         );
     }
 
@@ -35,7 +46,8 @@ contract DeployNonUsZkPassportConditionScript is Script {
         string memory expectedDomain,
         string memory expectedScope,
         uint256 maxValidityPeriod,
-        uint256 chainId
+        uint256 chainId,
+        bool ownedByDeployer // for test because our staging env is Base mainnet
     ) public returns (BorgAuth zkpassportAuth, NonUSNationalityCondition zkpassportCondition) {
 
         bytes32 salt = keccak256(bytes(saltStr));
@@ -74,6 +86,15 @@ contract DeployNonUsZkPassportConditionScript is Script {
         orAddrs[0] = address(zkpassportCondition);
         orAddrs[1] = deployment.lexchexCondition;
         OrCondition orCondition = new OrCondition(orAddrs);
+
+        if (!ownedByDeployer) {
+            // Assign ownership to MetaLeX multisig
+            zkpassportAuth.updateRole(deployment.metalexSafe, zkpassportAuth.OWNER_ROLE());
+
+            // Deployer to self-revoke ownership
+            zkpassportAuth.zeroOwner();
+            console2.log("Transferred ownership to %s:", deployment.metalexSafe);
+        }
 
         vm.stopBroadcast();
 

--- a/src/libs/conditions/NonUSNationalityCondition.sol
+++ b/src/libs/conditions/NonUSNationalityCondition.sol
@@ -8,6 +8,10 @@ import "../LexScroWLite.sol";
 import "../auth.sol";
 import "../../interfaces/IZKPassportVerifier.sol";
 
+interface ICyberCorpManager {
+    function AUTH() external view returns (address);
+}
+
 /// @title NonUSNationalityCondition
 /// @notice Round condition requiring a valid, non-US ZKPassport proof for the participant
 contract NonUSNationalityCondition is BaseCondition, BorgAuthACL {
@@ -21,6 +25,8 @@ contract NonUSNationalityCondition is BaseCondition, BorgAuthACL {
     error ProofExpired();
     error ProofAlreadyUsed();
     error MaxValidityPeriodExceeded();
+    error InvalidManager();
+    error InvalidInvestor();
 
     event ProofSubmitted(
         address indexed account,
@@ -29,6 +35,12 @@ contract NonUSNationalityCondition is BaseCondition, BorgAuthACL {
 
     event MaxValidityPeriodUpdated(uint256 maxValidityPeriod);
     event ExcludedCountriesUpdated(string[] countries);
+    event FounderOverrideUpdated(
+        address indexed manager,
+        address indexed investor,
+        bool approved,
+        address indexed approver
+    );
 
     // Deterministic verifier address from ZKPassport docs.
     address public constant DEFAULT_ZKPASSPORT_VERIFIER =
@@ -41,6 +53,8 @@ contract NonUSNationalityCondition is BaseCondition, BorgAuthACL {
 
     mapping(address => uint256) public proofExpiry;
     mapping(bytes32 => bool) public usedProofIdentifiers;
+    // manager → investor → approved
+    mapping(address => mapping(address => bool)) public founderOverrides;
 
     string[] public excludedCountries;
 
@@ -149,6 +163,26 @@ contract NonUSNationalityCondition is BaseCondition, BorgAuthACL {
         emit ProofSubmitted(msg.sender, expiresAt);
     }
 
+    function setFounderOverride(
+        address _manager,
+        address _investor,
+        bool _approved
+    ) external {
+        if (_manager == address(0)) revert InvalidManager();
+        if (_investor == address(0)) revert InvalidInvestor();
+
+        // only the manager of the deal/round can set overrides
+        BorgAuth auth = BorgAuth(ICyberCorpManager(_manager).AUTH());
+        auth.onlyRole(auth.OWNER_ROLE(), msg.sender);
+
+        founderOverrides[_manager][_investor] = _approved;
+        emit FounderOverrideUpdated(_manager, _investor, _approved, msg.sender);
+    }
+
+    function isFounderOverrideApproved(address _manager, address _investor) external view returns (bool) {
+        return founderOverrides[_manager][_investor];
+    }
+
     /// @notice Condition check used by LexScroWLite.conditionCheck
     function checkCondition(
         address _contract,
@@ -158,7 +192,8 @@ contract NonUSNationalityCondition is BaseCondition, BorgAuthACL {
         LexScroWLite lexScrow = LexScroWLite(_contract);
         bytes32 agreementId = abi.decode(data, (bytes32));
         address counterparty = lexScrow.getEscrowDetails(agreementId).counterParty;
+        // check overrides first, then the ZK proof
+        if (founderOverrides[_contract][counterparty]) return true;
         return proofExpiry[counterparty] >= block.timestamp;
     }
-
 }

--- a/src/libs/conditions/NonUSNationalityCondition.sol
+++ b/src/libs/conditions/NonUSNationalityCondition.sol
@@ -179,10 +179,6 @@ contract NonUSNationalityCondition is BaseCondition, BorgAuthACL {
         emit FounderOverrideUpdated(_manager, _investor, _approved, msg.sender);
     }
 
-    function isFounderOverrideApproved(address _manager, address _investor) external view returns (bool) {
-        return founderOverrides[_manager][_investor];
-    }
-
     /// @notice Condition check used by LexScroWLite.conditionCheck
     function checkCondition(
         address _contract,

--- a/test/NonUSNationalityConditionForkTest.t.sol
+++ b/test/NonUSNationalityConditionForkTest.t.sol
@@ -16,6 +16,31 @@ import {NonUSNationalityCondition} from "../src/libs/conditions/NonUSNationality
 import {BorgAuth} from "../src/libs/auth.sol";
 import {stdJson} from "forge-std/StdJson.sol";
 
+contract MockManager {
+    BorgAuth public AUTH;
+    mapping(bytes32 => address) public counterpartyByAgreementId;
+
+    constructor(address auth) { AUTH = BorgAuth(auth); }
+
+    function setCounterparty(bytes32 agreementId, address counterparty) external {
+        counterpartyByAgreementId[agreementId] = counterparty;
+    }
+
+    function getEscrowDetails(bytes32 agreementId) external view returns (Escrow memory esc) {
+        Token[] memory corpAssets = new Token[](0);
+        Token[] memory buyerAssets = new Token[](0);
+        esc = Escrow({
+            agreementId: agreementId,
+            counterParty: counterpartyByAgreementId[agreementId],
+            corpAssets: corpAssets,
+            buyerAssets: buyerAssets,
+            signature: "",
+            expiry: block.timestamp + 1 days,
+            status: EscrowStatus.PAID
+        });
+    }
+}
+
 library NonUSNationalityConditionHelper {
     using stdJson for string;
 
@@ -105,6 +130,19 @@ contract NonUSNationalityConditionForkTest is Test {
         vm.prank(account);
         condition.submitProof(params, false);
         assertEq(condition.proofExpiry(account), signedTimestamp + params.serviceConfig.validityPeriodInSeconds, "unexpected proof expiry");
+    }
+
+    function test_FounderOverride_HappyPath() public {
+        BorgAuth managerAuth = new BorgAuth(address(this));
+        MockManager manager = new MockManager(address(managerAuth));
+        address investor = address(0xA11CE);
+        bytes32 agreementId = keccak256("agreement-fork-override");
+        manager.setCounterparty(agreementId, investor);
+
+        condition.setFounderOverride(address(manager), investor, true);
+
+        assertTrue(condition.isFounderOverrideApproved(address(manager), investor));
+        assertTrue(condition.checkCondition(address(manager), bytes4(0), abi.encode(agreementId)));
     }
 
     /// @notice Real proof of non-FRA nationality should not pass since we want non-US + non-sanctioned proof

--- a/test/NonUSNationalityConditionForkTest.t.sol
+++ b/test/NonUSNationalityConditionForkTest.t.sol
@@ -141,7 +141,7 @@ contract NonUSNationalityConditionForkTest is Test {
 
         condition.setFounderOverride(address(manager), investor, true);
 
-        assertTrue(condition.isFounderOverrideApproved(address(manager), investor));
+        assertTrue(condition.founderOverrides(address(manager), investor));
         assertTrue(condition.checkCondition(address(manager), bytes4(0), abi.encode(agreementId)));
     }
 

--- a/test/NonUSNationalityConditionTest.t.sol
+++ b/test/NonUSNationalityConditionTest.t.sol
@@ -344,8 +344,28 @@ contract NonUSNationalityConditionTest is Test {
 
         condition.setFounderOverride(address(manager), investor, true);
 
-        assertTrue(condition.isFounderOverrideApproved(address(manager), investor));
+        assertTrue(condition.founderOverrides(address(manager), investor));
         assertTrue(condition.checkCondition(address(manager), bytes4(0), abi.encode(agreementId)));
+    }
+
+    function test_SetFounderOverride_PublicMappingGetter() public {
+        BorgAuth managerAuth = new BorgAuth(address(this));
+        MockManager manager = new MockManager(address(managerAuth));
+        address investor = address(0xA11CE);
+
+        assertFalse(condition.founderOverrides(address(manager), investor));
+        condition.setFounderOverride(address(manager), investor, true);
+        assertTrue(condition.founderOverrides(address(manager), investor));
+    }
+
+    function test_SetFounderOverride_EmitsFounderOverrideUpdated() public {
+        BorgAuth managerAuth = new BorgAuth(address(this));
+        MockManager manager = new MockManager(address(managerAuth));
+        address investor = address(0xA11CE);
+
+        vm.expectEmit(true, true, true, true);
+        emit NonUSNationalityCondition.FounderOverrideUpdated(address(manager), investor, true, address(this));
+        condition.setFounderOverride(address(manager), investor, true);
     }
 
     function test_SetFounderOverride_RevokeOverride() public {
@@ -358,7 +378,7 @@ contract NonUSNationalityConditionTest is Test {
         condition.setFounderOverride(address(manager), investor, true);
         condition.setFounderOverride(address(manager), investor, false);
 
-        assertFalse(condition.isFounderOverrideApproved(address(manager), investor));
+        assertFalse(condition.founderOverrides(address(manager), investor));
         assertFalse(condition.checkCondition(address(manager), bytes4(0), abi.encode(agreementId)));
     }
 

--- a/test/NonUSNationalityConditionTest.t.sol
+++ b/test/NonUSNationalityConditionTest.t.sol
@@ -110,6 +110,32 @@ contract MockZKPassportVerifier is IZKPassportVerifier {
     }
 }
 
+// TODO rename it
+contract MockManager {
+    BorgAuth public AUTH;
+    mapping(bytes32 => address) public counterpartyByAgreementId;
+
+    constructor(address auth) { AUTH = BorgAuth(auth); }
+
+    function setCounterparty(bytes32 agreementId, address counterparty) external {
+        counterpartyByAgreementId[agreementId] = counterparty;
+    }
+
+    function getEscrowDetails(bytes32 agreementId) external view returns (Escrow memory esc) {
+        Token[] memory corpAssets = new Token[](0);
+        Token[] memory buyerAssets = new Token[](0);
+        esc = Escrow({
+            agreementId: agreementId,
+            counterParty: counterpartyByAgreementId[agreementId],
+            corpAssets: corpAssets,
+            buyerAssets: buyerAssets,
+            signature: "",
+            expiry: block.timestamp + 1 days,
+            status: EscrowStatus.PAID
+        });
+    }
+}
+
 contract NonUSNationalityConditionTest is Test {
     string internal constant EXPECTED_DOMAIN = "app.example";
     string internal constant EXPECTED_SCOPE = "non-us-round";
@@ -305,6 +331,94 @@ contract NonUSNationalityConditionTest is Test {
         vm.warp(block.timestamp + 2 days);
         bool result = condition.checkCondition(address(escrowSource), bytes4(0), abi.encode(agreementId));
         assertFalse(result);
+    }
+
+    // --- founder override tests ---
+
+    function test_SetFounderOverride_HappyPath() public {
+        BorgAuth managerAuth = new BorgAuth(address(this));
+        MockManager manager = new MockManager(address(managerAuth));
+        address investor = address(0xA11CE);
+        bytes32 agreementId = keccak256("agreement-override");
+        manager.setCounterparty(agreementId, investor);
+
+        condition.setFounderOverride(address(manager), investor, true);
+
+        assertTrue(condition.isFounderOverrideApproved(address(manager), investor));
+        assertTrue(condition.checkCondition(address(manager), bytes4(0), abi.encode(agreementId)));
+    }
+
+    function test_SetFounderOverride_RevokeOverride() public {
+        BorgAuth managerAuth = new BorgAuth(address(this));
+        MockManager manager = new MockManager(address(managerAuth));
+        address investor = address(0xA11CE);
+        bytes32 agreementId = keccak256("agreement-revoke");
+        manager.setCounterparty(agreementId, investor);
+
+        condition.setFounderOverride(address(manager), investor, true);
+        condition.setFounderOverride(address(manager), investor, false);
+
+        assertFalse(condition.isFounderOverrideApproved(address(manager), investor));
+        assertFalse(condition.checkCondition(address(manager), bytes4(0), abi.encode(agreementId)));
+    }
+
+    function test_CheckCondition_FounderOverrideTakesPrecedence() public {
+        BorgAuth managerAuth = new BorgAuth(address(this));
+        MockManager manager = new MockManager(address(managerAuth));
+        address investor = address(0xA11CE);
+        bytes32 agreementId = keccak256("agreement-expired");
+        manager.setCounterparty(agreementId, investor);
+
+        ProofVerificationParams memory params = _buildParams(investor, block.timestamp, 1 days);
+        vm.prank(investor);
+        condition.submitProof(params, false);
+
+        vm.warp(block.timestamp + 2 days);
+        assertFalse(condition.checkCondition(address(manager), bytes4(0), abi.encode(agreementId)));
+
+        condition.setFounderOverride(address(manager), investor, true);
+        assertTrue(condition.checkCondition(address(manager), bytes4(0), abi.encode(agreementId)));
+    }
+
+    function test_CheckCondition_OverrideScopedToManager() public {
+        BorgAuth managerAuthA = new BorgAuth(address(this));
+        MockManager managerA = new MockManager(address(managerAuthA));
+        BorgAuth managerAuthB = new BorgAuth(address(this));
+        MockManager managerB = new MockManager(address(managerAuthB));
+        address investor = address(0xA11CE);
+        bytes32 agreementId = keccak256("agreement-scoped");
+        managerA.setCounterparty(agreementId, investor);
+        managerB.setCounterparty(agreementId, investor);
+
+        condition.setFounderOverride(address(managerA), investor, true);
+
+        assertTrue(condition.checkCondition(address(managerA), bytes4(0), abi.encode(agreementId)));
+        assertFalse(condition.checkCondition(address(managerB), bytes4(0), abi.encode(agreementId)));
+    }
+
+    function test_RevertWhen_SetFounderOverride_Unauthorized() public {
+        BorgAuth managerAuth = new BorgAuth(address(this));
+        MockManager manager = new MockManager(address(managerAuth));
+        address attacker = address(0xDEAD);
+
+        vm.prank(attacker);
+        vm.expectRevert(
+            abi.encodeWithSelector(BorgAuth.BorgAuth_NotAuthorized.selector, uint256(99), attacker)
+        );
+        condition.setFounderOverride(address(manager), address(0xA11CE), true);
+    }
+
+    function test_RevertWhen_SetFounderOverride_InvalidManager() public {
+        vm.expectRevert(NonUSNationalityCondition.InvalidManager.selector);
+        condition.setFounderOverride(address(0), address(0xA11CE), true);
+    }
+
+    function test_RevertWhen_SetFounderOverride_InvalidInvestor() public {
+        BorgAuth managerAuth = new BorgAuth(address(this));
+        MockManager manager = new MockManager(address(managerAuth));
+
+        vm.expectRevert(NonUSNationalityCondition.InvalidInvestor.selector);
+        condition.setFounderOverride(address(manager), address(0), true);
     }
 
     // --- access control tests ---

--- a/test/PumpCorpFactory.t.sol
+++ b/test/PumpCorpFactory.t.sol
@@ -126,7 +126,8 @@ contract PumpCorpFactoryTest is Test {
             expectedDomain,
             expectedScope,
             2592000, // maxValidityPeriod,
-            block.chainid
+            block.chainid,
+            false
         );
 
         // Deploy OrCondition (zkPassport || LexChex)


### PR DESCRIPTION
- Added `setFounderOverride(manager, investor, approved)` — lets a manager whitelist investors to bypass the ZK proof check. Access-gated to the manager's BorgAuth owner role
- Updated checkCondition to short-circuit on a valid founder override before checking proof expiry                                                                                    
- Emits FounderOverrideUpdated event on each override change                                                                                                                          
- Added related tests