### PR TITLE
NonUSNationalityCondition upgrades

### DIFF
--- a/script/deploy-non-us-zkpassport-condition.s.sol
+++ b/script/deploy-non-us-zkpassport-condition.s.sol
@@ -7,6 +7,7 @@ import {NonUSNationalityCondition} from "../src/libs/conditions/NonUSNationality
 import {OrCondition} from "../src/libs/conditions/OrCondition.sol";
 import {BorgAuth} from "../src/libs/auth.sol";
 import {DeploymentConstants} from "./libs/DeploymentConstants.sol";
+import {ERC1967Proxy} from "openzeppelin-contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 contract DeployNonUsZkPassportConditionScript is Script {
     function run() public returns (BorgAuth zkpassportAuth, NonUSNationalityCondition zkpassportCondition) {
@@ -72,13 +73,19 @@ contract DeployNonUsZkPassportConditionScript is Script {
 
         zkpassportAuth = new BorgAuth{salt: salt}(deployerAddress);
 
-        zkpassportCondition = new NonUSNationalityCondition{salt: salt}(
-            address(zkpassportAuth),
-            expectedDomain,
-            expectedScope,
-            address(0), // verifier (use default)
-            maxValidityPeriod,
-            outCountries
+        NonUSNationalityCondition impl = new NonUSNationalityCondition{salt: salt}();
+        zkpassportCondition = NonUSNationalityCondition(
+            address(new ERC1967Proxy{salt: salt}(
+                address(impl),
+                abi.encodeCall(NonUSNationalityCondition.initialize, (
+                    address(zkpassportAuth),
+                    expectedDomain,
+                    expectedScope,
+                    address(0), // verifier (use default)
+                    maxValidityPeriod,
+                    outCountries
+                ))
+            ))
         );
 
         // Deploy OrCondition (zkPassport || LexChex)

--- a/script/deploy-non-us-zkpassport-condition.s.sol
+++ b/script/deploy-non-us-zkpassport-condition.s.sol
@@ -13,7 +13,7 @@ contract DeployNonUsZkPassportConditionScript is Script {
     function run() public returns (BorgAuth zkpassportAuth, NonUSNationalityCondition zkpassportCondition) {
         return runWithArgs(
             // Production
-            "MetaLexCyberCorp.NonUSNationalityZkpassport.V1.1.0",
+            "MetaLexCyberCorp.NonUSNationalityZkpassport.V1.2.0",
             vm.envUint("PRIVATE_KEY_MAIN"),
             "ace.metalex.tech",
             "non-us-non-sanctioned",
@@ -22,7 +22,7 @@ contract DeployNonUsZkPassportConditionScript is Script {
             false // ownedByDeployer
 
 //            // Staging (localhost)
-//            "MetaLexCyberCorp.NonUSNationalityZkpassport.V1.1.0.staging.dev1",
+//            "MetaLexCyberCorp.NonUSNationalityZkpassport.V1.2.0.staging.dev0-localhost",
 //            vm.envUint("PRIVATE_KEY_MAIN"),
 //            "localhost",
 //            "non-us-non-sanctioned",
@@ -31,7 +31,7 @@ contract DeployNonUsZkPassportConditionScript is Script {
 //            true // ownedByDeployer
 
 //            // Staging (staging.ace.metalex.tech)
-//            "MetaLexCyberCorp.NonUSNationalityZkpassport.V1.1.0.staging.dev1-staging.ace.metalex.tech",
+//            "MetaLexCyberCorp.NonUSNationalityZkpassport.V1.2.0.staging.dev0-staging.ace.metalex.tech",
 //            vm.envUint("PRIVATE_KEY_MAIN"),
 //            "staging.ace.metalex.tech",
 //            "non-us-non-sanctioned",

--- a/src/libs/conditions/NonUSNationalityCondition.sol
+++ b/src/libs/conditions/NonUSNationalityCondition.sol
@@ -42,6 +42,7 @@ contract NonUSNationalityCondition is BaseCondition, BorgAuthACL {
         address indexed approver
     );
 
+    // TODO this should be upgradeable
     // Deterministic verifier address from ZKPassport docs.
     address public constant DEFAULT_ZKPASSPORT_VERIFIER =
         0x1D000001000EFD9a6371f4d90bB8920D5431c0D8;
@@ -123,7 +124,7 @@ contract NonUSNationalityCondition is BaseCondition, BorgAuthACL {
         (bool verified, bytes32 uniqueIdentifier, IZKPassportHelper helper) = verifier.verify(params);
         if (!verified || address(helper) == address(0)) revert InvalidProof();
 
-        if (uniqueIdentifierExpiry[uniqueIdentifier] > block.timestamp) revert ProofAlreadyUsed();
+        if (uniqueIdentifierExpiry[uniqueIdentifier] >= block.timestamp) revert ProofAlreadyUsed();
 
         if (
             !helper.verifyScopes(
@@ -153,10 +154,9 @@ contract NonUSNationalityCondition is BaseCondition, BorgAuthACL {
         );
 
         uint256 validityPeriod = params.serviceConfig.validityPeriodInSeconds;
-        if (validityPeriod > maxValidityPeriod) revert MaxValidityPeriodExceeded();
-
         uint256 expiresAt = proofTimestamp + validityPeriod;
         if (expiresAt < block.timestamp) revert ProofExpired();
+        if (expiresAt > block.timestamp + maxValidityPeriod) revert MaxValidityPeriodExceeded();
 
         proofExpiry[msg.sender] = expiresAt;
         uniqueIdentifierExpiry[uniqueIdentifier] = expiresAt;

--- a/src/libs/conditions/NonUSNationalityCondition.sol
+++ b/src/libs/conditions/NonUSNationalityCondition.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity 0.8.28;
 
-import "@openzeppelin/contracts/interfaces/IERC165.sol";
-import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "openzeppelin-contracts/interfaces/IERC165.sol";
+import "openzeppelin-contracts-upgradeable/proxy/utils/Initializable.sol";
+import "openzeppelin-contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "./baseCondition.sol";
 import "../LexScroWLite.sol";
 import "../auth.sol";
@@ -14,7 +15,7 @@ interface ICyberCorpManager {
 
 /// @title NonUSNationalityCondition
 /// @notice Round condition requiring a valid, non-US ZKPassport proof for the participant
-contract NonUSNationalityCondition is BaseCondition, BorgAuthACL {
+contract NonUSNationalityCondition is BaseCondition, UUPSUpgradeable, BorgAuthACL {
     error InvalidVerifier();
     error InvalidProof();
     error InvalidScope();
@@ -42,7 +43,6 @@ contract NonUSNationalityCondition is BaseCondition, BorgAuthACL {
         address indexed approver
     );
 
-    // TODO this should be upgradeable
     // Deterministic verifier address from ZKPassport docs.
     address public constant DEFAULT_ZKPASSPORT_VERIFIER =
         0x1D000001000EFD9a6371f4d90bB8920D5431c0D8;
@@ -59,23 +59,11 @@ contract NonUSNationalityCondition is BaseCondition, BorgAuthACL {
 
     string[] public excludedCountries;
 
-    /// @notice initialize atomically since this is not an upgradeable contract
-    constructor(
-        address _auth,
-        string memory _expectedDomain,
-        string memory _expectedScope,
-        address _verifier,
-        uint256 _maxValidityPeriod,
-        string[] memory _excludedCountries
-    ) {
-        initialize(
-            _auth,
-            _expectedDomain,
-            _expectedScope,
-            _verifier,
-            _maxValidityPeriod,
-            _excludedCountries
-        );
+    uint256[41] private __gap;
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
     }
 
     function initialize(
@@ -86,6 +74,7 @@ contract NonUSNationalityCondition is BaseCondition, BorgAuthACL {
         uint256 _maxValidityPeriod,
         string[] memory _excludedCountries
     ) public initializer {
+        __UUPSUpgradeable_init();
         __BorgAuthACL_init(_auth);
 
         expectedDomain = _expectedDomain;
@@ -192,4 +181,6 @@ contract NonUSNationalityCondition is BaseCondition, BorgAuthACL {
         if (founderOverrides[_contract][counterparty]) return true;
         return proofExpiry[counterparty] >= block.timestamp;
     }
+
+    function _authorizeUpgrade(address) internal override onlyOwner {}
 }

--- a/src/libs/conditions/NonUSNationalityCondition.sol
+++ b/src/libs/conditions/NonUSNationalityCondition.sol
@@ -143,6 +143,7 @@ contract NonUSNationalityCondition is BaseCondition, UUPSUpgradeable, BorgAuthAC
         );
 
         uint256 validityPeriod = params.serviceConfig.validityPeriodInSeconds;
+        if (validityPeriod > maxValidityPeriod) revert MaxValidityPeriodExceeded();
         uint256 expiresAt = proofTimestamp + validityPeriod;
         if (expiresAt < block.timestamp) revert ProofExpired();
         if (expiresAt > block.timestamp + maxValidityPeriod) revert MaxValidityPeriodExceeded();

--- a/src/libs/conditions/NonUSNationalityCondition.sol
+++ b/src/libs/conditions/NonUSNationalityCondition.sol
@@ -52,7 +52,7 @@ contract NonUSNationalityCondition is BaseCondition, BorgAuthACL {
     uint256 public maxValidityPeriod;
 
     mapping(address => uint256) public proofExpiry;
-    mapping(bytes32 => bool) public usedProofIdentifiers;
+    mapping(bytes32 => uint256) public uniqueIdentifierExpiry;
     // manager → investor → approved
     mapping(address => mapping(address => bool)) public founderOverrides;
 
@@ -123,8 +123,7 @@ contract NonUSNationalityCondition is BaseCondition, BorgAuthACL {
         (bool verified, bytes32 uniqueIdentifier, IZKPassportHelper helper) = verifier.verify(params);
         if (!verified || address(helper) == address(0)) revert InvalidProof();
 
-        if (usedProofIdentifiers[uniqueIdentifier]) revert ProofAlreadyUsed();
-        usedProofIdentifiers[uniqueIdentifier] = true;
+        if (uniqueIdentifierExpiry[uniqueIdentifier] > block.timestamp) revert ProofAlreadyUsed();
 
         if (
             !helper.verifyScopes(
@@ -160,6 +159,7 @@ contract NonUSNationalityCondition is BaseCondition, BorgAuthACL {
         if (expiresAt < block.timestamp) revert ProofExpired();
 
         proofExpiry[msg.sender] = expiresAt;
+        uniqueIdentifierExpiry[uniqueIdentifier] = expiresAt;
         emit ProofSubmitted(msg.sender, expiresAt);
     }
 

--- a/test/NonUSNationalityConditionForkTest.t.sol
+++ b/test/NonUSNationalityConditionForkTest.t.sol
@@ -15,6 +15,7 @@ import {
 import {NonUSNationalityCondition} from "../src/libs/conditions/NonUSNationalityCondition.sol";
 import {BorgAuth} from "../src/libs/auth.sol";
 import {stdJson} from "forge-std/StdJson.sol";
+import {ERC1967Proxy} from "openzeppelin-contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 contract MockManager {
     BorgAuth public AUTH;
@@ -110,13 +111,19 @@ contract NonUSNationalityConditionForkTest is Test {
 
         zkpassportAuth = new BorgAuth(address(this));
 
-        condition = new NonUSNationalityCondition(
-            address(zkpassportAuth),
-            domain,
-            scope,
-            REAL_VERIFIER,
-            MAX_VALIDITY_PERIOD,
-            excludedCountries
+        NonUSNationalityCondition impl = new NonUSNationalityCondition();
+        condition = NonUSNationalityCondition(
+            address(new ERC1967Proxy(
+                address(impl),
+                abi.encodeCall(NonUSNationalityCondition.initialize, (
+                    address(zkpassportAuth),
+                    domain,
+                    scope,
+                    REAL_VERIFIER,
+                    MAX_VALIDITY_PERIOD,
+                    excludedCountries
+                ))
+            ))
         );
     }
 

--- a/test/NonUSNationalityConditionTest.t.sol
+++ b/test/NonUSNationalityConditionTest.t.sol
@@ -292,6 +292,28 @@ contract NonUSNationalityConditionTest is Test {
         condition.submitProof(params, false);
     }
 
+    function test_UniqueIdentifier_CanBeReusedAfterProofExpired() public {
+        address investor = address(0xA11CE);
+        uint256 validityPeriod = 1 days;
+
+        uint256 firstTimestamp = 1000;
+        uint256 firstExpiry = firstTimestamp + validityPeriod;
+
+        vm.warp(firstTimestamp);
+        ProofVerificationParams memory params = _buildParams(investor, firstTimestamp, validityPeriod);
+        vm.prank(investor);
+        condition.submitProof(params, false);
+
+        uint256 secondTimestamp = firstExpiry + 1;
+        vm.warp(secondTimestamp);
+
+        ProofVerificationParams memory renewalParams = _buildParams(investor, secondTimestamp, validityPeriod);
+        vm.prank(investor);
+        condition.submitProof(renewalParams, false);
+
+        assertEq(condition.proofExpiry(investor), secondTimestamp + validityPeriod);
+    }
+
     function test_SubmitProof_HappyPath() public {
         address investor = address(0xA11CE);
         uint256 proofTimestamp = block.timestamp;

--- a/test/NonUSNationalityConditionTest.t.sol
+++ b/test/NonUSNationalityConditionTest.t.sol
@@ -6,8 +6,10 @@ import {Escrow, EscrowStatus, Token} from "../src/storage/LexScrowStorage.sol";
 import {NonUSNationalityCondition} from "../src/libs/conditions/NonUSNationalityCondition.sol";
 import {BorgAuth} from "../src/libs/auth.sol";
 import {ICondition} from "../src/interfaces/ICondition.sol";
-import {IERC165} from "@openzeppelin/contracts/interfaces/IERC165.sol";
-import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {ERC1967ProxyLib} from "./libs/ERC1967ProxyLib.sol";
+import {IERC165} from "openzeppelin-contracts/interfaces/IERC165.sol";
+import {Initializable} from "openzeppelin-contracts-upgradeable/proxy/utils/Initializable.sol";
+import {ERC1967Proxy} from "openzeppelin-contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {
     BoundData,
     DisclosedData,
@@ -138,6 +140,8 @@ contract MockManager {
 }
 
 contract NonUSNationalityConditionTest is Test {
+    using ERC1967ProxyLib for address;
+
     string internal constant EXPECTED_DOMAIN = "app.example";
     string internal constant EXPECTED_SCOPE = "non-us-round";
 
@@ -158,13 +162,19 @@ contract NonUSNationalityConditionTest is Test {
         string[] memory excludedCountries = new string[](1);
         excludedCountries[0] = "USA";
 
-        condition = new NonUSNationalityCondition(
-            address(zkpassportAuth),
-            EXPECTED_DOMAIN,
-            EXPECTED_SCOPE,
-            address(mockVerifier),
-            MAX_VALIDITY_PERIOD,
-            excludedCountries
+        NonUSNationalityCondition impl = new NonUSNationalityCondition();
+        condition = NonUSNationalityCondition(
+            address(new ERC1967Proxy(
+                address(impl),
+                abi.encodeCall(NonUSNationalityCondition.initialize, (
+                    address(zkpassportAuth),
+                    EXPECTED_DOMAIN,
+                    EXPECTED_SCOPE,
+                    address(mockVerifier),
+                    MAX_VALIDITY_PERIOD,
+                    excludedCountries
+                ))
+            ))
         );
         escrowSource = new MockEscrowSource();
     }
@@ -635,15 +645,18 @@ contract NonUSNationalityConditionTest is Test {
     function test_RevertWhen_Initialize_ZeroMaxValidityPeriod() public {
         string[] memory excludedCountries = new string[](1);
         excludedCountries[0] = "USA";
-
+        NonUSNationalityCondition freshImpl = new NonUSNationalityCondition();
         vm.expectRevert(NonUSNationalityCondition.InvalidMaxValidityPeriod.selector);
-        NonUSNationalityCondition fresh = new NonUSNationalityCondition(
-            address(zkpassportAuth),
-            EXPECTED_DOMAIN,
-            EXPECTED_SCOPE,
-            address(mockVerifier),
-            0,
-            excludedCountries
+        new ERC1967Proxy(
+            address(freshImpl),
+            abi.encodeCall(NonUSNationalityCondition.initialize, (
+                address(zkpassportAuth),
+                EXPECTED_DOMAIN,
+                EXPECTED_SCOPE,
+                address(mockVerifier),
+                0,
+                excludedCountries
+            ))
         );
     }
 
@@ -664,6 +677,27 @@ contract NonUSNationalityConditionTest is Test {
             MAX_VALIDITY_PERIOD,
             excludedCountries
         );
+    }
+
+    function test_ImplementationInitializerDisabled() public {
+        NonUSNationalityCondition impl = new NonUSNationalityCondition();
+        string[] memory countries = new string[](0);
+        vm.expectRevert(Initializable.InvalidInitialization.selector);
+        impl.initialize(address(zkpassportAuth), "x", "x", address(mockVerifier), 1 days, countries);
+    }
+
+    function test_RevertWhen_Upgrade_Unauthorized() public {
+        NonUSNationalityCondition newImpl = new NonUSNationalityCondition();
+        vm.expectRevert(abi.encodeWithSelector(BorgAuth.BorgAuth_NotAuthorized.selector, zkpassportAuth.OWNER_ROLE(), address(0xDEAD)));
+        vm.prank(address(0xDEAD));
+        condition.upgradeToAndCall(address(newImpl), "");
+    }
+
+    function test_Upgrade_SucceedsForAdmin() public {
+        NonUSNationalityCondition newImpl = new NonUSNationalityCondition();
+        condition.upgradeToAndCall(address(newImpl), "");
+        assertEq(address(condition).getErc1967Implementation(), address(newImpl));
+        assertEq(condition.maxValidityPeriod(), MAX_VALIDITY_PERIOD);
     }
 
     // --- supportsInterface tests ---

--- a/test/NonUSNationalityConditionTest.t.sol
+++ b/test/NonUSNationalityConditionTest.t.sol
@@ -7,6 +7,7 @@ import {NonUSNationalityCondition} from "../src/libs/conditions/NonUSNationality
 import {BorgAuth} from "../src/libs/auth.sol";
 import {ICondition} from "../src/interfaces/ICondition.sol";
 import {IERC165} from "@openzeppelin/contracts/interfaces/IERC165.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {
     BoundData,
     DisclosedData,
@@ -198,6 +199,13 @@ contract NonUSNationalityConditionTest is Test {
         assertEq(condition.excludedCountries(1), "NK");
     }
 
+    function test_UpdateExcludedCountries_EmptyArray() public {
+        string[] memory empty = new string[](0);
+        vm.expectEmit(false, false, false, true);
+        emit NonUSNationalityCondition.ExcludedCountriesUpdated(empty);
+        condition.updateExcludedCountries(empty);
+    }
+
     // --- submitProof tests ---
 
     function test_RevertWhen_InvalidProof_VerificationFailed() public {
@@ -339,6 +347,80 @@ contract NonUSNationalityConditionTest is Test {
         condition.submitProof(params, false);
     }
 
+    function test_RevertWhen_SybilAttempt_SameUniqueId_DifferentWallet() public {
+        address investor = address(0xA11CE);
+        address attacker = address(0xDEAD);
+        uint256 firstTimestamp = 1000;
+        uint256 validityPeriod = 1 days;
+
+        vm.warp(firstTimestamp);
+        vm.prank(investor);
+        condition.submitProof(_buildParams(investor, firstTimestamp, validityPeriod), false);
+
+        vm.prank(attacker);
+        vm.expectRevert(NonUSNationalityCondition.ProofAlreadyUsed.selector);
+        condition.submitProof(_buildParams(attacker, firstTimestamp, validityPeriod), false);
+    }
+
+    function test_UniqueIdentifier_AllowedForDifferentWalletAfterExpiry() public {
+        address investor = address(0xA11CE);
+        address newWallet = address(0xBEEF);
+        uint256 firstTimestamp = 1000;
+        uint256 validityPeriod = 1 days;
+        uint256 firstExpiry = firstTimestamp + validityPeriod;
+
+        vm.warp(firstTimestamp);
+        vm.prank(investor);
+        condition.submitProof(_buildParams(investor, firstTimestamp, validityPeriod), false);
+
+        uint256 secondTimestamp = firstExpiry + 1;
+        vm.warp(secondTimestamp);
+        vm.prank(newWallet);
+        condition.submitProof(_buildParams(newWallet, secondTimestamp, validityPeriod), false);
+
+        assertEq(condition.proofExpiry(newWallet), secondTimestamp + validityPeriod);
+    }
+
+    function test_SubmitProof_UniqueIdentifierExpiryIsWritten() public {
+        address investor = address(0xA11CE);
+        uint256 proofTimestamp = 1000;
+        uint256 validityPeriod = 1 days;
+
+        vm.warp(proofTimestamp);
+        vm.prank(investor);
+        condition.submitProof(_buildParams(investor, proofTimestamp, validityPeriod), false);
+
+        assertEq(condition.uniqueIdentifierExpiry(mockVerifier.uniqueId()), proofTimestamp + validityPeriod);
+    }
+
+    function test_SubmitProof_EarlyRenewal_DifferentUniqueId_OverwritesExpiry() public {
+        address investor = address(0xA11CE);
+        uint256 firstTimestamp = 1000;
+        uint256 validityPeriod = 1 days;
+
+        vm.warp(firstTimestamp);
+        vm.prank(investor);
+        condition.submitProof(_buildParams(investor, firstTimestamp, validityPeriod), false);
+        assertEq(condition.proofExpiry(investor), firstTimestamp + validityPeriod);
+
+        uint256 secondTimestamp = firstTimestamp + 12 hours;
+        vm.warp(secondTimestamp);
+        mockVerifier.setUniqueId(keccak256("second-proof-id"));
+        vm.prank(investor);
+        condition.submitProof(_buildParams(investor, secondTimestamp, validityPeriod), false);
+
+        assertEq(condition.proofExpiry(investor), secondTimestamp + validityPeriod);
+    }
+
+    function test_SubmitProof_ValidityPeriodAtMaxBoundary() public {
+        address investor = address(0xA11CE);
+        uint256 proofTimestamp = 1000;
+        vm.warp(proofTimestamp);
+        vm.prank(investor);
+        condition.submitProof(_buildParams(investor, proofTimestamp, MAX_VALIDITY_PERIOD), false);
+        assertEq(condition.proofExpiry(investor), proofTimestamp + MAX_VALIDITY_PERIOD);
+    }
+
     function test_SubmitProof_HappyPath() public {
         address investor = address(0xA11CE);
         uint256 proofTimestamp = block.timestamp;
@@ -378,6 +460,46 @@ contract NonUSNationalityConditionTest is Test {
         vm.warp(block.timestamp + 2 days);
         bool result = condition.checkCondition(address(escrowSource), bytes4(0), abi.encode(agreementId));
         assertFalse(result);
+    }
+
+    function test_CheckCondition_TrueAtExactExpiry() public {
+        bytes32 agreementId = keccak256("agreement-exact");
+        address investor = address(0xA11CE);
+        escrowSource.setCounterparty(agreementId, investor);
+
+        uint256 proofTimestamp = 1000;
+        uint256 validityPeriod = 1 days;
+        uint256 expiresAt = proofTimestamp + validityPeriod;
+
+        vm.warp(proofTimestamp);
+        vm.prank(investor);
+        condition.submitProof(_buildParams(investor, proofTimestamp, validityPeriod), false);
+
+        vm.warp(expiresAt);
+        assertTrue(condition.checkCondition(address(escrowSource), bytes4(0), abi.encode(agreementId)));
+    }
+
+    function test_CheckCondition_FalseOneSecondAfterExpiry() public {
+        bytes32 agreementId = keccak256("agreement-past");
+        address investor = address(0xA11CE);
+        escrowSource.setCounterparty(agreementId, investor);
+
+        uint256 proofTimestamp = 1000;
+        uint256 validityPeriod = 1 days;
+        uint256 expiresAt = proofTimestamp + validityPeriod;
+
+        vm.warp(proofTimestamp);
+        vm.prank(investor);
+        condition.submitProof(_buildParams(investor, proofTimestamp, validityPeriod), false);
+
+        vm.warp(expiresAt + 1);
+        assertFalse(condition.checkCondition(address(escrowSource), bytes4(0), abi.encode(agreementId)));
+    }
+
+    function test_CheckCondition_ZeroAddressCounterparty() public {
+        bytes32 agreementId = keccak256("agreement-zero-cp");
+        // counterparty not set — escrowSource returns address(0) by default
+        assertFalse(condition.checkCondition(address(escrowSource), bytes4(0), abi.encode(agreementId)));
     }
 
     // --- founder override tests ---
@@ -528,6 +650,20 @@ contract NonUSNationalityConditionTest is Test {
     function test_RevertWhen_UpdateMaxValidityPeriod_Zero() public {
         vm.expectRevert(NonUSNationalityCondition.InvalidMaxValidityPeriod.selector);
         condition.updateMaxValidityPeriod(0);
+    }
+
+    function test_RevertWhen_Initialize_CalledTwice() public {
+        string[] memory excludedCountries = new string[](1);
+        excludedCountries[0] = "USA";
+        vm.expectRevert(Initializable.InvalidInitialization.selector);
+        condition.initialize(
+            address(zkpassportAuth),
+            EXPECTED_DOMAIN,
+            EXPECTED_SCOPE,
+            address(mockVerifier),
+            MAX_VALIDITY_PERIOD,
+            excludedCountries
+        );
     }
 
     // --- supportsInterface tests ---

--- a/test/NonUSNationalityConditionTest.t.sol
+++ b/test/NonUSNationalityConditionTest.t.sol
@@ -348,6 +348,20 @@ contract NonUSNationalityConditionTest is Test {
         condition.submitProof(_buildParams(investor, firstExpiry, validityPeriod), false);
     }
 
+    function test_RevertWhen_StaleProof_OversizedValidityPeriod() public {
+        // proofTimestamp backdated by 1 day, validityPeriod = maxValidityPeriod + 1 day
+        // expiresAt = (now - 1d) + (30d + 1d) = now + 30d — passes the expiresAt window check
+        // but validityPeriod > maxValidityPeriod, so it must revert
+        address investor = address(0xA11CE);
+        uint256 now_ = 2 days;
+        vm.warp(now_);
+        uint256 proofTimestamp = now_ - 1 days;
+        uint256 oversizedValidity = MAX_VALIDITY_PERIOD + 1 days;
+        vm.prank(investor);
+        vm.expectRevert(NonUSNationalityCondition.MaxValidityPeriodExceeded.selector);
+        condition.submitProof(_buildParams(investor, proofTimestamp, oversizedValidity), false);
+    }
+
     function test_RevertWhen_FutureTimestamp_ExceedsMaxValidityWindow() public {
         address investor = address(0xA11CE);
         uint256 futureTimestamp = block.timestamp + 1;

--- a/test/NonUSNationalityConditionTest.t.sol
+++ b/test/NonUSNationalityConditionTest.t.sol
@@ -314,6 +314,31 @@ contract NonUSNationalityConditionTest is Test {
         assertEq(condition.proofExpiry(investor), secondTimestamp + validityPeriod);
     }
 
+    function test_RevertWhen_ProofAlreadyUsed_AtExpiryBlock() public {
+        address investor = address(0xA11CE);
+        uint256 firstTimestamp = 1000;
+        uint256 validityPeriod = 1 days;
+        uint256 firstExpiry = firstTimestamp + validityPeriod;
+
+        vm.warp(firstTimestamp);
+        vm.prank(investor);
+        condition.submitProof(_buildParams(investor, firstTimestamp, validityPeriod), false);
+
+        vm.warp(firstExpiry);
+        vm.prank(investor);
+        vm.expectRevert(NonUSNationalityCondition.ProofAlreadyUsed.selector);
+        condition.submitProof(_buildParams(investor, firstExpiry, validityPeriod), false);
+    }
+
+    function test_RevertWhen_FutureTimestamp_ExceedsMaxValidityWindow() public {
+        address investor = address(0xA11CE);
+        uint256 futureTimestamp = block.timestamp + 1;
+        ProofVerificationParams memory params = _buildParams(investor, futureTimestamp, MAX_VALIDITY_PERIOD);
+        vm.prank(investor);
+        vm.expectRevert(NonUSNationalityCondition.MaxValidityPeriodExceeded.selector);
+        condition.submitProof(params, false);
+    }
+
     function test_SubmitProof_HappyPath() public {
         address investor = address(0xA11CE);
         uint256 proofTimestamp = block.timestamp;


### PR DESCRIPTION
## Updated
- `NonUSNationalityCondition` becomes upgradeable by owner roles
- Add expiry to unique identifiers
- Cap extreme proof timestamps with `maxValidityPeriod`
- Increased test coverage