### PR TITLE
docs: comprehensive cyberCORPs protocol documentation (Diátaxis, GitBook)

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -1,0 +1,8 @@
+root: ./docs/
+
+structure:
+  readme: README.md
+  summary: SUMMARY.md
+
+redirects:
+  previous/page: new-folder/page.md

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,65 @@
+---
+description: >-
+  Natively tokenized private securities on Ethereum, anchored in each issuer's
+  governing law.
+---
+
+# Welcome to cyberCORPs
+
+**cyberCORPs** is MetaLeX's smart-contract protocol for turning a legal entity
+(a Delaware C-corp or LLC, a Cayman LLC or SPC, a BVI fund, an English company,
+or any analogous structure) into an *onchain entity* that issues legally
+constitutive digital securities, maintains its register of holders, conducts
+fundraising rounds, and settles deals through a composable system of contracts.
+
+In a cyberCORP, **the blockchain IS the official register** — not a pointer to
+one.
+
+The protocol is entity-type and jurisdiction agnostic. Delaware C-corp stock is
+the most fully worked-out reference implementation. LLC membership interests,
+LP interests, segregated-portfolio-company shares, and non-US equity all flow
+through the same primitives.
+
+Live on **Ethereum mainnet**, **Arbitrum**, and **Base**.
+
+## How this documentation is organised
+
+These docs follow the [Diátaxis](https://diataxis.fr/) framework. Each section
+serves a different need:
+
+| Section | When to read it |
+|---|---|
+| [**Tutorials**](tutorials/README.md) | You're new and want to *learn by doing*. Start here. |
+| [**How-to Guides**](how-to/README.md) | You have a specific goal and want a recipe. |
+| [**Reference**](reference/README.md) | You need the dry technical facts (contract APIs, roles, events, addresses). |
+| [**Explanation**](explanation/README.md) | You want to *understand why* the protocol is the way it is. |
+
+## The two-minute version
+
+1. A **cyberCORP** is an onchain entity whose constitutional documents
+   (certificate of incorporation, operating agreement, partnership agreement,
+   fund constitutional documents, articles of association, etc.) designate the
+   onchain contract system as the entity's official register of holders.
+2. A **cyberCERT** (ERC-721) is a *Ledger Entry Token* — a single entry on that
+   register, encoding the holder, units, class/series, restrictions,
+   endorsements, signatures, and the governing agreement URI.
+3. A **cyberSCRIP** (ERC-20) is the *fungible* form of that same security. It
+   is minted from a cyberCERT via `scripifyCert()` and convertible back via
+   `convertScripToCert()`. It is itself a security in scrip form (e.g., DGCL
+   §155), not a wrapper or derivative.
+4. A growing **application stack** runs on this single contract suite:
+   **cyberRAISE** (primary fundraising), **cyberTRADE** (secondary
+   settlement), **ACE** (Asset Conversion to Equity), **LiquiLeX** (AMM-native
+   scrip liquidity), and **cyberSign** (cybernetic legal agreement execution),
+   all surfaced to issuers through the cyberCORPs **Mainframe**.
+
+## Illustrative applications
+
+The [metalex-webapp](https://github.com/MetaLex-Tech/metalex-webapp) monorepo
+hosts reference UIs built on these contracts. They are not the protocol; they
+are *examples* of what an issuer or front-end provider can build on top of it.
+See [Application Stack](explanation/application-stack.md) for a mapping.
+
+## Contracts repository
+
+[github.com/MetaLex-Tech/cybercorps-contracts](https://github.com/MetaLex-Tech/cybercorps-contracts)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,0 +1,66 @@
+# Summary
+
+* [Welcome](README.md)
+
+## Tutorials
+
+* [Overview](tutorials/README.md)
+* [Incorporate a cyberCORP](tutorials/incorporate-a-cybercorp.md)
+* [Run a cyberRAISE round](tutorials/run-a-cyberraise-round.md)
+* [Scripify and settle a secondary trade](tutorials/scripify-and-settle.md)
+
+## How-to Guides
+
+* [Overview](how-to/README.md)
+* [Configure BorgAuth roles](how-to/configure-roles.md)
+* [Issue a cyberCERT](how-to/issue-a-cybercert.md)
+* [Restrict cyberSCRIP transfers](how-to/restrict-transfers.md)
+* [Gate state transitions with conditions](how-to/gate-with-conditions.md)
+* [Run a secondary trade](how-to/run-a-secondary-trade.md)
+* [Convert SAFEs to equity](how-to/convert-safe-to-equity.md)
+* [Deploy a PumpCorp for ACE](how-to/deploy-pumpcorp-ace.md)
+* [Deploy a MetaDAO SPC](how-to/deploy-metadao-spc.md)
+* [Deploy a LiquiLeX pool](how-to/deploy-liquilex-pool.md)
+* [Upgrade a cyberCORP](how-to/upgrade-a-cybercorp.md)
+* [Sign a cyberAgreement](how-to/sign-a-cyberagreement.md)
+* [Integrate from a frontend](how-to/integrate-from-frontend.md)
+
+## Reference
+
+* [Overview](reference/README.md)
+* [Core contracts](reference/contracts.md)
+  * [CyberCorp](reference/contracts/CyberCorp.md)
+  * [IssuanceManager](reference/contracts/IssuanceManager.md)
+  * [CyberCertPrinter](reference/contracts/CyberCertPrinter.md)
+  * [CyberScrip](reference/contracts/CyberScrip.md)
+  * [CyberShares](reference/contracts/CyberShares.md)
+  * [DealManager](reference/contracts/DealManager.md)
+  * [RoundManager](reference/contracts/RoundManager.md)
+  * [LeXscroWLite](reference/contracts/LeXscroWLite.md)
+  * [CyberAgreementRegistry](reference/contracts/CyberAgreementRegistry.md)
+  * [SafeCertificateConverter](reference/contracts/SafeCertificateConverter.md)
+  * [LexChex / LexChexMinter](reference/contracts/LexChex.md)
+  * [CertificateUriBuilder](reference/contracts/CertificateUriBuilder.md)
+* [Factories](reference/factories.md)
+* [Certificate extensions](reference/extensions.md)
+* [Hooks](reference/hooks.md)
+* [Conditions](reference/conditions.md)
+* [Access control (BorgAuth)](reference/access-control.md)
+* [Upgrade model](reference/upgrade-model.md)
+* [Agreement templates](reference/templates.md)
+* [Security types](reference/security-types.md)
+* [Deployments](reference/deployments.md)
+* [Glossary](reference/glossary.md)
+
+## Explanation
+
+* [Overview](explanation/README.md)
+* [Constitutive vs. pointer tokenization](explanation/constitutive-vs-pointer.md)
+* [The dual-token model](explanation/dual-token-model.md)
+* [Legal mappings across jurisdictions](explanation/legal-mappings.md)
+* [Co-approval upgradeability](explanation/co-approval-upgradeability.md)
+* [Composability and DeFi](explanation/composability.md)
+* [Compliance architecture](explanation/compliance-architecture.md)
+* [The role of MetaLeX](explanation/role-of-metalex.md)
+* [Regulatory context](explanation/regulatory-context.md)
+* [The cyberCORPs application stack](explanation/application-stack.md)

--- a/docs/explanation/README.md
+++ b/docs/explanation/README.md
@@ -1,0 +1,29 @@
+# Explanation
+
+Explanation is understanding-oriented. The other three quadrants tell you
+*what* and *how*; explanation tells you *why*. Read these when you want
+to know the design rationale, the legal grounding, and the trade-offs the
+protocol makes.
+
+## Contents
+
+* [Constitutive vs. pointer tokenization](constitutive-vs-pointer.md) — the
+  thesis on which the protocol rests.
+* [The dual-token model](dual-token-model.md) — why cyberCERT (ERC-721) and
+  cyberSCRIP (ERC-20) coexist, and how they relate.
+* [Legal mappings across jurisdictions](legal-mappings.md) — how Delaware,
+  LLC, Cayman, BVI, and English law map onto the same primitives.
+* [Co-approval upgradeability](co-approval-upgradeability.md) — why neither
+  MetaLeX nor any single issuer can unilaterally upgrade.
+* [Composability and DeFi](composability.md) — what scripification enables
+  and where its boundaries are.
+* [Compliance architecture](compliance-architecture.md) — conditions,
+  credentials, zkPassport, Reg D vs. Reg S, and the de-scripification
+  boundary.
+* [The role of MetaLeX](role-of-metalex.md) — protocol developer and
+  steward, not securities intermediary.
+* [Regulatory context](regulatory-context.md) — SEC statements, statutory
+  grounding, UI-provider safe harbour.
+* [The cyberCORPs application stack](application-stack.md) — cyberRAISE,
+  cyberTRADE, ACE, LiquiLeX, cyberSign, Mainframe, and how the illustrative
+  apps in `metalex-webapp` realise them.

--- a/docs/explanation/application-stack.md
+++ b/docs/explanation/application-stack.md
@@ -1,0 +1,136 @@
+# The cyberCORPs application stack
+
+CyberCORPs is the **protocol**; the cyberCORPs **Mainframe** is the
+issuer-facing app surface. Several products run on top of the same contract
+suite. Each is independently usable. Each has a reference implementation
+in the [`metalex-webapp`](https://github.com/MetaLex-Tech/metalex-webapp)
+monorepo.
+
+## cyberRAISE
+
+**What it is.** Onchain primary fundraising. Issuers configure rounds with
+raise caps, ticket sizes, pricing, payment tokens (typically USDC), security
+types (SAFE, SAFT, SAFTE, equity rounds), and round modes (first-come or
+admission-based). Investors submit EIP-712-signed Expressions of Interest,
+funds are escrowed in `LeXscroWLite`, and close mints the corresponding
+cyberCERTs.
+
+**Contracts:** [`RoundManager`](../reference/contracts/RoundManager.md),
+[`DealManager`](../reference/contracts/DealManager.md),
+[`LeXscroWLite`](../reference/contracts/LeXscroWLite.md).
+
+**Reference UI:** the `/cyberraise` route in
+[`apps/cybercorps-web/src/app/(frame-layout)/cyberraise`](https://github.com/MetaLex-Tech/metalex-webapp/tree/develop/apps/cybercorps-web/src/app/%28frame-layout%29/cyberraise).
+MetaLeX's prior SAFE rounds were run through this UI; the resulting SAFE
+certificates are visible onchain as cyberCERTs.
+
+## cyberTRADE
+
+**What it is.** Post-negotiation settlement for secondary trades of fund
+interests, LLC membership interests, LP units, private company stock, and
+other private securities, across US and non-US jurisdictions. Counterparty
+discovery and bilateral negotiation happen wherever they happen; cyberTRADE
+handles compliance verification, agreement execution, escrow, and atomic
+settlement.
+
+**Two settlement paths:**
+
+* **Registered ledger path** — edits to the existing cyberCERT (or
+  burn-and-mint with new metadata) under issuer approval, with full holder
+  cap, accreditation, qualified-purchaser, and jurisdiction gating.
+* **Scrip path** — settlement at the cyberSCRIP layer with deferred
+  de-scripification, including the AMM-native variant powered by LiquiLeX.
+
+**Contracts:** [`DealManager`](../reference/contracts/DealManager.md),
+[`LeXscroWLite`](../reference/contracts/LeXscroWLite.md),
+[`IssuanceManager`](../reference/contracts/IssuanceManager.md),
+[`CyberScrip`](../reference/contracts/CyberScrip.md).
+
+## ACE (Asset Conversion to Equity)
+
+**What it is.** A structured Reg-S-compliant offering with zkPassport-based
+jurisdictional gating that lets a token community convert into equity
+stakeholders of an issuing corporation. Live at
+[ace.metalex.tech](https://ace.metalex.tech).
+
+**Contracts:**
+[`PumpCorpFactory`](../reference/factories.md#pumpcorpfactory),
+[`ACESAFEExtension`](../reference/extensions.md#acesafeextension).
+
+**Reference UI:** the `/ace` route in
+[`apps/cybercorps-web/src/app/ace`](https://github.com/MetaLex-Tech/metalex-webapp/tree/develop/apps/cybercorps-web/src/app/ace),
+with Solana bridge integrations (`/ace/bridge-to-solana`,
+`/ace/bridge-from-solana`).
+
+## LiquiLeX
+
+**What it is.** AMM-native secondary liquidity for cyberSCRIPs. Uniswap v4
+pools paired against stablecoins, with the
+[`MetalexIssuerFeeHook`](../reference/hooks.md#metalexissuerfeehook)
+routing swap fees to MetaLeX and the issuer.
+
+**Two compliance models:** whitelisted pool (full credential check on every
+swap) and open pool (compliance gated at de-scripification, optionally with
+a lighter zkPassport gate at the swap layer).
+
+## cyberSign
+
+**What it is.** Cybernetic legal-agreement execution. Templates registered
+in `CyberAgreementRegistry`, parties countersign onchain via EIP-712, and
+execution is anchored to cyberCERTs and deal records. Unbundled from
+cyberRAISE: usable as a standalone signing layer for any legal instrument.
+
+**Contracts:**
+[`CyberAgreementRegistry`](../reference/contracts/CyberAgreementRegistry.md).
+
+## Mainframe
+
+Issuer-facing hub. Cap table / holder register by class, fundraising round
+configuration, deal management, agreement signing, scripification controls,
+transfer hook configuration, BorgAuth role management, holder-of-record
+reporting, and 12(g) (or jurisdictional analogue) threshold monitoring
+across cyberCERT and cyberSCRIP holder bases.
+
+**Reference UI:** the `/cybercorps` route in
+[`apps/cybercorps-web/src/app/(frame-layout)/cybercorps`](https://github.com/MetaLex-Tech/metalex-webapp/tree/develop/apps/cybercorps-web/src/app/%28frame-layout%29/cybercorps).
+
+## MetaDAO
+
+Futarchy-governed Cayman SPC structure. Each portfolio (SegCo) has its own
+futarchy oracle.
+
+**Contracts:**
+[`MetaDAOFactory`](../reference/factories.md#metadaofactory).
+
+**Reference UI:** the `/metadao` route in
+[`apps/cybercorps-web/src/app/(frame-layout)/metadao`](https://github.com/MetaLex-Tech/metalex-webapp/tree/develop/apps/cybercorps-web/src/app/%28frame-layout%29/metadao).
+
+## LeXcheX
+
+Onchain accreditation / KYC-AML credentials. Soulbound, wallet-bound NFT
+certificates.
+
+**Contracts:**
+[`LexChex / LexChexMinter`](../reference/contracts/LexChex.md).
+
+**Reference UI:**
+[`apps/lexchex-web`](https://github.com/MetaLex-Tech/metalex-webapp/tree/develop/apps/lexchex-web)
+at lexchex.metalex.tech, with an oracle service at
+[`apps/lexchex-oracle`](https://github.com/MetaLex-Tech/metalex-webapp/tree/develop/apps/lexchex-oracle).
+
+## Supporting services in `metalex-webapp`
+
+* **`apps/cybercorps-indexer`** — ponder-based indexer projecting protocol
+  events into a SQL store for fast cap-table queries.
+* **`apps/notifier`** — event-driven notifications (round close, deal
+  ready, registration approval needed).
+* **`apps/snapshot-executor`** — executes Snapshot governance outcomes
+  on-chain where they affect a cyberCORP's authority.
+* **`apps/landing`** — the marketing landing page.
+
+## Build your own
+
+The contracts are the public surface. None of the apps above are required.
+Any front end can interact with the protocol; see
+[How-to: Integrate from a frontend](../how-to/integrate-from-frontend.md)
+for the recommended stack and patterns.

--- a/docs/explanation/co-approval-upgradeability.md
+++ b/docs/explanation/co-approval-upgradeability.md
@@ -1,0 +1,59 @@
+# Co-approval upgradeability
+
+Upgradeable contracts are a power-concentration risk. The wrong upgrade key
+on a stock-ledger contract is, functionally, the wrong signature on a board
+resolution. cyberCORPs solves this with a **co-approval** model: neither
+MetaLeX nor any individual issuer can unilaterally upgrade a deployed
+cyberCORP.
+
+## How it works
+
+Each cyberCORP's top-level contracts (`CyberCorp`, `IssuanceManager`,
+`DealManager`, `RoundManager` in v3) are UUPS-upgradeable proxies. The
+`upgradeToAndCall(impl, data)` function is gated on **two** invariants:
+
+1. `impl` must be a MetaLeX-published reference implementation (tracked on
+   the relevant factory via `setRefImplementation` / variants).
+2. The caller must hold the issuer's `UPGRADE_AUTHORITY` BorgAuth role.
+
+Neither condition is sufficient alone:
+
+* MetaLeX publishing a new implementation does *not* upgrade anyone. The
+  factory's reference is just a published address.
+* An issuer attempting to upgrade to an arbitrary implementation will
+  revert. The implementation must be on the factory's allow-list.
+
+## What this buys you
+
+* **No forced migrations.** A cyberCORP that wants to stay on its current
+  implementation can do so indefinitely.
+* **No MetaLeX admin keys over your stock ledger.** MetaLeX is a protocol
+  developer and steward, not a securities intermediary.
+* **No issuer escape to a malicious implementation.** Issuers cannot dodge
+  protocol invariants by upgrading to a fork.
+
+## Beacons for downstream instances
+
+`CyberCertPrinter` and `CyberScrip` instances use beacon proxies pointing at
+beacons **owned by the IssuanceManager itself**. When the IssuanceManager's
+officer upgrades the beacon, every printer/scrip instance under that
+IssuanceManager moves together — which is what you usually want, since they
+share storage layout and behavioural assumptions.
+
+The same co-approval invariant applies: the beacon will only accept
+implementations registered on the factory.
+
+## Legacy paths
+
+Legacy cyberCORPs deployed before v3 use top-level beacon proxies pointing
+at MetaLeX-owned beacons. They continue to receive upgrades via the beacon
+pattern (which is more MetaLeX-controlled), but the underlying invariant
+— co-approval — is preserved at the implementation-publication step. Legacy
+deployments can migrate to v3 in place via the `*WithMigration.sol`
+variants.
+
+## See also
+
+* [Upgrade model](../reference/upgrade-model.md)
+* [How-to: Upgrade a cyberCORP](../how-to/upgrade-a-cybercorp.md)
+* [The role of MetaLeX](role-of-metalex.md)

--- a/docs/explanation/compliance-architecture.md
+++ b/docs/explanation/compliance-architecture.md
@@ -1,0 +1,85 @@
+# Compliance architecture
+
+The protocol does not bake any specific compliance regime into the
+contracts. Instead, it exposes a small number of **extension points** —
+conditions, credentials, and the de-scripification boundary — and lets
+issuers compose them to satisfy whatever rules apply to them (Reg D, Reg S,
+local private-placement regimes, qualified-purchaser rules, sanctions
+screening, etc.).
+
+## The two big extension points
+
+### 1. `ICondition` everywhere
+
+Every state transition that matters legally — issuance, scripification,
+de-scripification, deal close, round acceptance — accepts an `ICondition`.
+The condition is evaluated at the moment of state change.
+
+This means you can express:
+
+* "This investor must hold a valid LeXcheX accreditation credential."
+* "This buyer must have a zkPassport proof that they are non-US."
+* "This recipient must hold a soulbound club-membership NFT."
+* "This transaction must occur after our SEC Form D filing block."
+
+…and any composition of the above.
+
+### 2. The de-scripification boundary
+
+The critical insight: **compliance at the register boundary, freedom in
+between**. cyberSCRIP can flow freely (or under light gates); when someone
+wants to become the holder of record, the full gate runs.
+
+This pattern lets you:
+
+* Have a globally tradable AMM market on private equity.
+* Avoid having to KYC every counterparty in that market.
+* Still maintain a fully compliant register at the level that matters
+  legally.
+
+For regulated instruments where even the swap layer must be gated, the
+whitelisted-pool model checks credentials on every swap. Both models live in
+the same contract suite.
+
+## Credentials: LeXcheX
+
+LeXcheX is the protocol's accreditation and KYC-AML credential layer (see
+[`LexChex`](../reference/contracts/LexChex.md)). Credentials are soulbound
+NFTs minted to a wallet after the holder completes onboarding (questionnaire,
+portfolio valuation, agreement countersigning). The credentials can be
+checked by `lexchexCondition` anywhere in the protocol.
+
+For onchain wealth-based accreditation ("my $5M ETH portfolio makes me
+qualified"), see the reference UI at
+[`apps/lexchex-web`](https://github.com/MetaLex-Tech/metalex-webapp/tree/develop/apps/lexchex-web)
+in `metalex-webapp`.
+
+## Credentials: zkPassport
+
+For Reg S and sanctions-screening purposes, `NonUSNationalityCondition`
+integrates a zkPassport proof that the address is held by a non-US person.
+Unlike LeXcheX, zkPassport is zero-knowledge: the address proves
+nationality status without revealing identity. Useful at the swap layer of
+open LiquiLeX pools.
+
+## Reg D vs. Reg S
+
+| Regime | Typical pattern |
+|---|---|
+| Reg D (US) | LeXcheX accreditation + KYC required on all primary investors and on de-scripification. Whitelisted LiquiLeX pool. |
+| Reg S (non-US) | zkPassport non-US proof at primary, optional light zkPassport gate at swap, full credential on de-scripification. |
+| Combined | `OrCondition` allowing either path; cyberCORP serves both audiences with two issuance flows. |
+
+## Holder caps
+
+`CyberCertPrinter.setMaxHolders(n)` and `CyberScrip.setMaxHolders(n)` let
+you monitor and enforce 12(g) thresholds (US) and their analogues. The
+Mainframe UI surfaces these alongside the holder lists for proactive
+management.
+
+## See also
+
+* [Conditions](../reference/conditions.md)
+* [`LexChex`](../reference/contracts/LexChex.md)
+* [How-to: Gate state transitions with conditions](../how-to/gate-with-conditions.md)
+* [Composability and DeFi](composability.md)

--- a/docs/explanation/composability.md
+++ b/docs/explanation/composability.md
@@ -1,0 +1,59 @@
+# Composability and DeFi
+
+A tokenised security is only as useful as the protocols it can interact
+with. cyberSCRIP is the layer where that interaction happens.
+
+## What cyberSCRIP unlocks
+
+* **AMM liquidity.** A LiquiLeX Uniswap v4 pool can quote a cyberSCRIP
+  against USDC continuously. The `MetalexIssuerFeeHook` routes a portion of
+  swap fees to the issuer, turning the cyberCORP into a tiny perpetual
+  fee-receiver on its own scrip.
+* **Lending and money markets.** A cyberSCRIP, like USDC, is an ERC-20 with
+  optional compliance powers. It can be listed as collateral on lending
+  protocols that accept ERC-20s with admin extensions.
+* **Vesting and streaming.** Any standard ERC-20 vesting contract works.
+* **Programmable distributions.** Dividends, buybacks, or other holder-
+  facing flows can be paid in or settled against cyberSCRIP.
+
+## What you trade off
+
+### Restricted ERC-20
+
+A cyberSCRIP with a `WhitelistTransferHook` is not a free-floating ERC-20.
+Some integrations (especially permissionless ones) will reject it. Operators
+should either pick an open compliance model (no transfer hook, compliance at
+the de-scripification boundary) or accept that their scrip will only flow
+through whitelisted venues.
+
+### Compliance powers are visible
+
+Force transfer / force burn / freeze / blocklist are public functions on the
+cyberSCRIP, even when not currently invoked. Some lending protocols will
+decline to list any ERC-20 with these powers. The **permanent disable**
+toggles (`permanentlyDisableForceTransfer`, etc.) exist for exactly this
+reason: an issuer can credibly commit to an open posture.
+
+### Token possession ≠ registered ownership
+
+This is by design (see [the dual-token model](dual-token-model.md)) but it
+means naive integrations may make wrong assumptions. The cyberSCRIP holder
+is not the holder of record. The cyberCERT holder is. Anywhere registered
+ownership matters (voting, dividends to record holders, §219 lists), reads
+must go through the cert layer.
+
+## The two LiquiLeX models, side-by-side
+
+| Aspect | Whitelisted pool | Open pool |
+|---|---|---|
+| Per-swap check | Full LeXcheX credential | Optional zkPassport (sanctions / Reg S) |
+| Pool address | Only whitelisted addresses can hold LP | Anyone can hold LP |
+| Holder of record | Same regardless of trades | Same regardless of trades |
+| De-scripification gate | Standard | Standard (this is where compliance lives) |
+| Best for | High-touch private credits, Reg D names | Reg S issuances, public-style scrip |
+
+## See also
+
+* [How-to: Deploy a LiquiLeX pool](../how-to/deploy-liquilex-pool.md)
+* [Compliance architecture](compliance-architecture.md)
+* [Hooks](../reference/hooks.md)

--- a/docs/explanation/constitutive-vs-pointer.md
+++ b/docs/explanation/constitutive-vs-pointer.md
@@ -1,0 +1,70 @@
+# Constitutive vs. pointer tokenization
+
+Most "tokenized securities" today are **pointer tokens**. The official cap
+table lives at a transfer agent, on Carta, or in a law firm's filing cabinet.
+The chain is a notification layer. Onchain transfers are not the legal
+transfer; they are a request to update an offchain register that the issuer
+or its agents may decline to honour. The blockchain does no essential work
+and could be removed without changing the underlying legal reality.
+
+cyberCORPs takes the opposite approach.
+
+## The constitutive move
+
+Each cyberCORP's governing documents — certificate of incorporation and
+bylaws, operating agreement, articles of association, partnership agreement,
+fund constitutional documents, or analogous instrument under the entity's
+governing law — **designate the onchain contract system as the entity's
+official register of holders**, with the fungible scrip layer authorised by
+the same instruments.
+
+The legal state-transition function and the chain state-transition function
+are unified: **changing onchain state is the legal change**. There is no
+offchain register to reconcile against, no transfer agent to instruct, and no
+possibility of the chain and the legal record diverging.
+
+## Why this is possible under Delaware law
+
+* **DGCL §224** explicitly permits *any* books and records, including the
+  stock ledger, to be kept in any form, including a blockchain, provided the
+  records can be converted to clearly legible paper form and provide
+  information required by other DGCL sections (§158 share-certificate
+  requirements, §219 stockholder list rights, etc.).
+* **DGCL §155** authorises scrip — meaning the cyberSCRIP layer is itself
+  authorised as a form of the security, not as a synthetic derivative.
+* **DGCL §158** sets the information that a certificate must convey (issuer
+  name, holder name, units, class, restrictions, signatures). cyberCERT
+  metadata encodes all of these directly.
+* **DGCL §202** permits restrictive legends; cyberCERT extensions encode
+  them.
+* **DGCL §219** governs stockholder-list rights; the cyberCORP register is
+  queryable on-chain by anyone and can be exported to any required format.
+
+## Why this is possible elsewhere
+
+Delaware is the most fully worked-out reference. Comparable provisions or
+contractual workarounds exist under Delaware LLC law (operating agreement
+autonomy), Cayman corporate and SPC regimes, BVI corporate law, English
+corporate law, and partnership / fund statutes.
+
+The protocol does not assume any specific statute. It assumes only that the
+entity's governing law permits the onchain register to be designated as
+authoritative through the entity's governing documents — and offers
+entity-type and jurisdiction as configuration on the `CyberCorp` contract.
+
+## What this lets you do
+
+* A cyberCERT is your interest in the entity *as it lives in the official
+  records*. Not a pointer.
+* A cyberSCRIP is *the same security in scrip form*. Not a wrapper, not a
+  derivative, not a receipt for a receipt.
+* You can hand a regulator, an auditor, or a court the chain itself and ask
+  what the entity's holder register is. The answer is in the bytes.
+
+This is the basis of every other design decision the protocol makes.
+
+## Further reading
+
+* MetaLeX, ["What Is Slop Tokenization and Why Is It Bad?"](https://metalex.substack.com/)
+* MetaLeX, ["5 Ways of Tokenizing Securities (& One Which Is Best)"](https://x.com/lex_node/status/2030322576208068616)
+* SEC, January 2026 Joint Staff Statement on Tokenized Securities.

--- a/docs/explanation/dual-token-model.md
+++ b/docs/explanation/dual-token-model.md
@@ -1,0 +1,83 @@
+# The dual-token model
+
+The protocol's defining architectural innovation is a dual-token model that
+resolves the tension between **legal fidelity** and **DeFi composability**.
+
+## The two tokens
+
+### cyberCERT (ERC-721) — the register
+
+Each cyberCERT is a single entry on the cyberCORP's onchain register of
+holders, encoding everything that the relevant governing law requires:
+holder name, unit count, class / series, restriction legends, endorsement
+history, authorized signatures, acquisition price, and the governing
+agreement URI.
+
+Crucially, **NFT transfer alone does not change registered ownership.**
+Metadata must be explicitly mutated through `IssuanceManager`. This
+maintains the distinction between *token possession* and *registered
+ownership* that corporate, LLC, partnership, and fund law require.
+
+### cyberSCRIP (ERC-20) — the trading form
+
+cyberSCRIPs are fungible tokens generated from cyberCERTs via
+`scripifyCert()` and convertible back via `convertScripToCert()`. They are
+the DeFi composable layer: usable in AMMs (including LiquiLeX pools),
+lending protocols, vesting contracts, and as collateral.
+
+The critical claim: **cyberSCRIPs are not wrappers or derivatives.** They
+are *securities in scrip form*. Under DGCL §155 (in the Delaware corp case)
+or the analogous contractual or statutory authority under the entity's
+governing law, scrip is itself an authorised form of the security. Every
+circulating cyberSCRIP traces, through the protocol's own logic, to a
+specific cyberCERT on the authoritative register.
+
+## The plain-English version
+
+* A **cyberCERT** is your interest in the entity as it lives in the official
+  records (a share of stock, an LLC membership interest, an LP unit, a fund
+  interest).
+* A **cyberSCRIP** is what you can trade or post as collateral when you do
+  not need to be registered as a holder of record at that moment.
+* Both are the same security in different forms, with bidirectional
+  conversion always available.
+
+## Why this works
+
+### Composability without losing the register
+
+A cyberSCRIP can sit in a Uniswap v4 pool and trade in size all day. The
+register does not move. When a long-term holder wants to be the holder of
+record, they de-scripify — and at that moment, and only at that moment, the
+full issuer-approval / accreditation gate runs.
+
+### Compliance at the boundary
+
+This is what lets a LiquiLeX pool be either *whitelisted* (compliance on
+every swap) or *open* (compliance at de-scripification, with optional
+light-touch zkPassport screening at swap). The boundary is the only place
+that matters legally, because that is where the register changes.
+
+### Partial scripification
+
+A holder of 1,000,000 units can scripify 250,000 to trade and keep 750,000
+on the cert. The cert remains active with the reduced unit count. The
+Scripified Share Pool (an ERC-4626-style vault inside the `IssuanceManager`)
+tracks each registered holder's scripified balance so that de-scripification
+withdraws proportionally.
+
+## What it isn't
+
+* Not a wrapped-token model. The scrip is the security; the wrap-and-unwrap
+  framing is wrong.
+* Not a derivative model. There is no contract for difference, no
+  shadow-asset, no offchain leg.
+* Not a synthetic. A cyberSCRIP is not a claim on a cyberCERT; it is the
+  same security in a different form.
+
+## See also
+
+* [Tutorial 3: Scripify and settle](../tutorials/scripify-and-settle.md)
+* [`IssuanceManager`](../reference/contracts/IssuanceManager.md),
+  [`CyberScrip`](../reference/contracts/CyberScrip.md)
+* [Composability and DeFi](composability.md)

--- a/docs/explanation/legal-mappings.md
+++ b/docs/explanation/legal-mappings.md
@@ -1,0 +1,81 @@
+# Legal mappings across jurisdictions
+
+cyberCORPs treats entity type and jurisdiction as *configuration*. The same
+contract primitives serve a Delaware C-corp, a Delaware LLC, a Cayman SPC,
+a BVI fund, and an English company. The mappings below show what each
+field on a cyberCERT or cyberCORP means under each regime.
+
+## Delaware C-corp (the worked example)
+
+| Protocol object | Statutory hook |
+|---|---|
+| Onchain register | DGCL §224 (books and records in any form) |
+| Authorized share counts | DGCL §151 (classes / series) |
+| cyberSCRIP | DGCL §155 (scrip authority) |
+| Cert metadata (holder, units, class, signatures) | DGCL §158 (share-certificate requirements) |
+| Restrictive legends | DGCL §202 |
+| Stockholder list rights | DGCL §219 (the register is the list) |
+
+The entity's certificate of incorporation and bylaws designate the onchain
+contract system as authoritative.
+
+## Delaware LLC
+
+* The operating agreement designates the onchain register as authoritative.
+  Delaware LLC law gives operating agreements broad latitude to define
+  member-interest accounting; there is no "§224 analogue" needed.
+* Membership interests use the same `ShareExtension` (configured per the
+  LLC's class structure).
+* Cert fields map to whatever the operating agreement requires for each
+  membership-interest entry.
+
+## Cayman LLC / SPC
+
+* The constitutional documents (M&AA, LLC agreement) designate the onchain
+  register as authoritative. Cayman LLC and SPC statutes accommodate this
+  contractually.
+* SPC structures use `MetaDAOFactory` (or a custom factory) to model
+  segregated portfolios as logical sub-entities sharing the same parent
+  cyberCORP.
+
+## BVI fund / company
+
+* Articles of association or the fund's constitutional documents anchor the
+  onchain register.
+* Cert fields map to the BVI Business Companies Act 2004 share-register
+  requirements, or to the fund's constitutional analogues.
+
+## English company
+
+* Articles of association designate the onchain register as authoritative.
+* Cert fields map to the Companies Act 2006 §113 register-of-members
+  requirements.
+* Note that uncertificated shares in CREST are a separate regime; the
+  cyberCORP register is *the* register for purposes of the constitutional
+  documents.
+
+## Funds (LP / LLC / fund interests)
+
+* The partnership agreement / fund LPA designates the onchain register as
+  authoritative.
+* Capital commitments, calls, and distributions can be modelled using the
+  existing primitives (cyberCERT for the LP unit, cyberSCRIP for tradable
+  fund interest, `DealManager` for capital calls).
+
+## The common substrate
+
+Under every regime, two things must be true for the protocol to apply:
+
+1. The governing law permits the entity's constitutional documents to
+   designate an external record-keeping system as authoritative.
+2. The constitutional documents in fact do so, and identify the cyberCORP
+   contract suite (by addresses or by registry reference).
+
+Most developed corporate, LLC, partnership, and fund regimes satisfy (1).
+The second is a drafting task, addressed by MetaLeX's template library.
+
+## See also
+
+* [Constitutive vs. pointer tokenization](constitutive-vs-pointer.md)
+* [Regulatory context](regulatory-context.md)
+* [Agreement templates](../reference/templates.md)

--- a/docs/explanation/regulatory-context.md
+++ b/docs/explanation/regulatory-context.md
@@ -1,0 +1,76 @@
+# Regulatory context
+
+This page is a brief, non-exhaustive map of the regulatory backdrop the
+protocol is designed for. It is **not legal advice**. Issuers must consult
+their own counsel.
+
+## US securities laws
+
+### Reg D (private placements to US investors)
+
+The standard exemption for unregistered US private placements. Imposes
+accreditation requirements (Rule 506(b)/(c)) and limits on general
+solicitation. The protocol supports Reg D via:
+
+* `lexchexCondition` with `hasAccreditation` checks at issuance, deal close,
+  and de-scripification.
+* Reg D agreement templates (`MetaLeX cyberSAFE US style Reg D`, etc.).
+* Holder caps (12(g) threshold monitoring via `setMaxHolders`).
+
+### Reg S (offers to non-US persons)
+
+The extraterritorial-offering exemption. The protocol supports Reg S via:
+
+* `NonUSNationalityCondition` (zkPassport).
+* Reg S agreement templates.
+* Optional whitelisted-pool or open-pool LiquiLeX models with the
+  appropriate gate.
+
+### Tokenized securities — SEC January 2026 Joint Staff Statement
+
+In January 2026 the SEC's Division of Corporation Finance issued a joint
+staff statement clarifying that the agency's traditional analytical
+framework for securities laws applies to tokenized securities. The cyberCORPs
+protocol is designed to be compatible with that framework: a tokenized
+security is a security, treated as such, and the chain is the medium not
+the escape.
+
+See:
+[corp-fin-statement-tokenized-securities-012826](https://www.sec.gov/newsroom/speeches-statements/corp-fin-statement-tokenized-securities-012826).
+
+### Covered User Interface Providers — SEC April 2026 Staff Statement
+
+In April 2026 the SEC issued staff guidance on "covered user interface
+providers" (File No. 4-894). The statement creates a safe harbour for
+front-end operators that meet specified conditions, relevant to operators of
+cyberTRADE and LiquiLeX front ends. The contract architecture stays neutral
+to front-end legal status: whichever harbour a UI operator chooses to
+rely on, the chain-side primitives do not change.
+
+## Delaware General Corporation Law
+
+The most fully worked-out statutory reference for the protocol. See
+[Legal mappings](legal-mappings.md) for the field-by-field hooks (DGCL §§
+151, 155, 158, 202, 219, 224).
+
+## Other jurisdictions
+
+Delaware LLC law, Cayman corporate / SPC regimes, BVI corporate law,
+English corporate law (Companies Act 2006), and various partnership /
+fund statutes all accommodate the protocol's constitutional designation
+pattern. See [Legal mappings](legal-mappings.md).
+
+## What is *not* in scope
+
+* Broker-dealer registration analysis for any specific front end. (See SEC
+  April 2026 Staff Statement for the UI-provider safe harbour conditions.)
+* AIFMD / EU MiCA / specific national private-placement regimes. The
+  protocol does not encode these; issuers under those regimes configure
+  conditions and agreements to comply.
+* Tax. The protocol records what happens; tax treatment of each event is
+  an issuer/holder question.
+
+## See also
+
+* [MetaLeX Substack](https://metalex.substack.com/) for the running
+  commentary on regulatory developments.

--- a/docs/explanation/role-of-metalex.md
+++ b/docs/explanation/role-of-metalex.md
@@ -1,0 +1,61 @@
+# The role of MetaLeX
+
+A tokenised-securities system designed badly turns the issuing platform into
+a securities intermediary with admin keys over every issuer's stock ledger.
+That is bad legally (the platform becomes a transfer agent / clearing
+intermediary, subject to the corresponding regulatory burden) and bad
+structurally (the issuer's autonomy is fictional).
+
+cyberCORPs is designed so that MetaLeX is **not** an intermediary.
+
+## What MetaLeX does
+
+* Develops the contracts.
+* Publishes new implementations to the factories.
+* Maintains agreement templates.
+* Operates LeXcheX (an oracle), so MetaLeX or a delegate signs accreditation
+  attestations into the credential registry.
+* Runs the reference UIs (the cyberCORPs Mainframe, ACE, LeXcheX onboarding,
+  the landing page) — *as one possible front end*. Anyone can build their
+  own.
+
+## What MetaLeX does *not* do
+
+* Hold issuer custody. Funds in flight are in `LeXscroWLite`, which has no
+  admin keys. MetaLeX cannot move them.
+* Hold issuer admin keys. Each cyberCORP's BorgAuth roles are owned by the
+  issuer's governance addresses (board / officer multisigs). MetaLeX is not
+  on the list.
+* Force upgrades. The co-approval upgrade model requires the issuer's
+  `UPGRADE_AUTHORITY` to opt in. MetaLeX cannot push an upgrade. (See
+  [co-approval upgradeability](co-approval-upgradeability.md).)
+* Approve trades. The issuer's `OFFICER_AUTHORITY` approves deals; MetaLeX
+  is not in that loop.
+* Maintain a separate offchain register. There is no offchain register.
+
+## Why this matters
+
+If MetaLeX held admin keys over each issuer's cyberCORP, MetaLeX would be
+the transfer agent. That has legal consequences (transfer-agent
+registration, intermediary liability) and structural ones ("trustless"
+is a lie).
+
+By making MetaLeX a *protocol developer and steward* — publishing
+implementations and operating a credential oracle, but never holding
+issuer-side authority — the protocol stays neutral, and each cyberCORP's
+governance is exactly what its constitutional documents say it is.
+
+## The UI provider question
+
+When MetaLeX (or anyone) runs a front end that helps investors find issuers
+(cyberRAISE, LiquiLeX, ACE), it may fall under the SEC's April 2026 Staff
+Statement on Covered User Interface Providers (File No. 4-894). The contract
+architecture is designed so that whatever a UI provider does at the
+web layer, the chain-side state-transition system stays neutral. See
+[regulatory context](regulatory-context.md).
+
+## See also
+
+* [Co-approval upgradeability](co-approval-upgradeability.md)
+* [Constitutive vs. pointer tokenization](constitutive-vs-pointer.md)
+* [Regulatory context](regulatory-context.md)

--- a/docs/how-to/README.md
+++ b/docs/how-to/README.md
@@ -1,0 +1,30 @@
+# How-to Guides
+
+How-to guides are recipes. They assume you already know roughly what you are
+doing and want the shortest path to a specific result.
+
+If you are new, work through the [Tutorials](../tutorials/README.md) first.
+
+## Issuance & governance
+
+* [Configure BorgAuth roles](configure-roles.md)
+* [Issue a cyberCERT](issue-a-cybercert.md)
+* [Restrict cyberSCRIP transfers](restrict-transfers.md)
+* [Gate state transitions with conditions](gate-with-conditions.md)
+* [Sign a cyberAgreement](sign-a-cyberagreement.md)
+
+## Settlement & trading
+
+* [Run a secondary trade](run-a-secondary-trade.md)
+* [Convert SAFEs to equity](convert-safe-to-equity.md)
+* [Deploy a LiquiLeX pool](deploy-liquilex-pool.md)
+
+## Specialised entity structures
+
+* [Deploy a PumpCorp for ACE](deploy-pumpcorp-ace.md)
+* [Deploy a MetaDAO SPC](deploy-metadao-spc.md)
+
+## Operations
+
+* [Upgrade a cyberCORP](upgrade-a-cybercorp.md)
+* [Integrate from a frontend](integrate-from-frontend.md)

--- a/docs/how-to/configure-roles.md
+++ b/docs/how-to/configure-roles.md
@@ -1,0 +1,68 @@
+# Configure BorgAuth roles
+
+All authority on a cyberCORP flows through **BorgAuth**, a multi-authority
+role-based access control framework (see
+[borg-core](https://github.com/MetaLex-Tech/borg-core)).
+
+Roles correspond to governance roles in the entity's constitutional documents
+(officers, directors, secretary, manager, general partner, etc.). The cyberCORP
+makes no assumption about which roles exist — you wire them.
+
+## When to use this guide
+
+You need to grant, revoke, or rotate authority on an existing cyberCORP.
+
+## Steps
+
+### 1. Identify the role
+
+Common BorgAuth role identifiers used by the protocol:
+
+| Role | Permitted actions |
+|---|---|
+| `ISSUER_AUTHORITY` | Mint and revoke cyberCERTs via `IssuanceManager`. |
+| `OFFICER_AUTHORITY` | Co-sign on registration approvals, sign agreements on the entity's behalf. |
+| `DIRECTOR_AUTHORITY` | Approve resolutions, change officers, authorise share classes. |
+| `SECRETARY_AUTHORITY` | Endorse cyberCERTs (e.g., legend updates). |
+| `UPGRADE_AUTHORITY` | Co-approve UUPS implementation upgrades for this cyberCORP. |
+| `COMPLIANCE_AUTHORITY` | Operate force-transfer / force-burn / freeze / blocklist powers on cyberSCRIP (if not renounced). |
+
+See [Access control reference](../reference/access-control.md) for the
+authoritative list.
+
+### 2. Grant a role
+
+```solidity
+IBorgAuth auth = IBorgAuth(cyberCorp.auth());
+auth.grantRole(ISSUER_AUTHORITY, newOfficer);
+```
+
+The call requires the existing `ADMIN_AUTHORITY` (typically the board /
+managers, often a multisig).
+
+### 3. Revoke a role
+
+```solidity
+auth.revokeRole(ISSUER_AUTHORITY, departedOfficer);
+```
+
+### 4. Rotate (atomic)
+
+For a clean swap, batch into one transaction (e.g., from a Safe multisig):
+
+```solidity
+auth.grantRole(OFFICER_AUTHORITY, newCfo);
+auth.revokeRole(OFFICER_AUTHORITY, oldCfo);
+```
+
+## Verification
+
+```solidity
+bool hasIt = auth.hasRole(OFFICER_AUTHORITY, newCfo);
+```
+
+## Related
+
+* [Access control reference](../reference/access-control.md)
+* [The role of MetaLeX](../explanation/role-of-metalex.md) — why no
+  protocol-level admin keys exist over your roles.

--- a/docs/how-to/convert-safe-to-equity.md
+++ b/docs/how-to/convert-safe-to-equity.md
@@ -1,0 +1,64 @@
+# Convert SAFEs to equity
+
+When a cyberCORP runs its first priced round, outstanding SAFEs must convert
+into the new preferred series. The `SafeCertificateConverter` computes the
+conversion plan from a round-pricing snapshot and a cap-table snapshot, and
+the `IssuanceManager` executes it.
+
+## Prerequisites
+
+* You have one or more SAFE cyberCERTs outstanding (issued via the
+  [`SAFEExtension`](../reference/extensions.md)).
+* You have configured the priced round in the `RoundManager` and know its
+  `pricePerShare` and `preMoneyValuation`.
+* The Series A `ShareExtension` parameters (liquidation preference, etc.) are
+  set.
+
+## Steps
+
+### 1. Snapshot the cap table
+
+```solidity
+bytes32 capTableSnapshot = cyberShares.snapshot();
+```
+
+### 2. Compute the plan
+
+```solidity
+ISafeCertificateConverter converter = ISafeCertificateConverter(CONVERTER);
+
+ConversionPlan memory plan = converter.computePlan(
+    safeCertIds,        // uint256[] of SAFE certs to convert
+    capTableSnapshot,
+    RoundPricing({
+        pricePerShare: 2.50e6,        // $2.50 / share in USDC
+        preMoneyValuation: 20_000_000e6
+    })
+);
+```
+
+The plan applies each SAFE's valuation cap, discount and MFN provisions
+(per its `SAFEExtension` metadata) to produce a per-SAFE share count and
+residual cash refund (if any).
+
+### 3. Review and execute
+
+Inspect `plan.entries[i]` for each SAFE. When satisfied:
+
+```solidity
+issuanceManager.executeSafeConversion(plan);
+```
+
+The call will:
+
+* burn each input SAFE cyberCERT,
+* mint a Series A `ShareExtension`-typed cyberCERT to each former SAFE holder,
+* endorse each new cert with a reference to the conversion event,
+* refund any residual to the holder (rare; depends on rounding policy).
+
+## Related
+
+* Reference:
+  [`SafeCertificateConverter`](../reference/contracts/SafeCertificateConverter.md),
+  [Extensions](../reference/extensions.md).
+* Tutorial: [Run a cyberRAISE round](../tutorials/run-a-cyberraise-round.md).

--- a/docs/how-to/deploy-liquilex-pool.md
+++ b/docs/how-to/deploy-liquilex-pool.md
@@ -1,0 +1,64 @@
+# Deploy a LiquiLeX pool
+
+**LiquiLeX** provides AMM-native secondary liquidity for cyberSCRIP via
+Uniswap v4 pools paired against a stablecoin, with the
+`MetalexIssuerFeeHook` routing swap fees to MetaLeX and the issuer at
+configured rates.
+
+## Prerequisites
+
+* A cyberCORP with a deployed `CyberScrip` for the class you want to make
+  liquid.
+* You have decided on a compliance model:
+  * **Whitelisted pool** — every swap checks LeXcheX credentials.
+  * **Open pool** — swaps are unrestricted; compliance is enforced at the
+    de-scripification boundary, optionally with a lighter zkPassport gate at
+    swap for sanctions and Reg S screening.
+
+## Steps
+
+### 1. Deploy the fee hook
+
+```solidity
+MetalexIssuerFeeHook hook = new MetalexIssuerFeeHook(
+    METALEX_TREASURY,
+    issuerTreasury,
+    metalexBps,     // e.g., 10  (0.10%)
+    issuerBps       // e.g., 20  (0.20%)
+);
+```
+
+Uniswap v4 hooks have address-suffix requirements. Use `HookMiner` or the
+standard salt-mining flow to deploy at a compliant address.
+
+### 2. Initialise the pool
+
+Create a Uniswap v4 pool with:
+
+* `currency0 = cyberScrip`
+* `currency1 = USDC` (or your chosen stablecoin)
+* `fee = poolFee` (the protocol fee; separate from the issuer/MetaLeX hook fee)
+* `hooks = address(hook)`
+
+### 3. Seed liquidity
+
+A founder, treasury, or scripified position provides initial liquidity. If the
+cyberSCRIP has a `WhitelistTransferHook`, whitelist the pool address.
+
+### 4. (Optional) Add a zkPassport gate
+
+For open pools used for Reg S issuances, attach a `NonUSNationalityCondition`
+to the swap path through a custom router hook.
+
+## Compliance summary
+
+| Model | Per-swap check | De-scripification check |
+|---|---|---|
+| Whitelisted pool | Full LeXcheX | None additional |
+| Open pool | Optional zkPassport (sanctions, Reg S) | Full issuer approval + credential |
+
+## Related
+
+* Reference: [`MetalexIssuerFeeHook`](../reference/hooks.md#metalexissuerfeehook),
+  [`CyberScrip`](../reference/contracts/CyberScrip.md).
+* Explanation: [Composability and DeFi](../explanation/composability.md).

--- a/docs/how-to/deploy-metadao-spc.md
+++ b/docs/how-to/deploy-metadao-spc.md
@@ -1,0 +1,55 @@
+# Deploy a MetaDAO SPC
+
+A **MetaDAO** is a futarchy-governed corporation structured as a Cayman
+Segregated Portfolio Company (SPC) where each portfolio is independently
+governed by onchain prediction-market governance.
+
+The live UI lives at the
+[`apps/cybercorps-web/src/app/(frame-layout)/metadao`](https://github.com/MetaLex-Tech/metalex-webapp/tree/develop/apps/cybercorps-web/src/app/%28frame-layout%29/metadao)
+route of `metalex-webapp`.
+
+## Prerequisites
+
+* You have legal counsel familiar with Cayman SPCs and futarchy governance
+  on hand. The corresponding agreement templates are in the contracts
+  repository under `templates/` (search for `MetaDAO Futarchy Governance SPC`).
+* You are ready to designate a futarchy market venue.
+
+## Steps
+
+### 1. Use `MetaDAOFactory.createMetaDAO`
+
+```solidity
+IMetaDAOFactory f = IMetaDAOFactory(METADAO_FACTORY);
+
+address metaDao = f.createMetaDAO(MetaDAOParams({
+    legalName: "Acme MetaDAO SPC",
+    jurisdiction: "Cayman Islands",
+    futarchyOracle: ORACLE,        // prediction-market oracle
+    boardConsentTemplate: "ipfs://metadao-board-consent-v1",
+    segCoCombinedTemplate: "ipfs://metadao-segco-combined-v1"
+}));
+```
+
+The factory deploys an SPC-style cyberCORP and configures the agreement
+registry with the MetaDAO Futarchy templates.
+
+### 2. Approve segregated portfolios ("SegCos")
+
+New SegCos are approved by a board consent recorded in
+`CyberAgreementRegistry`. The factory pre-registers the `MetaDAO Futarchy
+Governance SPC - Board Consent - Approval of SegCo v 1.0` template; instances
+are countersigned onchain.
+
+### 3. Wire futarchy market outcomes to authority
+
+Each SegCo's governance authority is bound to the futarchy oracle's decision
+for that portfolio. Implementation detail varies by oracle; see the
+`MetaDAOFactory` source.
+
+## Related
+
+* Reference: [`MetaDAOFactory`](../reference/factories.md#metadaofactory),
+  [Agreement templates](../reference/templates.md).
+* Explanation:
+  [Legal mappings across jurisdictions](../explanation/legal-mappings.md).

--- a/docs/how-to/deploy-pumpcorp-ace.md
+++ b/docs/how-to/deploy-pumpcorp-ace.md
@@ -1,0 +1,63 @@
+# Deploy a PumpCorp for ACE
+
+**ACE** (Asset Conversion to Equity) lets a token community convert into
+equity stakeholders of an issuing corporation through a Reg S compliant
+offering with zkPassport-based jurisdictional gating.
+
+Under the hood, ACE is powered by `PumpCorpFactory` and the
+`ACESAFEExtension`. The live consumer product is
+[ace.metalex.tech](https://ace.metalex.tech), implemented in the
+[`apps/cybercorps-web/src/app/ace`](https://github.com/MetaLex-Tech/metalex-webapp/tree/develop/apps/cybercorps-web/src/app/ace)
+route of `metalex-webapp`.
+
+## When to use this guide
+
+You are an issuer who wants to run an ACE-style round: a structured Reg S
+offering open to non-US persons, where investors arrive holding tokens and
+leave holding ACE SAFEs (later convertible to equity).
+
+## Steps
+
+### 1. Configure the PumpCorp
+
+```solidity
+IPumpCorpFactory pf = IPumpCorpFactory(PUMP_FACTORY);
+
+address pumpCorp = pf.createPumpCorp(PumpCorpParams({
+    legalName: "Acme PumpCorp, Inc.",
+    jurisdiction: "Delaware, USA",
+    pricePerShare: 0.50e6,
+    raiseCap: 5_000_000e6,
+    perPartyAllocations: ...,           // optional per-investor allocations
+    nationalityCondition: nonUsCond,    // zkPassport: non-US only by default
+    agreementTemplate: "ipfs://ace-safe-regs-v1"
+}));
+```
+
+The factory deploys a complete cyberCORP suite plus an ACE-configured
+`RoundManager` and registers the `ACESAFEExtension` on the
+`CyberCertPrinter`.
+
+### 2. Open the round
+
+The round is created automatically on PumpCorp deployment in Reg-S-default
+mode. Open and close timestamps are part of `PumpCorpParams`.
+
+### 3. Investors submit EOIs and fund
+
+Identical to a standard cyberRAISE flow (see
+[Tutorial 2](../tutorials/run-a-cyberraise-round.md)), with the additional
+zkPassport check.
+
+### 4. Close and mint ACE SAFEs
+
+On close, each investor receives an ACE SAFE cyberCERT (an `ACESAFEExtension`
+cert). These convert to equity in the next priced round via the same
+[SAFE conversion flow](convert-safe-to-equity.md).
+
+## Related
+
+* Reference: [`PumpCorpFactory`](../reference/factories.md#pumpcorpfactory),
+  [Extensions → `ACESAFEExtension`](../reference/extensions.md#acesafeextension).
+* Explanation:
+  [Application stack — ACE](../explanation/application-stack.md#ace).

--- a/docs/how-to/gate-with-conditions.md
+++ b/docs/how-to/gate-with-conditions.md
@@ -1,0 +1,69 @@
+# Gate state transitions with conditions
+
+Any state transition in the protocol — issuance, scripification,
+de-scripification, deal close, round acceptance, secondary trade — can be
+gated by an arbitrary onchain check via the `ICondition` interface.
+
+## Built-in conditions
+
+| Condition | Effect |
+|---|---|
+| `lexchexCondition` | Requires a valid LeXcheX credential (KYC/AML, accreditation, qualified-purchaser). |
+| `NonUSNationalityCondition` | zkPassport-based check that the address is held by a non-US person (Reg S). |
+| `IssuerApprovalRecertificationCondition` | Requires explicit issuer approval before a non-registered scrip holder can present scrip for de-scripification. |
+| `OrCondition` | Composes multiple conditions with disjunctive logic. |
+
+See [Conditions reference](../reference/conditions.md).
+
+## Attach a condition to a round
+
+```solidity
+ICondition lexCond = ICondition(LEXCHEX_CONDITION_ADDR);
+
+roundManager.createRound(RoundConfig({
+    // ...
+    conditions: lexCond
+}));
+```
+
+Now no EOI can be accepted unless the investor's address has the credential.
+
+## Attach a condition to scripification
+
+```solidity
+issuanceManager.setScripifyCondition(SHARE_CLASS_COMMON, lexCond);
+```
+
+A cert holder will be unable to scripify unless they pass the check.
+
+## Compose conditions
+
+Use `OrCondition` (or a custom composer) for unions:
+
+```solidity
+OrCondition or = new OrCondition();
+or.add(lexchexCondition);
+or.add(nonUsCondition);
+issuanceManager.setDescripifyCondition(SHARE_CLASS_COMMON, or);
+```
+
+## Write a custom condition
+
+Implement `ICondition`:
+
+```solidity
+interface ICondition {
+    function check(address subject, bytes calldata context) external view returns (bool);
+}
+```
+
+Deploy and register it like any other. Anything expressible onchain — a token
+balance threshold, a Snapshot vote outcome, a UMA assertion, a Soulbound
+credential — can become a precondition for a state transition on your
+cyberCORP.
+
+## Related
+
+* Reference: [Conditions](../reference/conditions.md)
+* Explanation:
+  [Compliance architecture](../explanation/compliance-architecture.md)

--- a/docs/how-to/integrate-from-frontend.md
+++ b/docs/how-to/integrate-from-frontend.md
@@ -1,0 +1,87 @@
+# Integrate from a frontend
+
+This guide covers calling the protocol from a TypeScript / React / Next.js
+front end. The reference implementation is the
+[`metalex-webapp`](https://github.com/MetaLex-Tech/metalex-webapp) monorepo;
+the app most directly equivalent to a generic issuer Mainframe is
+[`apps/cybercorps-web`](https://github.com/MetaLex-Tech/metalex-webapp/tree/develop/apps/cybercorps-web).
+
+## Stack used in the reference UIs
+
+* **Next.js (App Router)** with `bun` as package manager
+* **wagmi + viem** for contract interaction
+* **RainbowKit / Rabby / Safe** for wallet connection
+* **Privy / SIWE** for session auth (`SIWE_ALLOWED_DOMAINS` env var)
+* **Tailwind + biome** for styling and linting
+* **A custom indexer** (`apps/cybercorps-indexer`) for cap-table queries
+* **A notifier** (`apps/notifier`) for event-driven notifications
+* **An oracle** (`apps/lexchex-oracle`) for accreditation backstop
+
+## Calling the contracts
+
+### 1. Generate types from ABIs
+
+With `wagmi/cli` and the package containing the protocol ABIs:
+
+```ts
+import { useReadContract, useWriteContract } from "wagmi";
+import { cyberCorpAbi } from "@/abis";
+
+const { data: legalName } = useReadContract({
+  abi: cyberCorpAbi,
+  address: cyberCorpAddr,
+  functionName: "legalName",
+});
+```
+
+### 2. Submit an EIP-712 EOI
+
+Use `viem.signTypedData` with the schema published by `RoundManager`:
+
+```ts
+const signature = await wallet.signTypedData({
+  domain: { name: "cyberRAISE", version: "1", chainId, verifyingContract: roundManagerAddr },
+  types: { EOI: [...] },
+  primaryType: "EOI",
+  message: { investor: account.address, amount: 100_000_000_000n, /* ... */ }
+});
+
+await write({ functionName: "submitEOI", args: [roundId, eoi, signature] });
+```
+
+### 3. Read the register
+
+A cap-table view typically pages over `CyberCertPrinter` tokens via an
+indexer rather than reading on-chain. The reference
+[`cybercorps-indexer`](https://github.com/MetaLex-Tech/metalex-webapp/tree/develop/apps/cybercorps-indexer)
+uses **ponder** to project events into a SQL store.
+
+### 4. Render the cert SVG
+
+`tokenURI` returns a base64-encoded JSON whose `image` is itself a base64 SVG.
+To display:
+
+```ts
+const json = JSON.parse(atob(uri.split(",")[1]));
+const svg = atob(json.image.split(",")[1]);
+return <img src={`data:image/svg+xml;base64,${btoa(svg)}`} />;
+```
+
+## Subdomain routing in the reference app
+
+The webapp exposes multiple product surfaces (cyberRAISE, ACE, profile, etc.)
+behind subdomains driven by env vars:
+
+```
+NEXT_PUBLIC_USE_SUBDOMAIN_ROUTING=true
+NEXT_PUBLIC_APP_DOMAIN=metalex.tech
+SIWE_ALLOWED_DOMAINS=cybercorps.metalex.tech,cyberraise.metalex.tech,pump.metalex.tech
+```
+
+Use the same pattern if you want to mount the issuer Mainframe at one domain
+and the public ACE / cyberRAISE views at others.
+
+## Related
+
+* Explanation: [Application stack](../explanation/application-stack.md).
+* See the `cybercorps-web` `README.md` in `metalex-webapp` for env setup.

--- a/docs/how-to/issue-a-cybercert.md
+++ b/docs/how-to/issue-a-cybercert.md
@@ -1,0 +1,70 @@
+# Issue a cyberCERT
+
+This is the canonical way to mint a new entry on a cyberCORP's register of
+holders — whether that entry represents Common Stock, Preferred Stock, a SAFE,
+a SAFT, a SAFTE, a Token Warrant, an LLC membership interest, or any other
+supported security type.
+
+## Prerequisites
+
+* The caller has the `ISSUER_AUTHORITY` BorgAuth role.
+* The relevant `CertificateExtension` (e.g., `ShareExtension`,
+  `SAFEExtension`) is registered on the `CyberCertPrinter`.
+* If the security is a share, the share class is authorised in `CyberShares`
+  with sufficient headroom (`authorized - outstanding ≥ units`).
+
+## Steps
+
+### 1. Build the `CertIssuance`
+
+The struct varies by extension. See [extensions](../reference/extensions.md)
+for the per-extension metadata. A Preferred Stock example:
+
+```solidity
+CertIssuance memory cert = CertIssuance({
+    holderName: "Alice Investor LLC",
+    holderAddress: 0xAaA...,
+    units: 1_000_000,
+    shareClass: SHARE_CLASS_PREFERRED,
+    series: "Series A",
+    legend: STANDARD_RESTRICTIVE_LEGEND,
+    agreementUri: "ipfs://series-a-spa-v1",
+    acquisitionPriceUsd: 2_500_000e6,
+    extensionData: abi.encode(ShareExtensionParams({
+        liquidationPreference: 1e18,
+        conversionRatio: 1e18,
+        antiDilution: AntiDilution.BROAD_BASED_WEIGHTED_AVG,
+        votingPower: 1
+    }))
+});
+```
+
+### 2. Call `IssuanceManager.issueCert`
+
+```solidity
+uint256 tokenId = issuanceManager.issueCert(cert);
+```
+
+### 3. Verify
+
+```solidity
+string memory uri = certPrinter.tokenURI(tokenId);
+// renders the SVG share certificate inline
+
+uint256 outstanding = cyberShares.outstanding(SHARE_CLASS_PREFERRED);
+```
+
+## Common variations
+
+* **Endorsement** (record an event on an existing cert) —
+  `issuanceManager.endorseCert(tokenId, endorsementData)`.
+* **Revoke** — `issuanceManager.revokeCert(tokenId)` (requires the relevant
+  legal grounds; the extension can enforce them).
+* **Pre-set registration approval** for a new holder receiving cyberSCRIP —
+  see [Run a secondary trade](run-a-secondary-trade.md).
+
+## Related
+
+* Reference: [`IssuanceManager`](../reference/contracts/IssuanceManager.md),
+  [`CyberCertPrinter`](../reference/contracts/CyberCertPrinter.md),
+  [Certificate extensions](../reference/extensions.md).

--- a/docs/how-to/restrict-transfers.md
+++ b/docs/how-to/restrict-transfers.md
@@ -1,0 +1,63 @@
+# Restrict cyberSCRIP transfers
+
+cyberSCRIP is an ERC-20, so by default it moves freely. The protocol gives you
+several knobs to restrict transfers when the underlying security requires it
+(Reg D / Reg S secondary restrictions, an unaccredited-holder cap, a private
+whitelist, etc.).
+
+## Options
+
+| Mechanism | Use when |
+|---|---|
+| `WhitelistTransferHook` | Closed circle of pre-approved counterparties. |
+| `ToggleTransferHook` | Per-cert switch; useful for time-limited freezes. |
+| Compliance powers (force transfer / burn, freeze, blocklist) | Reg-driven incident response, with **independent, permanent disable toggles** per power. |
+| Max-holder cap on `CyberCertPrinter` | Stay below 12(g) (or analogue) thresholds. |
+
+See [Hooks reference](../reference/hooks.md).
+
+## Install a whitelist hook
+
+### 1. Deploy the hook
+
+```solidity
+WhitelistTransferHook hook = new WhitelistTransferHook(cyberCorpAddr);
+```
+
+### 2. Register it on the cyberSCRIP
+
+From an account with the `OFFICER_AUTHORITY` role:
+
+```solidity
+cyberScrip.setTransferHook(address(hook));
+```
+
+### 3. Whitelist counterparties
+
+```solidity
+hook.setWhitelisted(alice, true);
+hook.setWhitelisted(bob, true);
+```
+
+Any `transfer` involving an address not in the set will revert. AMM pool
+addresses (e.g., a LiquiLeX Uniswap v4 pool) can be whitelisted too.
+
+## Permanently disable a compliance power
+
+Force-transfer, force-burn, freeze and blocklist on cyberSCRIP each have
+**independent, irreversible disable toggles**. Once an issuer renounces a
+power, no party — including MetaLeX — can restore it.
+
+```solidity
+// Permanently renounce force-transfer.
+cyberScrip.permanentlyDisableForceTransfer();
+```
+
+This is a one-way operation. Use it to harden the cyberSCRIP toward the
+"open" end of the compliance spectrum once you no longer need a given power.
+
+## Related
+
+* Explanation: [Composability and DeFi](../explanation/composability.md)
+* Reference: [`CyberScrip`](../reference/contracts/CyberScrip.md),
+  [Hooks](../reference/hooks.md).

--- a/docs/how-to/run-a-secondary-trade.md
+++ b/docs/how-to/run-a-secondary-trade.md
@@ -1,0 +1,74 @@
+# Run a secondary trade
+
+There are two settlement paths for a secondary trade of cyberCORP securities,
+both supported by the same contracts. cyberTRADE is the issuer-facing app
+surface; the contracts are agnostic.
+
+* **Registered ledger path** — edit the existing cyberCERT (or burn-and-mint
+  with new metadata) under issuer approval. Best when both parties want to be
+  registered holders of record.
+* **Scrip path** — settle at the cyberSCRIP layer, with deferred
+  de-scripification, including AMM-native trades through LiquiLeX.
+
+## Registered ledger path
+
+### 1. Negotiate off-chain or off-protocol
+
+Discovery, KYC, price discovery and bilateral negotiation happen wherever
+they happen. The cyberCORP suite does not opinionate. You arrive at this step
+with a willing seller, a willing buyer, a price, and an asset description.
+
+### 2. Open a deal in the cyberCORP's `DealManager`
+
+```solidity
+uint256 dealId = dealManager.proposeDeal(DealParams({
+    sellerCertId: 42,
+    units: 100_000,
+    buyer: bob,
+    paymentToken: USDC,
+    price: 200_000e6,
+    conditions: dealConditions,    // e.g. buyer accreditation + issuer approval
+    agreementHash: keccak256(spa)
+}));
+```
+
+### 3. Both parties countersign
+
+Each party signs an EIP-712 deal payload. Seller approves transfer of the
+cert (or of the units to be moved), buyer approves USDC to `LeXscroWLite`.
+
+### 4. The escrow settles atomically on conditions
+
+When every `ICondition` returns true (e.g., `lexchexCondition` passes for
+both, and the issuer has called `dealManager.approveDeal(dealId)`),
+`LeXscroWLite` releases:
+
+* USDC to seller,
+* either an edited cyberCERT or a freshly minted cert to buyer (depending on
+  `DealParams.settlementMode`),
+* an endorsement is added to the cert recording the trade.
+
+The atomic step **is** the legal transfer.
+
+## Scrip path
+
+If both parties accept the scrip form of the security, the deal can settle in
+cyberSCRIP. Subsequent de-scripification onto the buyer's register entry can
+be deferred (or never happen — many cyberSCRIP holders just hold the scrip).
+
+This is the path used by AMM trades through a
+[LiquiLeX pool](deploy-liquilex-pool.md). Compliance is enforced either:
+
+* on every swap, via a whitelisted-pool model with full credential checks, or
+* at the de-scripification boundary, with a lighter zkPassport gate at swap
+  for sanctions and Reg S screening.
+
+See Tutorial 3 for the full mechanics of
+[scripify and settle](../tutorials/scripify-and-settle.md).
+
+## Related
+
+* Reference: [`DealManager`](../reference/contracts/DealManager.md),
+  [`LeXscroWLite`](../reference/contracts/LeXscroWLite.md).
+* Explanation:
+  [Application stack — cyberTRADE](../explanation/application-stack.md#cybertrade).

--- a/docs/how-to/sign-a-cyberagreement.md
+++ b/docs/how-to/sign-a-cyberagreement.md
@@ -1,0 +1,74 @@
+# Sign a cyberAgreement
+
+**cyberSign** is the protocol's cybernetic legal-agreement execution layer.
+Templates are registered in `CyberAgreementRegistry`, parties countersign
+onchain via EIP-712, and execution is anchored to the resulting cyberCERTs
+and deal records.
+
+cyberSign is unbundled from cyberRAISE: you can use it as a standalone
+signing layer for any legal instrument that should run on the same chain as
+the assets it governs.
+
+## When to use this guide
+
+You need to record a signed legal agreement (a SAFE, a side letter, a board
+consent, a stockholder consent, an investor representation letter, etc.)
+onchain such that it is bound to a specific cyberCORP, party, and (optionally)
+deal or cyberCERT.
+
+## Steps
+
+### 1. Register the template
+
+If the template is not already in `CyberAgreementRegistry`, an admin uploads
+it:
+
+```solidity
+uint256 templateId = registry.registerTemplate(TemplateData({
+    name: "Series A Stockholder Consent v1",
+    contentUri: "ipfs://...",      // canonical text
+    contentHash: keccak256(text),
+    schema: "..."                  // optional EIP-712 schema for typed params
+}));
+```
+
+Most commonly used templates (see
+[Agreement templates](../reference/templates.md)) are pre-registered.
+
+### 2. Instantiate an executed agreement
+
+```solidity
+uint256 agreementId = registry.proposeAgreement(AgreementProposal({
+    templateId: templateId,
+    parties: [acme, alice],
+    params: abi.encode(...),       // values for the typed parameters
+    boundCertIds: [42],            // optional: bind to specific certs
+    boundDealId: 0                 // optional: bind to a deal
+}));
+```
+
+### 3. Countersign
+
+Each party signs an EIP-712 payload covering the template id, params, and
+their party identity, and submits the signature:
+
+```solidity
+registry.signAgreement(agreementId, aliceSig);
+```
+
+When all parties have signed, the registry emits `AgreementExecuted` and the
+agreement is permanently anchored — addressable by `agreementId` from any cert
+or deal that bound to it.
+
+### 4. (Optional) Use as a precondition
+
+A `RequireAgreementExecutedCondition` (custom) can be attached to any
+state transition to require that a specific agreement is fully executed first
+— e.g., "this round cannot close until the side letter is signed."
+
+## Related
+
+* Reference:
+  [`CyberAgreementRegistry`](../reference/contracts/CyberAgreementRegistry.md),
+  [Agreement templates](../reference/templates.md).
+* Explanation: [Application stack — cyberSign](../explanation/application-stack.md#cybersign).

--- a/docs/how-to/upgrade-a-cybercorp.md
+++ b/docs/how-to/upgrade-a-cybercorp.md
@@ -1,0 +1,68 @@
+# Upgrade a cyberCORP
+
+All contracts use UUPS upgradeable proxies (with beacon proxies for
+`CyberCertPrinter` and `CyberScrip` instances) and ERC-7201 namespaced
+storage. Upgrades use a **co-approval** model: MetaLeX publishes new
+implementations, but each cyberCORP independently opts in. No unilateral
+pushes.
+
+For architecture detail, see [Upgrade model](../reference/upgrade-model.md)
+and [Co-approval upgradeability](../explanation/co-approval-upgradeability.md).
+
+## Steps
+
+### 1. Confirm a MetaLeX-published implementation
+
+MetaLeX publishes implementation addresses (and a release note) to
+[the official Substack](https://metalex.substack.com/) and the contracts
+repository. For v3 architectures, the published address is registered on the
+relevant factory (e.g., `IssuanceManagerFactory.setRefImplementation`).
+
+Verify the address you intend to upgrade to:
+
+```solidity
+address published = issuanceManagerFactory.refImplementation();
+```
+
+### 2. Call `upgradeToAndCall` from the issuer's `UPGRADE_AUTHORITY`
+
+```solidity
+UUPSUpgradeable(yourCyberCorp).upgradeToAndCall(published, "");
+```
+
+For downstream beacon-proxied contracts (`CyberCertPrinter`, `CyberScrip`),
+upgrade the cyberCORP's *own* beacon — this batches all instances of that
+type owned by your `IssuanceManager`:
+
+```solidity
+issuanceManager.upgradeCertPrinterBeaconImplementation(publishedPrinter);
+issuanceManager.upgradeScripBeaconImplementation(publishedScrip);
+```
+
+### 3. Verify the new implementation pointer
+
+For a UUPS proxy:
+
+```solidity
+bytes32 SLOT = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+address impl = address(uint160(uint256(vm.load(yourCyberCorp, SLOT))));
+assert(impl == published);
+```
+
+## What you can and cannot do
+
+* ✅ You can stay on your original implementation indefinitely. There is no
+  forced migration.
+* ✅ You can roll back to an earlier MetaLeX-approved implementation if it
+  is still set on the factory.
+* ❌ You cannot upgrade to an arbitrary implementation. The reference
+  implementation gate ensures MetaLeX and the issuer must both agree.
+* ❌ MetaLeX cannot upgrade your contracts. The upgrade transaction is
+  signed by your `UPGRADE_AUTHORITY`.
+
+## Related
+
+* Reference: [Upgrade model](../reference/upgrade-model.md).
+* Explanation:
+  [Co-approval upgradeability](../explanation/co-approval-upgradeability.md),
+  [The role of MetaLeX](../explanation/role-of-metalex.md).

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1,0 +1,28 @@
+# Reference
+
+Reference is information-oriented: dry, neutral, and complete. Use it to look
+up what something *is*, not to learn or to do.
+
+## Contents
+
+* [Core contracts](contracts.md) — table of every contract with a one-line
+  role, linking to per-contract pages.
+* [Factories](factories.md) — `CyberCorpFactory`, `PumpCorpFactory`,
+  `MetaDAOFactory`, `ParentCoFactory` and the `*ManagerFactory` family.
+* [Certificate extensions](extensions.md) — pluggable metadata for each
+  security type (`ShareExtension`, `SAFEExtension`, `SAFTExtension`,
+  `SAFTEExtension`, `TokenWarrantExtension`, `ACESAFEExtension`).
+* [Hooks](hooks.md) — transfer hooks and the LiquiLeX Uniswap v4 fee hook.
+* [Conditions](conditions.md) — the `ICondition` interface and the built-in
+  conditions.
+* [Access control (BorgAuth)](access-control.md) — role identifiers and what
+  each one can do.
+* [Upgrade model](upgrade-model.md) — UUPS + beacon proxies, ERC-7201 storage,
+  co-approval.
+* [Agreement templates](templates.md) — cyberSAFE, cyberSAFT,
+  cyberTokenWarrant, MetaDAO Futarchy, LeXcheX agreement.
+* [Security types](security-types.md) — every instrument the protocol can
+  natively issue.
+* [Deployments](deployments.md) — canonical addresses on Ethereum, Arbitrum,
+  Base.
+* [Glossary](glossary.md) — protocol-specific terms with one-line definitions.

--- a/docs/reference/access-control.md
+++ b/docs/reference/access-control.md
@@ -1,0 +1,44 @@
+# Access control (BorgAuth)
+
+All contracts use **BorgAuth** role-based access control with multi-authority
+requirements. BorgAuth lives in [borg-core](https://github.com/MetaLex-Tech/borg-core).
+
+Roles map cleanly to the governance roles defined in the entity's
+constitutional documents (officers, managers, general partners, directors,
+or analogues).
+
+## Roles used by the protocol
+
+| Role | Held by (typical) | Permits |
+|---|---|---|
+| `ADMIN_AUTHORITY` | Board / managers (Safe multisig) | Grant and revoke all other roles. |
+| `ISSUER_AUTHORITY` | Officer | Mint and revoke cyberCERTs. Manage scripify/descripify conditions. Reserve / release shares. |
+| `OFFICER_AUTHORITY` | Officer | Approve registrations. Sign agreements on behalf of the entity. Manage transfer hooks. Open / close rounds. Approve deals. |
+| `DIRECTOR_AUTHORITY` | Director | Authorise share classes (`setAuthorized`). Register extensions on `CyberCertPrinter`. Set max holders. |
+| `SECRETARY_AUTHORITY` | Secretary | Endorse cyberCERTs. Update legends. |
+| `UPGRADE_AUTHORITY` | Board / managers | Co-approve UUPS implementation upgrades for this cyberCORP. |
+| `COMPLIANCE_AUTHORITY` | Officer / compliance team | Operate force-transfer / force-burn / freeze / blocklist (if not renounced). |
+| `METALEX_ADMIN` | MetaLeX (factories only) | Set reference implementations on factories. Never applies to deployed cyberCORPs. |
+
+## Granting / revoking
+
+```solidity
+IBorgAuth auth = IBorgAuth(cyberCorp.auth());
+auth.grantRole(OFFICER_AUTHORITY, newCfo);
+auth.revokeRole(OFFICER_AUTHORITY, oldCfo);
+```
+
+Most role mutations themselves require `ADMIN_AUTHORITY` (typically a board
+multisig).
+
+## Multi-authority requirements
+
+Some state transitions are gated on the *conjunction* of two roles. For
+example, an `OFFICER_AUTHORITY` + `SECRETARY_AUTHORITY` co-signature may be
+required to endorse a cert in some configurations (mirroring corporate
+formalities).
+
+## See also
+
+* [How-to: Configure BorgAuth roles](../how-to/configure-roles.md)
+* [borg-core](https://github.com/MetaLex-Tech/borg-core)

--- a/docs/reference/conditions.md
+++ b/docs/reference/conditions.md
@@ -1,0 +1,67 @@
+# Conditions
+
+The `ICondition` interface is the universal precondition primitive. Any
+state transition in the protocol — issuance, scripification, de-scripification,
+deal close, round acceptance, secondary trade settlement — can be gated on
+any check expressible onchain.
+
+## `ICondition`
+
+```solidity
+interface ICondition {
+    function check(address subject, bytes calldata context)
+        external view returns (bool);
+}
+```
+
+## Built-in conditions
+
+### `lexchexCondition`
+
+Requires a valid LeXcheX credential at check time. Variants for
+`hasAccreditation`, `hasKyc`, `isQualifiedPurchaser`, and combined checks.
+See [`LexChex`](contracts/LexChex.md).
+
+### `NonUSNationalityCondition`
+
+zkPassport-based check that the subject address is held by a non-US person.
+For Regulation S issuances. The reference UI flow lives in
+[`features/zkpassport`](https://github.com/MetaLex-Tech/metalex-webapp/tree/develop/apps/cybercorps-web/src/features/zkpassport)
+in `cybercorps-web`.
+
+### `IssuerApprovalRecertificationCondition`
+
+Requires explicit issuer approval before a non-registered scrip holder can
+present scrip for de-scripification into a fresh cyberCERT. Implements the
+*new-holder path* of recertification (see
+[Tutorial 3](../tutorials/scripify-and-settle.md)).
+
+### `OrCondition`
+
+Composes multiple conditions with disjunctive logic:
+
+```solidity
+or.add(lexchexCondition);
+or.add(nonUsCondition);
+// passes if either is true
+```
+
+## Writing a custom condition
+
+Anything expressible onchain is fair game: a token-balance threshold, a
+Snapshot vote outcome, a UMA assertion, a Soulbound credential, a Chainlink
+oracle reading.
+
+```solidity
+contract MinHoldingCondition is ICondition {
+    IERC20 immutable token;
+    uint256 immutable minimum;
+    constructor(IERC20 t, uint256 m) { token = t; minimum = m; }
+    function check(address subject, bytes calldata) external view returns (bool) {
+        return token.balanceOf(subject) >= minimum;
+    }
+}
+```
+
+Register it on the cyberCORP wherever you need it (e.g.,
+`roundManager.createRound(...)`, `issuanceManager.setScripifyCondition(...)`).

--- a/docs/reference/contracts.md
+++ b/docs/reference/contracts.md
@@ -1,0 +1,20 @@
+# Core contracts
+
+| Contract | Role |
+|---|---|
+| [**CyberCorp**](contracts/CyberCorp.md) | Onchain legal entity. Stores legal name, entity type, jurisdiction, governance, escrowed signatures, dispute resolution, and references to all subsidiary contracts. Root of the knowledge graph. |
+| **CyberCorpFactory / CyberCorpSingleFactory** | Deploys new cyberCORPs and their full contract suite. See [Factories](factories.md). |
+| [**IssuanceManager**](contracts/IssuanceManager.md) | Issuance authority. Mints and revokes securities; manages scripification and de-scripification; deploys CyberScrip; enforces conversion conditions; gates registration approval. |
+| [**CyberCertPrinter**](contracts/CyberCertPrinter.md) | ERC-721 minting engine. Each token is a *Ledger Entry Token* (cyberCERT). Uses pluggable extensions for instrument-specific metadata. |
+| [**CyberScrip**](contracts/CyberScrip.md) | ERC-20 fungible token generated from cyberCERTs via scripification. USDC-style compliance powers with independent, irreversible disable toggles. |
+| [**CyberShares**](contracts/CyberShares.md) | Share tracking and accounting (outstanding, authorized, reservation). |
+| [**DealManager**](contracts/DealManager.md) | Deal lifecycle with integrated escrow. Proposes deals, manages counterparty signing, escrows assets, releases on condition satisfaction. |
+| [**RoundManager**](contracts/RoundManager.md) | Multi-investor fundraising rounds. First-come and admission modes, ticket sizing, raise caps, timed offers, EIP-712 EOIs. |
+| [**LeXscroWLite**](contracts/LeXscroWLite.md) | Atomic deal-closing escrow. Holds ERC-20 and ERC-721 against `ICondition`s and releases when satisfied. |
+| [**SafeCertificateConverter**](contracts/SafeCertificateConverter.md) | Computes SAFE→equity conversion plans using round pricing and cap-table snapshots. |
+| [**CyberAgreementRegistry**](contracts/CyberAgreementRegistry.md) | Onchain anchor for cybernetic legal agreements: templates, executed agreements, party signatures, escrow linkage. |
+| [**LexChex / LexChexMinter**](contracts/LexChex.md) | Compliance gating. Manages KYC/AML and accreditation credentials. |
+| [**CertificateUriBuilder / CertificateImageBuilder**](contracts/CertificateUriBuilder.md) | Constructs fully onchain token URI metadata (JSON + SVG). |
+
+For specialised factories see [Factories](factories.md). For extensions, hooks
+and conditions, see the dedicated reference pages.

--- a/docs/reference/contracts/CertificateUriBuilder.md
+++ b/docs/reference/contracts/CertificateUriBuilder.md
@@ -1,0 +1,34 @@
+# CertificateUriBuilder / CertificateImageBuilder
+
+These contracts construct the fully onchain token URI (JSON) and certificate
+image (SVG) for every cyberCERT.
+
+* **Sources:**
+  [`src/CertificateUriBuilder.sol`](https://github.com/MetaLex-Tech/cybercorps-contracts/blob/develop/src/CertificateUriBuilder.sol),
+  [`src/CertificateImageBuilder.sol`](https://github.com/MetaLex-Tech/cybercorps-contracts/blob/develop/src/CertificateImageBuilder.sol),
+  [`src/CertificateImageContentBuilder.sol`](https://github.com/MetaLex-Tech/cybercorps-contracts/blob/develop/src/CertificateImageContentBuilder.sol).
+
+## What they produce
+
+`tokenURI(tokenId)` returns a `data:application/json;base64,...` URI whose
+JSON payload includes:
+
+* a standard `name` / `description` consumable by NFT viewers,
+* a `data:image/svg+xml;base64,...` `image` rendered onchain — the
+  share-certificate-style SVG with the holder name, units, class, series,
+  signatures, legend, and entity branding,
+* an `attributes` array with the extension-specific instrument data (SAFE
+  valuation cap, SAFT vesting schedule, ShareExtension liquidation
+  preference, etc.).
+
+The entire metadata document is constructed onchain at read time. There is
+no IPFS dependency for visualisation (though the *governing-agreement* URI
+stored on the cert may itself be an IPFS pointer).
+
+## Why this matters
+
+* The register entry is self-describing forever, regardless of any external
+  service.
+* Anyone can render the certificate from a node, an explorer, or a wallet.
+* For DGCL §158 compliance (and analogues elsewhere), the certificate fields
+  required by statute are *in the asset itself*.

--- a/docs/reference/contracts/CyberAgreementRegistry.md
+++ b/docs/reference/contracts/CyberAgreementRegistry.md
@@ -1,0 +1,31 @@
+# CyberAgreementRegistry
+
+**CyberAgreementRegistry** is the onchain anchor for cybernetic legal
+agreements. Templates, executed agreements, party signatures, and escrow
+linkage all live here.
+
+* **Source:** [`src/CyberAgreementRegistry.sol`](https://github.com/MetaLex-Tech/cybercorps-contracts/blob/develop/src/CyberAgreementRegistry.sol)
+* **Proxy pattern:** UUPS
+
+## Responsibilities
+
+* Register agreement templates (content URI + content hash + optional schema).
+* Instantiate executed agreements (`proposeAgreement`).
+* Collect EIP-712 signatures from each party (`signAgreement`).
+* Emit `AgreementExecuted` once all required signatures are gathered.
+* Provide bidirectional links from agreements to cyberCERTs and deals (so a
+  cert can know its governing instrument).
+
+## Selected public interface
+
+```solidity
+function registerTemplate(TemplateData calldata) external returns (uint256 templateId);
+function proposeAgreement(AgreementProposal calldata) external returns (uint256 agreementId);
+function signAgreement(uint256 agreementId, bytes calldata signature) external;
+function getAgreement(uint256 agreementId) external view returns (Agreement memory);
+```
+
+## See also
+
+* [How-to: Sign a cyberAgreement](../../how-to/sign-a-cyberagreement.md)
+* [Agreement templates](../templates.md)

--- a/docs/reference/contracts/CyberCertPrinter.md
+++ b/docs/reference/contracts/CyberCertPrinter.md
@@ -1,0 +1,65 @@
+# CyberCertPrinter
+
+The **CyberCertPrinter** is the ERC-721 contract that mints cyberCERTs —
+Ledger Entry Tokens — for a single cyberCORP. There is typically one printer
+per instrument family, registered against the `IssuanceManager`.
+
+* **Source:** [`src/CyberCertPrinter.sol`](https://github.com/MetaLex-Tech/cybercorps-contracts/blob/develop/src/CyberCertPrinter.sol)
+* **Proxy pattern:** beacon proxy (owned by the cyberCORP's `IssuanceManager`)
+
+## What's encoded in each token
+
+Each cyberCERT carries — onchain — all information required by the relevant
+governing law for an entry on the holder register. For a Delaware C-corp this
+maps to DGCL §§158, 202, 219 requirements. For non-US entities the same
+fields satisfy the analogous statutory or contractual requirements.
+
+* Holder name (legal name of the holder of record)
+* Unit count (shares / membership-interest units / partnership-interest units
+  / fund-interest units)
+* Share class and series
+* Restriction legend
+* Endorsement history
+* Authorized signatures (officer / director / manager / general partner /
+  secretary)
+* Acquisition price
+* Governing agreement URI (`CyberAgreementRegistry` pointer + content hash)
+* A fully onchain Base64 SVG visualisation produced by
+  `CertificateImageBuilder`
+
+## Extensions
+
+Instrument-specific metadata is added via [extensions](../extensions.md)
+registered on the printer:
+
+* `ShareExtension` — Preferred / Common stock (NVCA-aligned terms)
+* `SAFEExtension`, `ACESAFEExtension`
+* `SAFTExtension`, `SAFTExtensionV2`
+* `SAFTEExtension`, `SAFTEExtensionV2`
+* `TokenWarrantExtension`, `TokenWarrantExtensionV2`
+
+## Selected public interface
+
+```solidity
+function mint(uint256 tokenId, address to, bytes calldata metadata) external; // IssuanceManager only
+function burn(uint256 tokenId) external;                                       // IssuanceManager only
+
+function tokenURI(uint256 tokenId) external view returns (string memory);
+function setExtension(bytes32 securityType, address extension) external;       // DIRECTOR_AUTHORITY
+function setMaxHolders(uint256) external;                                      // DIRECTOR_AUTHORITY
+function setLegend(uint256 tokenId, string calldata) external;                 // SECRETARY_AUTHORITY
+```
+
+## Behaviour: NFT transfer ≠ register transfer
+
+NFT `transferFrom` alone does **not** change registered ownership. Cert
+metadata must be explicitly mutated through the `IssuanceManager`. This
+maintains the distinction between *token possession* and *registered
+ownership* that corporate, LLC, partnership, and fund law require. See
+[The dual-token model](../../explanation/dual-token-model.md).
+
+## See also
+
+* [`IssuanceManager`](IssuanceManager.md)
+* [`CertificateUriBuilder`](CertificateUriBuilder.md)
+* [Extensions](../extensions.md)

--- a/docs/reference/contracts/CyberCorp.md
+++ b/docs/reference/contracts/CyberCorp.md
@@ -1,0 +1,56 @@
+# CyberCorp
+
+The **CyberCorp** contract is the root of a cyberCORP. It is the onchain
+representation of the legal entity. Every other contract in the suite is
+reachable from it.
+
+* **Source:** [`src/CyberCorp.sol`](https://github.com/MetaLex-Tech/cybercorps-contracts/blob/develop/src/CyberCorp.sol)
+* **Proxy pattern:** UUPS (v3) or beacon proxy (legacy)
+
+## Responsibilities
+
+* Store the entity's legal identity: `legalName`, `entityType`,
+  `jurisdiction`.
+* Hold references to subsidiary contracts: `issuanceManager`,
+  `dealManager`, `roundManager`, `cyberShares`, `auth` (BorgAuth),
+  `agreementRegistry`.
+* Hold the entity's authorized signatures escrow, default dispute resolution
+  URI, and entity-level metadata.
+* Expose UUPS `upgradeToAndCall` gated on `UPGRADE_AUTHORITY`.
+
+## Selected public interface
+
+```solidity
+function legalName() external view returns (string memory);
+function entityType() external view returns (EntityType);
+function jurisdiction() external view returns (string memory);
+function issuanceManager() external view returns (address);
+function dealManager() external view returns (address);
+function roundManager() external view returns (address);
+function cyberShares() external view returns (address);
+function auth() external view returns (address);
+function agreementRegistry() external view returns (address);
+
+function setLegalName(string calldata) external;             // OFFICER_AUTHORITY
+function setDefaultDisputeResolution(string calldata) external; // OFFICER_AUTHORITY
+
+function upgradeToAndCall(address, bytes calldata) external; // UPGRADE_AUTHORITY
+```
+
+## Entity types
+
+The `EntityType` enum is configuration. It does not change the contract's
+behaviour; it informs front-ends and the certificate URI builder. Supported
+values include Delaware C-corp, Delaware LLC, Cayman LLC, Cayman SPC, BVI
+fund, English company, generic LP, and analogues.
+
+## Events
+
+* `LegalNameUpdated(string newName)`
+* `DefaultDisputeResolutionUpdated(string newUri)`
+* `Upgraded(address indexed implementation)`
+
+## See also
+
+* [Access control](../access-control.md)
+* [Upgrade model](../upgrade-model.md)

--- a/docs/reference/contracts/CyberScrip.md
+++ b/docs/reference/contracts/CyberScrip.md
@@ -1,0 +1,56 @@
+# CyberScrip
+
+**CyberScrip** is the ERC-20 fungible form of a cyberCORP security. It is
+minted by `IssuanceManager.scripifyCert` and burned by `convertScripToCert`.
+It is itself a security in scrip form (e.g., DGCL §155), with limited
+contingent rights specified in its Terms of Service and a deterministic
+in-protocol tieback to the cyberCERTs it was minted from.
+
+* **Source:** [`src/CyberScrip.sol`](https://github.com/MetaLex-Tech/cybercorps-contracts/blob/develop/src/CyberScrip.sol)
+* **Proxy pattern:** beacon proxy (owned by the cyberCORP's `IssuanceManager`)
+
+## Compliance powers (USDC-style)
+
+| Power | Effect | Renounceable |
+|---|---|---|
+| Force transfer | Compel a transfer between any two addresses. | ✅ (`permanentlyDisableForceTransfer`) |
+| Force burn | Burn from any address. | ✅ (`permanentlyDisableForceBurn`) |
+| Freeze | Lock an address. | ✅ (`permanentlyDisableFreeze`) |
+| Blocklist | Reject transfers to/from an address. | ✅ (`permanentlyDisableBlocklist`) |
+
+Each disable toggle is **independent and irreversible**. Once an issuer
+renounces a power, no party — including MetaLeX — can restore it. This lets
+an issuer harden toward the "open" end of the compliance spectrum as the
+security matures, without redeploying.
+
+## Transfer hooks
+
+`CyberScrip` consults an optional transfer hook on every transfer. See
+[Hooks](../hooks.md) for `WhitelistTransferHook`, `ToggleTransferHook`, and
+the base classes.
+
+## Selected public interface
+
+```solidity
+function mint(address to, uint256 amount) external;     // IssuanceManager only
+function burn(address from, uint256 amount) external;   // IssuanceManager only
+
+function setTransferHook(address) external;             // OFFICER_AUTHORITY
+function setMaxHolders(uint256) external;               // DIRECTOR_AUTHORITY
+
+function forceTransfer(address from, address to, uint256 amount) external;
+function forceBurn(address from, uint256 amount) external;
+function freeze(address account) external;
+function blocklist(address account, bool) external;
+
+function permanentlyDisableForceTransfer() external;
+function permanentlyDisableForceBurn() external;
+function permanentlyDisableFreeze() external;
+function permanentlyDisableBlocklist() external;
+```
+
+## See also
+
+* [`IssuanceManager`](IssuanceManager.md)
+* [Hooks](../hooks.md)
+* [The dual-token model](../../explanation/dual-token-model.md)

--- a/docs/reference/contracts/CyberShares.md
+++ b/docs/reference/contracts/CyberShares.md
@@ -1,0 +1,27 @@
+# CyberShares
+
+**CyberShares** is the accounting layer for share counts on a cyberCORP. It
+tracks outstanding, authorized, and reserved units per share class.
+
+* **Source:** [`src/CyberShares.sol`](https://github.com/MetaLex-Tech/cybercorps-contracts/blob/develop/src/CyberShares.sol)
+
+## Responsibilities
+
+* Track `authorized(shareClass)` and `outstanding(shareClass)`.
+* Track reservations (e.g., shares promised to convert from SAFEs / options).
+* Refuse issuance that would exceed authorized.
+* Provide cap-table snapshots for SAFE conversion and other point-in-time uses.
+
+## Selected public interface
+
+```solidity
+function authorized(bytes32 shareClass) external view returns (uint256);
+function outstanding(bytes32 shareClass) external view returns (uint256);
+function reserved(bytes32 shareClass) external view returns (uint256);
+
+function setAuthorized(bytes32 shareClass, uint256) external; // DIRECTOR_AUTHORITY
+function reserve(bytes32 shareClass, uint256) external;       // ISSUER_AUTHORITY
+function release(bytes32 shareClass, uint256) external;       // ISSUER_AUTHORITY
+
+function snapshot() external returns (bytes32);
+```

--- a/docs/reference/contracts/DealManager.md
+++ b/docs/reference/contracts/DealManager.md
@@ -1,0 +1,40 @@
+# DealManager
+
+**DealManager** is the deal-lifecycle and escrow contract used by cyberTRADE
+and by `RoundManager` when closing rounds.
+
+* **Source:** [`src/DealManager.sol`](https://github.com/MetaLex-Tech/cybercorps-contracts/blob/develop/src/DealManager.sol)
+* **Proxy pattern:** UUPS (v3)
+
+## Responsibilities
+
+* Propose deals (`proposeDeal`).
+* Manage counterparty signatures (EIP-712).
+* Escrow assets (ERC-20 / ERC-721) via `LeXscroWLite`.
+* Evaluate `ICondition` sets and release atomically on satisfaction.
+* Endorse the affected cyberCERT(s) on close.
+
+## Selected public interface
+
+```solidity
+function proposeDeal(DealParams calldata) external returns (uint256 dealId);
+function signDeal(uint256 dealId, bytes calldata signature) external;
+function approveDeal(uint256 dealId) external;         // OFFICER_AUTHORITY (issuer side)
+function deposit(uint256 dealId) external;
+function close(uint256 dealId) external;
+function cancel(uint256 dealId) external;
+```
+
+## Settlement modes
+
+* `EDIT_CERT` — mutate the seller's existing cert's holder / units fields
+  in place under issuer approval.
+* `BURN_AND_MINT` — burn the seller's cert and mint a fresh one to the buyer
+  with new metadata.
+* `SCRIP` — settle in cyberSCRIP; the seller may scripify as part of close,
+  the buyer may de-scripify later or never.
+
+## See also
+
+* [`LeXscroWLite`](LeXscroWLite.md), [`RoundManager`](RoundManager.md)
+* [Conditions](../conditions.md)

--- a/docs/reference/contracts/IssuanceManager.md
+++ b/docs/reference/contracts/IssuanceManager.md
@@ -1,0 +1,68 @@
+# IssuanceManager
+
+The **IssuanceManager** is the issuance authority for a cyberCORP. It is the
+only contract permitted to mutate the register of holders.
+
+* **Source:** [`src/IssuanceManager.sol`](https://github.com/MetaLex-Tech/cybercorps-contracts/blob/develop/src/IssuanceManager.sol)
+* **Proxy pattern:** UUPS (v3)
+* **Owns:** `CyberCertPrinter` beacon, `CyberScrip` beacon
+
+## Responsibilities
+
+* Issue cyberCERTs (`issueCert`) of any registered extension type.
+* Revoke / burn cyberCERTs (`revokeCert`).
+* Endorse cyberCERTs (`endorseCert`).
+* Scripify a cert (full or partial) into cyberSCRIP (`scripifyCert`).
+* De-scripify cyberSCRIP back to a cert (`convertScripToCert`).
+* Manage per-class conditions for scripify / de-scripify.
+* Manage the scripify whitelist per cert.
+* Manage registration approvals for new holders presenting scrip.
+* Deploy `CyberScrip` instances per share class on demand.
+
+## Selected public interface
+
+```solidity
+function issueCert(CertIssuance calldata) external returns (uint256);  // ISSUER_AUTHORITY
+function revokeCert(uint256 tokenId) external;                          // ISSUER_AUTHORITY
+function endorseCert(uint256 tokenId, Endorsement calldata) external;   // SECRETARY_AUTHORITY
+
+function scripifyCert(uint256 tokenId, uint256 units, address to) external;
+function convertScripToCert(address scrip, uint256 amount) external returns (uint256 newTokenId);
+function requestRecertification(address scrip, uint256 amount) external;
+function approveRegistration(address holder, RegistrationData calldata) external; // OFFICER_AUTHORITY
+
+function setScripifyCondition(bytes32 shareClass, ICondition) external;
+function setDescripifyCondition(bytes32 shareClass, ICondition) external;
+
+function setAuthorizedShares(bytes32 shareClass, uint256 authorized) external; // DIRECTOR_AUTHORITY
+
+function upgradeCertPrinterBeaconImplementation(address impl) external; // UPGRADE_AUTHORITY
+function upgradeScripBeaconImplementation(address impl) external;       // UPGRADE_AUTHORITY
+```
+
+## Scripification model
+
+* **Partial scripification** is supported. The source cert remains active with
+  a reduced unit count.
+* **Configurable scrip ratio** (`numerator / denominator`) governs cert units
+  ↔ scrip ERC-20 unit conversion.
+* **Scripified Share Pool** is an ERC-4626-style vault tracking each
+  registered holder's scripified units. De-scripification withdraws
+  proportionally.
+* **Two recertification paths:**
+  * existing registered holders → direct merge onto their existing cert;
+  * new holders → require `approveRegistration` first (the
+    `IssuerApprovalRecertificationCondition` enforces this).
+
+## Events
+
+* `CertIssued(uint256 indexed tokenId, address indexed to, uint256 units, bytes32 shareClass)`
+* `CertRevoked(uint256 indexed tokenId)`
+* `CertScripified(uint256 indexed tokenId, uint256 units, address scrip, address to)`
+* `ScripConvertedToCert(address indexed scrip, uint256 amount, uint256 indexed newTokenId, address indexed to)`
+* `RegistrationApproved(address indexed holder, bytes32 dataHash)`
+
+## See also
+
+* [`CyberCertPrinter`](CyberCertPrinter.md), [`CyberScrip`](CyberScrip.md)
+* [Conditions](../conditions.md)

--- a/docs/reference/contracts/LeXscroWLite.md
+++ b/docs/reference/contracts/LeXscroWLite.md
@@ -1,0 +1,23 @@
+# LeXscroWLite
+
+**LeXscroWLite** is the atomic deal-closing escrow used by `DealManager` and
+`RoundManager`. It escrows ERC-20 and ERC-721 assets against a set of
+`ICondition`s and releases atomically when all conditions evaluate true.
+
+## Properties
+
+* No admin keys.
+* No partial release.
+* Conditions are evaluated at the time of `close`, not at deposit.
+* Cancellation paths exist for stale escrows that never reach conditions —
+  see the source for `cancel`.
+
+## Selected public interface
+
+```solidity
+function depositERC20(address token, uint256 amount) external;
+function depositERC721(address token, uint256 tokenId) external;
+function setConditions(ICondition[] calldata) external;
+function close() external;
+function cancel() external;
+```

--- a/docs/reference/contracts/LexChex.md
+++ b/docs/reference/contracts/LexChex.md
@@ -1,0 +1,44 @@
+# LexChex / LexChexMinter
+
+**LeXcheX** is MetaLeX's onchain accreditation / KYC-AML credential layer.
+It manages soulbound credentials that downstream conditions (e.g.,
+`lexchexCondition`) can check.
+
+* **Sources:**
+  [`src/creds/lexchex.sol`](https://github.com/MetaLex-Tech/cybercorps-contracts/blob/develop/src/creds/lexchex.sol),
+  [`src/creds/lexchexMinter.sol`](https://github.com/MetaLex-Tech/cybercorps-contracts/blob/develop/src/creds/lexchexMinter.sol)
+* **Reference consumer UI:**
+  [`apps/lexchex-web`](https://github.com/MetaLex-Tech/metalex-webapp/tree/develop/apps/lexchex-web)
+  (`lexchex.metalex.tech`).
+
+## Credential dimensions
+
+* **KYC/AML** — identity verification (individual or legal entity).
+* **Accreditation** — SEC Rule 501(a) status. The reference UI supports both
+  traditional documentation flows and onchain net-worth proof using
+  wallet-bound assets (target $1M for individuals, $5M for entities).
+* **Qualified-purchaser** — Investment Company Act §3(c)(7) status.
+* **Jurisdiction tags** — for Reg S / non-US gating, complementing the
+  zkPassport-based `NonUSNationalityCondition`.
+
+## Minting
+
+The `LexChexMinter` mints a soulbound (non-transferable, wallet-bound) NFT
+certificate to the credentialed address. The user must countersign the
+LeXcheX agreement (see [Templates](../templates.md)) onchain.
+
+## Selected public interface
+
+```solidity
+function mint(address subject, CredentialData calldata) external; // ORACLE_AUTHORITY
+function revoke(uint256 tokenId) external;
+function credentialOf(address subject) external view returns (CredentialData memory);
+function hasAccreditation(address subject) external view returns (bool);
+function hasKyc(address subject) external view returns (bool);
+function isNonUs(address subject) external view returns (bool);
+```
+
+## See also
+
+* [Conditions → `lexchexCondition`](../conditions.md#lexchexcondition)
+* [LeXcheX agreement template](../templates.md#lexchex-agreement)

--- a/docs/reference/contracts/RoundManager.md
+++ b/docs/reference/contracts/RoundManager.md
@@ -1,0 +1,41 @@
+# RoundManager
+
+**RoundManager** runs multi-investor primary fundraising rounds. It is the
+backend of cyberRAISE.
+
+* **Source:** [`src/RoundManager.sol`](https://github.com/MetaLex-Tech/cybercorps-contracts/blob/develop/src/RoundManager.sol)
+* **Proxy pattern:** UUPS (v3)
+
+## Round modes
+
+| Mode | Behaviour |
+|---|---|
+| `FIRST_COME` | First valid EOI is accepted automatically; cap fills in submission order. |
+| `ADMISSION` | Issuer must explicitly `acceptEOI` for each EOI. |
+
+## Round configuration
+
+* Security type (SAFE / SAFT / SAFTE / Token Warrant / priced equity round).
+* Payment token (typically USDC).
+* Raise cap, min ticket, max ticket.
+* Open / close timestamps.
+* Per-round `ICondition` (composed via `OrCondition` if needed).
+* Agreement template URI for the round's standard form.
+
+## Selected public interface
+
+```solidity
+function createRound(RoundConfig calldata) external returns (uint256 roundId); // OFFICER_AUTHORITY
+function submitEOI(uint256 roundId, EOI calldata, bytes calldata sig) external;
+function acceptEOI(uint256 roundId, uint256 eoiId) external;                    // OFFICER_AUTHORITY
+function rejectEOI(uint256 roundId, uint256 eoiId) external;                    // OFFICER_AUTHORITY
+function closeRound(uint256 roundId) external;
+
+function totalRaised(uint256 roundId) external view returns (uint256);
+function certsMinted(uint256 roundId) external view returns (uint256[] memory);
+```
+
+## See also
+
+* [`DealManager`](DealManager.md), [`IssuanceManager`](IssuanceManager.md)
+* [Tutorial: Run a cyberRAISE round](../../tutorials/run-a-cyberraise-round.md)

--- a/docs/reference/contracts/SafeCertificateConverter.md
+++ b/docs/reference/contracts/SafeCertificateConverter.md
@@ -1,0 +1,37 @@
+# SafeCertificateConverter
+
+**SafeCertificateConverter** computes SAFE-to-equity conversion plans for a
+cyberCORP. It is pure compute: it does not move tokens. The resulting plan is
+executed by `IssuanceManager`.
+
+* **Source:** [`src/converters/SafeCertificateConverter.sol`](https://github.com/MetaLex-Tech/cybercorps-contracts/blob/develop/src/converters/SafeCertificateConverter.sol)
+
+## Inputs
+
+* Array of SAFE cyberCERT token ids.
+* Cap-table snapshot (`bytes32` from `CyberShares.snapshot()`).
+* Round pricing (`pricePerShare`, `preMoneyValuation`).
+
+The converter reads each SAFE's `SAFEExtension` metadata (valuation cap,
+discount, MFN provisions) and applies them per the standard YC/NVCA rules.
+
+## Output
+
+A `ConversionPlan` struct containing one entry per SAFE: the resulting share
+class and unit count, the residual cash refund (if any), and the effective
+price used.
+
+## Selected public interface
+
+```solidity
+function computePlan(
+    uint256[] calldata safeCertIds,
+    bytes32 capTableSnapshot,
+    RoundPricing calldata pricing
+) external view returns (ConversionPlan memory);
+```
+
+## See also
+
+* [How-to: Convert SAFEs to equity](../../how-to/convert-safe-to-equity.md)
+* [Extensions → `SAFEExtension`](../extensions.md#safeextension)

--- a/docs/reference/deployments.md
+++ b/docs/reference/deployments.md
@@ -1,0 +1,45 @@
+# Deployments
+
+Canonical contract addresses, by chain.
+
+> **Source of truth:** the
+> [`script/`](https://github.com/MetaLex-Tech/cybercorps-contracts/tree/develop/script)
+> directory of the contracts repository and MetaLeX release notes on
+> [Substack](https://metalex.substack.com/). The tables below mirror those
+> sources and will be kept in sync with releases.
+
+## Ethereum mainnet
+
+| Contract | Address |
+|---|---|
+| `CyberCorpFactory` | _see latest deployment script_ |
+| `CyberCorpSingleFactory` | _see latest deployment script_ |
+| `IssuanceManagerFactory` | _see latest deployment script_ |
+| `DealManagerFactory` | _see latest deployment script_ |
+| `RoundManagerFactory` | _see latest deployment script_ |
+| `CyberAgreementRegistry` | _see latest deployment script_ |
+| `CertificateUriBuilder` | _see latest deployment script_ |
+| `LexChex` | _see latest deployment script_ |
+| `LexChexMinter` | _see latest deployment script_ |
+| `PumpCorpFactory` | _see latest deployment script_ |
+| `MetaDAOFactory` | _see latest deployment script_ |
+| `ParentCoFactory` | _see latest deployment script_ |
+
+## Arbitrum
+
+As above.
+
+## Base
+
+As above. ACE production deployment runs on Base (see
+[ace.metalex.tech](https://ace.metalex.tech)).
+
+## Test environments
+
+* **Base Sepolia** — the canonical test environment. Some tests fork Base
+  Sepolia (`forge test --via-ir --fork-url <rpc>`).
+
+## Reference cyberCORPs
+
+MetaLeX dogfoods the protocol with its own Delaware C-corp; MetaLeX's stock
+ledger is maintained natively onchain via this contract suite.

--- a/docs/reference/extensions.md
+++ b/docs/reference/extensions.md
@@ -1,0 +1,68 @@
+# Certificate extensions
+
+Extensions are pluggable metadata contracts registered on a `CyberCertPrinter`
+for a given security type. They produce the instrument-specific attributes
+built into the cyberCERT's `tokenURI` and enforce any instrument-specific
+rules at issuance time.
+
+Each extension is its own UUPS-upgradeable contract.
+
+## ShareExtension
+
+Preferred and Common stock. NVCA-aligned series terms.
+
+* Liquidation preference
+* Conversion ratio (preferred ↔ common)
+* Anti-dilution (broad-based weighted average, full ratchet, none)
+* Voting power
+* Series identifier ("Series Seed", "Series A", "Series Pre-A", etc.)
+
+## SAFEExtension
+
+Simple Agreement for Future Equity.
+
+* Custom provisions field
+* Valuation cap
+* Discount
+* MFN flag
+* Conversion trigger event
+
+Feeds [`SafeCertificateConverter`](contracts/SafeCertificateConverter.md).
+
+## ACESAFEExtension
+
+ACE-specific SAFE variant for token-to-equity conversions, used by
+[PumpCorpFactory](factories.md#pumpcorpfactory).
+
+## SAFTExtension / SAFTExtensionV2
+
+Simple Agreement for Future Tokens.
+
+* Unlock schedule
+* Cliff period
+* Vesting interval
+* Token (or token-yet-to-be-deployed) reference
+
+## SAFTEExtension / SAFTEExtensionV2
+
+Simple Agreement for Future Tokens or Equity. Combines SAFT and SAFE
+attributes; the conversion path is determined by which trigger event fires
+first.
+
+## TokenWarrantExtension / TokenWarrantExtensionV2
+
+Token warrants.
+
+* Exercise price
+* Token-amount calculation method (fixed, pro rata, formula)
+* Unlock parameters
+* Expiration
+
+## Registering an extension
+
+```solidity
+certPrinter.setExtension(SECURITY_TYPE_SAFE, address(safeExtension));
+```
+
+A `CertIssuance.extensionData` is then `abi.encode`d to the extension's
+expected struct.

--- a/docs/reference/factories.md
+++ b/docs/reference/factories.md
@@ -1,0 +1,67 @@
+# Factories
+
+Factories deploy and configure new cyberCORPs and their supporting
+contracts. They are themselves UUPS-upgradeable and live in MetaLeX's
+administrative domain (see [Upgrade model](upgrade-model.md)).
+
+## CyberCorpFactory
+
+The top-level entry point. Composes:
+
+* `CyberCorpSingleFactory` (deploys the root `CyberCorp` proxy)
+* `IssuanceManagerFactory` (deploys the issuance suite + beacons)
+* `DealManagerFactory` (deploys the cyberCORP's `DealManager`)
+* `RoundManagerFactory` (deploys the cyberCORP's `RoundManager`)
+
+```solidity
+function createCyberCorp(EntityConfig calldata, GovernanceConfig calldata)
+    external returns (address cyberCorp);
+```
+
+## CyberCorpSingleFactory
+
+Deploys a single `CyberCorp` UUPS proxy from the registered
+`refImplementation`.
+
+## IssuanceManagerFactory
+
+Deploys an `IssuanceManager` UUPS proxy plus the `CyberCertPrinter` and
+`CyberScrip` beacons owned by it. Holds the v3 reference implementations for
+all three.
+
+```solidity
+function setRefImplementation(address) external;                       // METALEX_ADMIN
+function setCyberCertPrinterRefImplementation(address) external;       // METALEX_ADMIN
+function setCyberScripRefImplementation(address) external;             // METALEX_ADMIN
+```
+
+## DealManagerFactory / RoundManagerFactory
+
+Symmetric factories for the deal and round managers.
+
+## PumpCorpFactory
+
+Powers **ACE**. Deploys a cyberCORP + `RoundManager` pre-configured for an
+ACE-style Reg S offering, registers `ACESAFEExtension` on the
+`CyberCertPrinter`, and seeds the agreement registry with the ACE SAFE
+template.
+
+Supports party-specific allocations and global price / cap configuration.
+
+## MetaDAOFactory
+
+Deploys a MetaDAO-style futarchy-governed Cayman SPC. Pre-registers the
+`MetaDAO Futarchy Governance SPC` templates. Wires governance authority to a
+futarchy oracle (per portfolio / SegCo).
+
+## ParentCoFactory
+
+Deploys parent + subsidiary cyberCORP structures for holding-company
+configurations. Both parent and sub share the same agreement registry and
+can cross-reference each other in their entity metadata.
+
+## See also
+
+* [How-to: Deploy a PumpCorp for ACE](../how-to/deploy-pumpcorp-ace.md)
+* [How-to: Deploy a MetaDAO SPC](../how-to/deploy-metadao-spc.md)
+* [Upgrade model](upgrade-model.md)

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -1,0 +1,74 @@
+# Glossary
+
+**ACE (Asset Conversion to Equity)** — MetaLeX's product for converting a
+token community into equity stakeholders. Live at
+[ace.metalex.tech](https://ace.metalex.tech). Powered by `PumpCorpFactory`
+and `ACESAFEExtension`.
+
+**BorgAuth** — MetaLeX's role-based access control framework. See
+[borg-core](https://github.com/MetaLex-Tech/borg-core).
+
+**cyberCERT** — A *Ledger Entry Token* (ERC-721). One token = one entry on a
+cyberCORP's register of holders.
+
+**cyberCORP** — An onchain legal entity that issues legally constitutive
+digital securities through this protocol.
+
+**cyberRAISE** — Onchain primary fundraising. Implemented via `RoundManager`,
+`DealManager`, and `LeXscroWLite`.
+
+**cyberSCRIP** — The ERC-20 fungible form of a cyberCORP security, minted
+from a cyberCERT via `scripifyCert` and convertible back. Itself a security
+in scrip form (e.g., DGCL §155).
+
+**cyberSign** — Cybernetic legal-agreement execution layer. Implemented via
+`CyberAgreementRegistry`.
+
+**cyberTRADE** — Post-negotiation settlement for secondary trades of private
+securities. Settles via `DealManager` + `LeXscroWLite`.
+
+**Constitutive tokenization** — Token issuance where the chain *is* the
+official register, not a pointer to one. Contrast with pointer tokenization.
+
+**DGCL** — Delaware General Corporation Law. The most fully worked-out
+statutory reference for the protocol.
+
+**Endorsement** — A record appended to a cyberCERT documenting a state-
+changing event (transfer, conversion, restriction change).
+
+**EOI (Expression of Interest)** — An EIP-712-signed message in which an
+investor declares intent to participate in a cyberRAISE round on stated
+terms.
+
+**LeXcheX** — MetaLeX's onchain accreditation / KYC-AML credential system.
+Soulbound, wallet-bound NFT credentials.
+
+**LeXscroWLite** — The atomic deal-closing escrow contract.
+
+**LiquiLeX** — AMM-native secondary liquidity for cyberSCRIPs, using
+Uniswap v4 pools and the `MetalexIssuerFeeHook`.
+
+**Mainframe** — The issuer-facing application surface in the cyberCORPs app.
+Reference UI at
+[`apps/cybercorps-web`](https://github.com/MetaLex-Tech/metalex-webapp/tree/develop/apps/cybercorps-web).
+
+**MetaDAO** — A futarchy-governed Cayman SPC structure deployed via
+`MetaDAOFactory`.
+
+**Pointer tokenization** — Token issuance where the chain is a notification
+layer; the official register lives offchain. Contrast with constitutive
+tokenization.
+
+**PumpCorp** — A cyberCORP variant deployed by `PumpCorpFactory` for ACE.
+
+**Reg D / Reg S** — Two exemption frameworks for private securities under
+the US Securities Act of 1933. Reg D is the US-investor framework
+(accreditation-driven); Reg S is the non-US-investor framework.
+
+**Scripification** — Minting cyberSCRIP from a cyberCERT.
+
+**SegCo** — Segregated Portfolio Company portfolio (Cayman SPC structure).
+Used by MetaDAO.
+
+**zkPassport** — Privacy-preserving passport credential used by
+`NonUSNationalityCondition`.

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -1,0 +1,56 @@
+# Hooks
+
+Hooks are pluggable contracts attached at well-defined extension points. The
+protocol exposes two families:
+
+* **Transfer hooks** — consulted by `CyberScrip` on every transfer.
+* **Uniswap v4 hooks** — used by LiquiLeX pools.
+
+## Transfer hooks
+
+### `BaseTransferHook`
+
+Abstract base class. Override `_check(from, to, amount)` to enforce a rule.
+
+### `WhitelistTransferHook`
+
+Restricts `cyberSCRIP` transfers to whitelisted addresses. The cyberCORP's
+officers manage the set:
+
+```solidity
+function setWhitelisted(address account, bool ok) external; // OFFICER_AUTHORITY
+function isWhitelisted(address account) external view returns (bool);
+```
+
+Use for closed-circle compliance models or to whitelist a single LiquiLeX
+pool.
+
+### `ToggleTransferHook`
+
+Per-cyberCERT transfer toggling by the issuer with a configurable default.
+Useful for time-limited freezes or per-class transferability switches.
+
+## Uniswap v4 hooks
+
+### `MetalexIssuerFeeHook`
+
+Fee router for LiquiLeX. Splits Uniswap v4 swap fees between MetaLeX and the
+issuer at configured BPS, enabling cyberSCRIP / stablecoin pools that pay
+the issuer onchain on every trade.
+
+```solidity
+constructor(
+    address metalexTreasury,
+    address issuerTreasury,
+    uint256 metalexBps,
+    uint256 issuerBps
+);
+```
+
+Address-suffix mining is required to deploy at a Uniswap-v4-compliant
+address; use the standard `HookMiner` salt-mining flow.
+
+## See also
+
+* [How-to: Restrict cyberSCRIP transfers](../how-to/restrict-transfers.md)
+* [How-to: Deploy a LiquiLeX pool](../how-to/deploy-liquilex-pool.md)

--- a/docs/reference/security-types.md
+++ b/docs/reference/security-types.md
@@ -1,0 +1,54 @@
+# Security types
+
+The protocol natively issues and manages the lifecycle of the following
+instrument types. Each maps to a registered
+[Certificate extension](extensions.md) on the cyberCORP's
+`CyberCertPrinter`.
+
+## Equity
+
+* **Common Stock** — `ShareExtension`.
+* **Preferred Stock**, Pre-Seed through Series F —
+  `ShareExtension` with the appropriate series identifier and NVCA-aligned
+  parameters.
+* **Stock Options** — `ShareExtension` (option variant) with reservation
+  accounting in `CyberShares`.
+* **Restricted Stock Purchase Agreements** — `ShareExtension` plus an
+  unlock / vesting condition.
+* **Restricted Stock Units (RSUs)** — `ShareExtension` (RSU variant).
+
+## SAFE family
+
+* **SAFEs** — `SAFEExtension`. YC post-money or jurisdiction-neutral
+  template (see [Templates](templates.md)).
+* **ACE SAFEs** — `ACESAFEExtension`. Used by
+  [PumpCorpFactory](factories.md#pumpcorpfactory).
+
+## SAFT family
+
+* **SAFTs** — `SAFTExtension` / `SAFTExtensionV2`.
+* **SAFTEs** — `SAFTEExtension` / `SAFTEExtensionV2` (tokens or equity, with
+  trigger-first conversion).
+
+## Token instruments
+
+* **Token Warrants** — `TokenWarrantExtension` / `TokenWarrantExtensionV2`
+  (a16z-derived, jurisdiction-neutral, and Reg S variants).
+* **Token Purchase Agreements** — issuable via `SAFTExtension` with
+  appropriate parameters.
+* **Restricted Token Purchase Agreements** — `SAFTExtension` + vesting
+  condition.
+* **Restricted Token Units** — `SAFTEExtension` (RTU variant).
+
+## Convertible Notes
+
+Issuable via `SAFEExtension` configured as a debt instrument with maturity,
+interest, and conversion terms. (Convention; the extension is intentionally
+flexible.)
+
+## LLC / partnership / fund
+
+LLC membership interests, LP interests, and fund interests flow through
+`ShareExtension` with the appropriate `entityType` on the parent cyberCORP
+and jurisdiction-appropriate legends. The protocol makes no assumption
+about the underlying corporate or partnership statute.

--- a/docs/reference/templates.md
+++ b/docs/reference/templates.md
@@ -1,0 +1,59 @@
+# Agreement templates
+
+Reusable legal-instrument templates live in the
+[`/templates`](https://github.com/MetaLex-Tech/cybercorps-contracts/tree/develop/templates)
+directory and are pre-registered in `CyberAgreementRegistry`.
+
+## cyberSAFE
+
+| Template | Style | Filing path |
+|---|---|---|
+| `MetaLeX cyberSAFE US style Reg D v 1.0.md` | YC post-money | Reg D (US) |
+| `MetaLeX cyberSAFE UK Cayman style Reg S v 1.0.md` | YC post-money | Reg S (UK / Cayman) |
+| `MetaLeX cyberSAFE jx-neutral-style Reg D raise v 1.0.md` | Jurisdiction-neutral | Reg D (US) |
+| `MetaLeX cyberSAFE jx-neutral-style Reg S raise v 1.0.md` | Jurisdiction-neutral | Reg S |
+| `mlx_safe_reg_d_v1_3.md` / `mlx_safe_reg_s_v1_3.md` | v1.3 series | Reg D / Reg S |
+
+## cyberSAFT
+
+| Template | Filing path |
+|---|---|
+| `MetaLeX cyberSAFT reg D v.1.0.md` | Reg D |
+| `MetaLeX cyberSAFT Reg S raise v 1.0.md` | Reg S |
+| `mlx_saft_reg_d_v1_3.md` / `mlx_saft_reg_s_v1_3.md` | v1.3 series |
+
+## cyberSAFTE
+
+* `mlx_safte_reg_d_v1_3.md` — Reg D, v1.3.
+
+## cyberTokenWarrant
+
+| Template | Filing path |
+|---|---|
+| `MetaLeX cyberTokenWarrant a16z US style reg D v 1.0.md` | a16z-derived, Reg D (US) |
+| `MetaLeX cyberTokenWarrant a16z jx-neutral-style-issuer Reg D raise v 1.0.md` | jx-neutral, Reg D |
+| `MetaLeX cyberTokenWarrant a16z-jx-neutral-style-issuer Reg S raise v 1.0.md` | jx-neutral, Reg S |
+| `MetaLeX cyberTokenWarrant non-US Reg S v 1.0.md` | Reg S |
+| `mlx_safe_tw_reg_d_v1_3.md` / `mlx_safe_tw_reg_s_v1_3.md` | v1.3 series |
+
+## MetaDAO Futarchy Governance SPC
+
+* `MetaDAO Futarchy Governance SPC - Board Consent - Approval of SegCo v 1.0.md`
+* `MetaDAO Futarchy Governance SPC - SegCo combined v 1.0.md`
+
+## LeXcheX agreement
+
+* `MetaLeX LeXCheX Agreement.md` — countersigned by a credential subject when
+  receiving a LeXcheX credential.
+
+## Custom templates
+
+Issuers can register their own templates with
+`CyberAgreementRegistry.registerTemplate(...)`. For example, the
+`Three Prime Custom cyberSAFE and cyberTokenWarrant.md` template demonstrates
+a custom variant.
+
+## See also
+
+* [How-to: Sign a cyberAgreement](../how-to/sign-a-cyberagreement.md)
+* [`CyberAgreementRegistry`](contracts/CyberAgreementRegistry.md)

--- a/docs/reference/upgrade-model.md
+++ b/docs/reference/upgrade-model.md
@@ -1,0 +1,54 @@
+# Upgrade model
+
+All contracts use UUPS upgradeable proxies (with beacon proxies for
+`CyberCertPrinter` and `CyberScrip` instances) and **ERC-7201 namespaced
+storage**. Upgrades follow a **co-approval** model.
+
+## Co-approval
+
+* MetaLeX publishes new implementations to the relevant factories
+  (`*Factory.setRefImplementation` / `setCyberCertPrinterRefImplementation`
+  / `setCyberScripRefImplementation`).
+* Each cyberCORP's `UPGRADE_AUTHORITY` independently opts in by calling
+  `upgradeToAndCall(published, "")` on its own UUPS proxy.
+* Neither side can act unilaterally:
+  * MetaLeX cannot push an upgrade.
+  * An issuer cannot upgrade to an arbitrary implementation outside the
+    MetaLeX-published reference.
+
+This keeps MetaLeX in the role of *protocol developer and steward* rather
+than a securities intermediary with admin keys over the issuer's stock
+ledger.
+
+## V3 vs legacy
+
+V3 architectures use UUPS for top-level contracts (`CyberCorp`,
+`IssuanceManager`, `DealManager`, `RoundManager`), giving each cyberCORP
+full control over its upgrade cadence.
+
+Legacy architectures use beacon proxies pointing at MetaLeX-owned beacons,
+allowing batch upgrades but giving MetaLeX more control. Legacy cyberCORPs
+continue to receive upgrades through the beacon pattern; new deployments
+are always v3.
+
+A legacy cyberCORP can migrate to v3 architecture in place via the
+`*WithMigration.sol` contracts in the repository.
+
+## Beacons for downstream instances
+
+Even in v3, instances *owned by* an `IssuanceManager` (its `CyberCertPrinter`
+and `CyberScrip` proxies) use beacon proxies pointing at a beacon **owned by
+the IssuanceManager itself**. This keeps the suite upgrading together when
+the issuer chooses to upgrade, while preserving co-approval against MetaLeX.
+
+## Architecture diagram
+
+See
+[`ownership-and-upgradeability.md`](https://github.com/MetaLex-Tech/cybercorps-contracts/blob/develop/ownership-and-upgradeability.md)
+in the repository root for the full Mermaid class diagram showing both v3
+and legacy paths.
+
+## See also
+
+* [How-to: Upgrade a cyberCORP](../how-to/upgrade-a-cybercorp.md)
+* [Explanation: Co-approval upgradeability](../explanation/co-approval-upgradeability.md)

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -1,0 +1,35 @@
+# Tutorials
+
+Tutorials are learning-oriented. Each one walks you, hand-in-hand, through a
+small but complete piece of the protocol, so that at the end you have done
+something concrete and understand *what just happened*.
+
+If this is your first encounter with cyberCORPs, work through them in order.
+
+1. [**Incorporate a cyberCORP**](incorporate-a-cybercorp.md) — deploy your
+   first onchain legal entity, issue its genesis cyberCERT, and inspect the
+   register.
+2. [**Run a cyberRAISE round**](run-a-cyberraise-round.md) — configure a SAFE
+   round, accept investor Expressions of Interest, escrow funds, and close.
+3. [**Scripify and settle a secondary trade**](scripify-and-settle.md) —
+   mint cyberSCRIP from a cyberCERT, trade it, and settle a buyer back onto
+   the register.
+
+## Prerequisites for all tutorials
+
+* [Foundry](https://book.getfoundry.sh/) installed.
+* An RPC endpoint for Base Sepolia (free tier is fine).
+* A funded test wallet on Base Sepolia.
+* A clone of [`cybercorps-contracts`](https://github.com/MetaLex-Tech/cybercorps-contracts)
+  with `forge build --via-ir` succeeding locally.
+* Familiarity with Solidity at the level of *can read a contract*.
+
+> **No live funds are required.** Every tutorial runs against a forked Base
+> Sepolia node. Replace `<your-rpc>` with your endpoint in commands.
+
+## What these tutorials are not
+
+They are not how-to recipes. They cover one path each, and they explain why
+you are taking each step. For a goal-oriented recipe ("how do I disable force
+transfer permanently?"), see [How-to Guides](../how-to/README.md). For dry
+API detail, see [Reference](../reference/README.md).

--- a/docs/tutorials/incorporate-a-cybercorp.md
+++ b/docs/tutorials/incorporate-a-cybercorp.md
@@ -1,0 +1,137 @@
+# Tutorial: Incorporate a cyberCORP
+
+In this tutorial you will deploy a brand-new cyberCORP representing a Delaware
+C-corp, issue its first cyberCERT (a genesis share certificate), and inspect
+the onchain register.
+
+At the end, you will have:
+
+* a `CyberCorp` proxy you control,
+* an `IssuanceManager`, `DealManager`, `RoundManager`, `CyberCertPrinter` and
+  `CyberShares` deployed as part of the suite,
+* a single cyberCERT minted to a founder address representing 10,000,000
+  authorized shares of Common Stock.
+
+## 1. Pick a factory
+
+New cyberCORPs are deployed by a `CyberCorpFactory`. The factory composes the
+`CyberCorpSingleFactory`, `IssuanceManagerFactory`, `DealManagerFactory` and
+`RoundManagerFactory` so that a single transaction produces a fully wired
+suite.
+
+Use the canonical Base Sepolia factory address from
+[Deployments](../reference/deployments.md). Cast it to the
+`ICyberCorpFactory` interface in your script.
+
+## 2. Assemble the entity config
+
+The `CyberCorp` contract stores the entity's legal identity. Fill in:
+
+* **Legal name** — `"Acme CyberCo, Inc."`
+* **Entity type** — `EntityType.DELAWARE_C_CORP`
+* **Jurisdiction** — `"Delaware, USA"`
+* **Governance roles** — addresses for `officer`, `director`,
+  `secretary` (these become BorgAuth roles)
+* **Default dispute resolution** — the URI of your governing arbitration
+  clause or a sentinel
+* **Authorized signatures** — initial escrowed signature data structures
+* **Agreement registry** — address of the canonical `CyberAgreementRegistry`
+  on your chain (see [Reference → Deployments](../reference/deployments.md))
+
+See [`CyberCorp.sol`](../reference/contracts/CyberCorp.md) for the full struct.
+
+## 3. Deploy via `createCyberCorp`
+
+```solidity
+ICyberCorpFactory factory = ICyberCorpFactory(FACTORY_ADDR);
+address corp = factory.createCyberCorp(entityConfig, governanceConfig);
+```
+
+The factory will:
+
+1. Deploy a UUPS `CyberCorp` proxy owned by your address.
+2. Deploy an `IssuanceManager` proxy and grant it the issuance authority.
+3. Deploy `CyberCertPrinter` (the ERC-721) and `CyberScrip` beacons under the
+   `IssuanceManager`.
+4. Deploy a `DealManager` and a `RoundManager`.
+5. Wire all addresses into the root `CyberCorp` contract.
+
+The transaction emits a `CyberCorpDeployed` event. Capture every address from
+the event for the next step.
+
+## 4. Issue the genesis cyberCERT
+
+A cyberCORP is born with zero issued shares. You authorize, then issue.
+
+```solidity
+IIssuanceManager im = IIssuanceManager(issuanceManagerAddr);
+
+// 4a. Authorise 10,000,000 shares of Common Stock under the share extension.
+im.setAuthorizedShares(SHARE_CLASS_COMMON, 10_000_000);
+
+// 4b. Build a CertIssuance struct (see CyberCertPrinter reference).
+CertIssuance memory cert = CertIssuance({
+    holderName: "Jane Founder",
+    holderAddress: founder,
+    units: 8_000_000,
+    shareClass: SHARE_CLASS_COMMON,
+    series: "",
+    legend: "These securities have not been registered under the Securities Act of 1933...",
+    agreementUri: "ipfs://...",
+    acquisitionPriceUsd: 0,
+    // ...
+});
+
+// 4c. Mint.
+uint256 tokenId = im.issueCert(cert);
+```
+
+The call will:
+
+* require the caller to hold the `ISSUER_AUTHORITY` BorgAuth role,
+* increment `CyberShares.outstanding(SHARE_CLASS_COMMON)` by 8,000,000,
+* mint an ERC-721 to `founder` whose `tokenURI` is a fully onchain JSON+SVG
+  certificate produced by `CertificateUriBuilder`,
+* emit `CertIssued(tokenId, ...)`.
+
+## 5. Inspect the register
+
+The register *is* the chain. Anything you want to know is readable:
+
+```solidity
+// What does this cert say?
+string memory uri = CyberCertPrinter(certPrinter).tokenURI(tokenId);
+// → data:application/json;base64,... with the rendered SVG inside
+
+// Who owns it?
+address owner = CyberCertPrinter(certPrinter).ownerOf(tokenId);
+
+// How many Common shares are outstanding?
+uint256 outstanding = CyberShares(sharesAddr).outstanding(SHARE_CLASS_COMMON);
+
+// What is the entity?
+string memory name = CyberCorp(corp).legalName();
+EntityType etype = CyberCorp(corp).entityType();
+```
+
+There is no offchain ledger to reconcile against, no transfer agent to
+instruct. Per the entity's governing documents, **this** is the official
+stock ledger of Acme CyberCo, Inc.
+
+## What you just did
+
+* Deployed a Delaware C-corp whose DGCL §224 stock ledger lives natively
+  onchain.
+* Used BorgAuth's role separation to make the founder a director-officer and
+  the IssuanceManager the only address that can mint share certificates.
+* Produced an ERC-721 whose metadata is itself the legal record (DGCL §158
+  share-certificate requirements are encoded into the token URI).
+
+## Next
+
+* Tutorial 2: [Run a cyberRAISE round](run-a-cyberraise-round.md) to actually
+  raise capital from outside investors.
+* Reference: [`CyberCertPrinter`](../reference/contracts/CyberCertPrinter.md),
+  [`IssuanceManager`](../reference/contracts/IssuanceManager.md).
+* Explanation:
+  [Constitutive vs. pointer tokenization](../explanation/constitutive-vs-pointer.md).

--- a/docs/tutorials/run-a-cyberraise-round.md
+++ b/docs/tutorials/run-a-cyberraise-round.md
@@ -1,0 +1,124 @@
+# Tutorial: Run a cyberRAISE round
+
+In this tutorial you will configure a SAFE round, accept signed Expressions of
+Interest (EOIs) from two investors, escrow their USDC, and close the round —
+minting two SAFE cyberCERTs.
+
+This is exactly what the [`cybercorps-web` `cyberraise` route](https://github.com/MetaLex-Tech/metalex-webapp/tree/develop/apps/cybercorps-web/src/app/%28frame-layout%29/cyberraise)
+does from a UI; here we drive it from Solidity.
+
+## Prerequisites
+
+You have completed [Tutorial 1](incorporate-a-cybercorp.md) and have the
+addresses of a fresh cyberCORP. Take note of `roundManagerAddr`,
+`issuanceManagerAddr`, and `dealManagerAddr`.
+
+## 1. Configure the round
+
+A round is created on the cyberCORP's own `RoundManager`. You choose:
+
+* **Security type** — `SecurityType.SAFE`
+* **Round mode** — `RoundMode.ADMISSION` (issuer approves each EOI) or
+  `RoundMode.FIRST_COME` (first valid EOI fills the cap)
+* **Payment token** — typically the canonical USDC on your chain
+* **Raise cap** — e.g. `2_000_000e6` for $2M
+* **Min / max ticket** — e.g. `25_000e6` / `500_000e6`
+* **Open / close timestamps** — Unix seconds
+* **Per-round conditions** — e.g. require a valid LeXcheX accreditation
+  credential ([`lexchexCondition`](../reference/conditions.md)).
+* **Agreement template** — the URI of the `MetaLeX cyberSAFE US style Reg D`
+  template you intend to use
+
+```solidity
+IRoundManager rm = IRoundManager(roundManagerAddr);
+uint256 roundId = rm.createRound(RoundConfig({
+    securityType: SecurityType.SAFE,
+    mode: RoundMode.ADMISSION,
+    paymentToken: USDC,
+    raiseCap: 2_000_000e6,
+    minTicket: 25_000e6,
+    maxTicket: 500_000e6,
+    opensAt: block.timestamp,
+    closesAt: block.timestamp + 30 days,
+    conditions: lexchexCond,
+    agreementTemplate: "ipfs://cybersafe-regd-v1"
+    /* ... */
+}));
+```
+
+## 2. Investors submit signed EOIs
+
+Each investor signs an EIP-712 EOI message off-chain (a `RoundManager`-typed
+payload) declaring their intent to invest a specific amount at the round's
+price / cap and agreeing to the linked SAFE template.
+
+The EOI is then submitted on-chain (by the investor or by your front-end as a
+relayer):
+
+```solidity
+rm.submitEOI(roundId, EOI({
+    investor: alice,
+    amount: 100_000e6,
+    agreementHash: keccak256(safeText),
+    /* ... */
+}), aliceSignature);
+```
+
+In `ADMISSION` mode the issuer must then call `rm.acceptEOI(roundId, eoiId)`.
+In `FIRST_COME` mode acceptance is implicit on submission.
+
+## 3. Investors fund the escrow
+
+On acceptance, the round creates a deal in the cyberCORP's `DealManager` and a
+`LeXscroWLite` escrow. The investor approves USDC to the escrow and calls:
+
+```solidity
+dealManager.deposit(dealId);
+```
+
+The escrow holds the funds until *all* conditions on the deal evaluate true.
+For a standard SAFE round this is typically:
+
+* the round is closed or its cap is hit,
+* the investor has a valid LeXcheX credential at close-time,
+* a `NonUSNationalityCondition` (Reg S only) or other configured gates.
+
+## 4. Close the round
+
+Once conditions are met (or you call `rm.closeRound(roundId)` after the close
+time), the `RoundManager`:
+
+1. Releases USDC from each accepted investor's escrow to the cyberCORP's
+   designated receiving address.
+2. Calls `IssuanceManager.issueCert(...)` for each filled ticket, minting a
+   SAFE cyberCERT to each investor. The cert's `tokenURI` embeds the SAFE
+   parameters (valuation cap, discount, MFN) via the
+   [SAFEExtension](../reference/extensions.md).
+3. Adds endorsements to each cyberCERT recording the deal-close event.
+4. Emits `RoundClosed(roundId)`.
+
+MetaLeX never custodies funds; the escrow contract is the only intermediary,
+and it has no admin keys.
+
+## 5. Inspect what happened
+
+```solidity
+uint256 raised = rm.totalRaised(roundId);          // 200,000e6 if two $100k
+uint256[] memory tokens = rm.certsMinted(roundId); // two token ids
+string memory aliceCert = CyberCertPrinter(certPrinter).tokenURI(tokens[0]);
+```
+
+The SAFE certs are now part of Acme's official register. They are bound to the
+specific SAFE legal instrument (anchored in `CyberAgreementRegistry`) and will
+later convert to preferred stock via the
+[`SafeCertificateConverter`](../reference/contracts/SafeCertificateConverter.md)
+when Acme runs its priced round.
+
+## Next
+
+* Tutorial 3: [Scripify and settle](scripify-and-settle.md) — give your
+  investors a tradable form of their security.
+* How-to: [Convert SAFEs to equity](../how-to/convert-safe-to-equity.md).
+* Reference: [`RoundManager`](../reference/contracts/RoundManager.md).
+* Explanation:
+  [Compliance architecture](../explanation/compliance-architecture.md).

--- a/docs/tutorials/scripify-and-settle.md
+++ b/docs/tutorials/scripify-and-settle.md
@@ -1,0 +1,128 @@
+# Tutorial: Scripify and settle a secondary trade
+
+In this tutorial you will:
+
+1. take an existing cyberCERT (a Common Stock entry) and *scripify* part of
+   it, producing fungible cyberSCRIP,
+2. transfer that scrip to a buyer, and
+3. settle the buyer back onto the register via *de-scripification*, with
+   issuer approval gating.
+
+This is the core flow that powers **cyberTRADE**'s "scrip path" and any
+AMM-native LiquiLeX pool.
+
+## Prerequisites
+
+You have a cyberCERT from Tutorial 1, say `tokenId = 1` representing 8,000,000
+shares of Common, owned by `alice`. Take note of the `issuanceManagerAddr` and
+the `cyberScripAddr` that the IssuanceManager deployed for the Common class.
+
+## 1. Scripify part of the cert
+
+Alice wants to make 1,000,000 units tradable while keeping the rest on her
+cert.
+
+```solidity
+IIssuanceManager im = IIssuanceManager(issuanceManagerAddr);
+
+im.scripifyCert(
+    tokenId,             // the cert to (partially) scripify
+    1_000_000,           // units to scripify
+    alice                // recipient of the resulting cyberSCRIP
+);
+```
+
+The call will:
+
+* check that `tokenId` is eligible (via the optional per-cert scripify
+  whitelist) and that scripification conditions are satisfied,
+* reduce `tokenId`'s `units` from 8,000,000 to 7,000,000 (partial
+  scripification leaves the cert active),
+* record 1,000,000 units in the **Scripified Share Pool** (ERC-4626-style
+  vault) crediting Alice as the underlying registered holder,
+* mint `1_000_000 * scripRatioNumerator / scripRatioDenominator` cyberSCRIP
+  ERC-20 tokens to Alice.
+
+> 🛈 **Same security, different form.** The cyberSCRIP is *itself* a security
+> in scrip form (DGCL §155, or the equivalent under your governing law). It is
+> not a wrapper. See
+> [the dual-token model](../explanation/dual-token-model.md).
+
+## 2. Sell the scrip
+
+Alice transfers her cyberSCRIP to Bob.
+
+```solidity
+CyberScrip(cyberScripAddr).transfer(bob, 1_000_000e18);
+```
+
+If the cyberSCRIP has a `WhitelistTransferHook` or other
+[transfer hook](../reference/hooks.md) installed, the transfer will only
+succeed if Bob's address passes. For an open LiquiLeX pool, no whitelist is
+required; compliance is enforced *at the de-scripification boundary*.
+
+## 3. Bob requests recertification
+
+Bob does not want to hold scrip indefinitely; he wants to be a registered
+holder of record. He calls:
+
+```solidity
+im.requestRecertification(cyberScripAddr, 1_000_000e18);
+```
+
+Because Bob is not yet a registered holder, this enters the **new-holder
+path**: it does *not* mint a cert yet. It records his request.
+
+## 4. Issuer approves the new holder
+
+An officer of Acme CyberCo reviews Bob's KYC/AML credentials (potentially via
+an onchain `lexchexCondition`) and pre-sets the certificate metadata:
+
+```solidity
+im.approveRegistration(bob, RegistrationData({
+    holderName: "Bob Buyer",
+    legend: "...",
+    officerSignature: officerSig,
+    // ...
+}));
+```
+
+Now Bob can present his scrip:
+
+```solidity
+uint256 newTokenId = im.convertScripToCert(cyberScripAddr, 1_000_000e18);
+```
+
+The call will:
+
+* burn 1,000,000e18 cyberSCRIP from Bob,
+* withdraw 1,000,000 units from the Scripified Share Pool (Alice's vault
+  balance decreases),
+* mint a fresh cyberCERT to Bob with the approved metadata and a pre-set
+  officer signature.
+
+Bob is now on Acme's register. The chain state transition *is* the legal state
+transition.
+
+> If Bob were *already* a registered holder, the existing-holder path applies:
+> `convertScripToCert` would merge the units onto his existing cyberCERT for
+> the same class without requiring further issuer approval.
+
+## 5. What you just did
+
+* Used the **scrip layer** to make Common Stock tradable like an ERC-20 while
+  the cert layer remained the authoritative register.
+* Routed the buyer through the **new-holder recertification path**, with
+  explicit issuer approval — the moment that matters for §158 / §219 / §202
+  compliance under Delaware law (and analogues elsewhere).
+* Kept the entire flow onchain. There was no transfer agent, no Carta, no
+  paper certificate.
+
+## Next
+
+* How-to: [Restrict cyberSCRIP transfers](../how-to/restrict-transfers.md) to
+  add a whitelist or per-cert toggle.
+* How-to: [Deploy a LiquiLeX pool](../how-to/deploy-liquilex-pool.md) for
+  AMM-native settlement.
+* Reference: [`CyberScrip`](../reference/contracts/CyberScrip.md),
+  [`IssuanceManager`](../reference/contracts/IssuanceManager.md).


### PR DESCRIPTION
## Summary

Adds a comprehensive, GitBook-ready documentation set for the cyberCORPs
protocol, organized per the [Diátaxis](https://diataxis.fr/) framework. The
docs live in a new `docs/` tree with a root `.gitbook.yaml` so a GitBook
space can sync directly from `develop`.

37 files across four sections:

- **Tutorials** (learning-oriented): incorporate a cyberCORP, run a cyberRAISE
  round, scripify + settle a secondary trade.
- **How-to Guides** (task-oriented): 12 recipes — BorgAuth roles, issuance,
  transfer restriction, condition gating, secondary trades, SAFE conversion,
  PumpCorp/ACE, MetaDAO SPC, LiquiLeX pools, upgrades, cyberSign, frontend
  integration.
- **Reference** (information-oriented): per-contract pages for the 12 core
  contracts, plus factories, certificate extensions, hooks, conditions,
  BorgAuth roles, the co-approval upgrade model, agreement templates,
  security types, deployments, and a glossary.
- **Explanation** (understanding-oriented): constitutive-vs-pointer
  tokenization, the dual-token model, statutory mappings across jurisdictions,
  co-approval upgradeability, composability, compliance architecture,
  MetaLeX's non-intermediary posture, regulatory context, and the cyberCORPs
  application stack (mapped to the illustrative apps in `metalex-webapp`).

Content is derived from the repository `README.md`,
`ownership-and-upgradeability.md`, the `src/` contract layout, the
`templates/` directory, and the reference UIs in `metalex-webapp`.

## Notes

- No code changes — documentation only.
- `.gitbook.yaml` at the repo root points GitBook at `./docs/`; `SUMMARY.md`
  builds the navigation.
- Deployment addresses in `reference/deployments.md` are left as placeholders
  pending the canonical values from the deployment scripts.

## Test plan

- [ ] Verify the `docs/` tree renders in the GitBook space synced from
      `develop` (all four sections populate, internal links resolve).
- [ ] Spot-check that contract reference pages match current `src/`
      interfaces before relying on them externally.

https://claude.ai/code/session_01XhDPyCY5oezwHF8RDRQvPk

---
_Generated by [Claude Code](https://claude.ai/code/session_01XhDPyCY5oezwHF8RDRQvPk)_