### PR TITLE
docs: cross-link web app guides to protocol sections (post-#101)

### DIFF
--- a/docs/webapp/README.md
+++ b/docs/webapp/README.md
@@ -4,6 +4,12 @@ This part of the documentation is for the people who **use** the MetaLeX
 apps — founders, officers, and investors. No code: just what each app is for
 and how to use it.
 
+If you want to understand the machinery beneath the apps — what a cyberCORP,
+a cyberCERT, or a cyberSCRIP actually *is*, and why the design works the way
+it does — that is **Part 1, Protocol**. Each guide here links into it at the
+relevant points; see [How the apps relate to the protocol](#how-the-apps-relate-to-the-protocol)
+below.
+
 ## The apps, and where they live
 
 The products run as **separate apps, each on its own subdomain**. Your
@@ -79,3 +85,29 @@ guide notes which steps are which.
   invest in a round.
 
 The full [Glossary](../reference/glossary.md) has the rest.
+
+## How the apps relate to the protocol
+
+The apps are **front ends over the cyberCORPs smart-contract protocol**.
+Every meaningful button is a call to a contract; nothing important happens
+in a database that the chain doesn't already record.
+
+* When you **deploy a cyberCORP**, the app calls the protocol's factory,
+  which deploys your company's contracts. The chain becomes your company's
+  *official register* — not a copy of one. This is the core idea of the
+  protocol: see
+  [Constitutive vs. pointer tokenization](../explanation/constitutive-vs-pointer.md).
+* When you **issue a security**, the app mints a **cyberCERT** — an entry on
+  that register.
+* When you **scripify**, the app deploys a **cyberSCRIP** — the same
+  security in fungible form. Why two forms exist is explained in
+  [The dual-token model](../explanation/dual-token-model.md).
+
+Throughout these guides, **“Under the hood”** boxes link the action you're
+taking to the protocol contract behind it. You never need to read Part 1 to
+use the apps — but if you want to know exactly what you are signing, it is
+all there.
+
+A good starting point for the protocol side is the
+[Protocol welcome / overview](../README.md) and the tutorial
+[Incorporate a cyberCORP](../tutorials/incorporate-a-cybercorp.md).

--- a/docs/webapp/ace.md
+++ b/docs/webapp/ace.md
@@ -66,6 +66,24 @@ override. Each override is an onchain transaction.
    SAFE certificates you hold, across both your wallet and any Safe
    multisig.
 
+## Under the hood
+
+ACE is the cyberCORPs protocol's **ACE / PumpCorp** path. An ACE raise
+deploys a cyberCORP configured for a token-to-equity offering and issues
+**ACE SAFE** cyberCERTs — a SAFE variant whose security series is `ACE`.
+The non-US eligibility check is an onchain **condition** (a zkPassport-backed
+`NonUSNationalityCondition`); a founder override writes to that condition
+contract.
+
+* Protocol view of the offering type:
+  [Deploy a PumpCorp for ACE](../how-to/deploy-pumpcorp-ace.md) and
+  [Factories](../reference/factories.md).
+* How eligibility gating works:
+  [Conditions](../reference/conditions.md) and
+  [Compliance architecture](../explanation/compliance-architecture.md).
+* What an ACE SAFE is as a security:
+  [Security types](../reference/security-types.md).
+
 ## Good to know
 
 * **Eligibility is privacy-preserving** — the non-US check proves your

--- a/docs/webapp/cyberraise.md
+++ b/docs/webapp/cyberraise.md
@@ -51,6 +51,12 @@ The round form collects, in order:
 Filling the form is free; the round is deployed onchain at the final step,
 where you also configure the standard agreement investors will sign.
 
+> **Under the hood.** A round is created on your cyberCORP's
+> [`RoundManager`](../reference/contracts/RoundManager.md). The contract-
+> level walkthrough — building the round, taking EOIs, allocating, and
+> closing — is the tutorial
+> [Run a cyberRAISE round](../tutorials/run-a-cyberraise-round.md).
+
 ### Managing your rounds
 
 The **rounds list** for your company shows active and closed rounds, each
@@ -80,6 +86,12 @@ and their LeXcheX accreditation status. You then either:
 * **Allocate** — enter an amount within the offer's min–max and confirm the
   onchain transaction that accepts them, or
 * **Reject** — confirm the onchain transaction that declines the offer.
+
+> **Under the hood.** Allocating an EOI releases the investor's escrowed
+> funds to the company and mints their security as a cyberCERT through the
+> [`IssuanceManager`](../reference/contracts/IssuanceManager.md). The legal
+> agreement each party signs is anchored in the
+> [`CyberAgreementRegistry`](../reference/contracts/CyberAgreementRegistry.md).
 
 ### Closing a round
 
@@ -127,6 +139,12 @@ founder accepts your offer or the round closes — any unused remainder is
 returned. In a first-come round, accepted investments mint the certificate
 without delay.
 
+> **Under the hood.** Your EOI is an EIP-712-signed offer recorded on the
+> [`RoundManager`](../reference/contracts/RoundManager.md); your funds sit
+> in an onchain escrow until the round resolves. The security you receive is
+> a **cyberCERT** — a real entry on the company's register, not a receipt.
+> See [The dual-token model](../explanation/dual-token-model.md).
+
 ### Track it in your Portfolio
 
 Your **Portfolio** shows your pending investments (EOIs awaiting a decision,
@@ -136,7 +154,8 @@ any scrip. You can also withdraw an EOI that hasn't been allocated yet.
 ## Good to know
 
 * **MetaLeX never holds your money.** Funds in flight are in an onchain
-  escrow with no override.
+  escrow with no override — see
+  [The role of MetaLeX](../explanation/role-of-metalex.md).
 * **Signing the agreement is free; approving the token and submitting are
   transactions.**
 * **Your security is real and onchain** — a cyberCERT is the actual register

--- a/docs/webapp/lexchex.md
+++ b/docs/webapp/lexchex.md
@@ -40,6 +40,16 @@ also qualify by **investing above a threshold** (around \$200k for an
 individual, \$1M for an entity) or through **manual verification** by a
 MetaLeX attorney. The route that fits you depends on your circumstances.
 
+## Under the hood
+
+A LeXcheX credential is an onchain accreditation NFT issued by the protocol's
+[`LexChex` / `LexChexMinter`](../reference/contracts/LexChex.md) contracts.
+When a round requires accreditation, it attaches a **`lexchexCondition`** —
+an onchain [condition](../reference/conditions.md) that checks for a valid
+LeXcheX credential before letting an investment proceed. How this fits into
+Reg D / Reg S gating is covered in
+[Compliance architecture](../explanation/compliance-architecture.md).
+
 ## After you have the credential
 
 * It stays in your wallet. Restricted rounds verify it automatically — you

--- a/docs/webapp/mainframe.md
+++ b/docs/webapp/mainframe.md
@@ -50,6 +50,17 @@ confirms, your company exists onchain.
 > governing documents need to designate the onchain system as its official
 > register. MetaLeX provides templates for this — involve your counsel.
 
+> **Under the hood.** “Deploy cyberCORP” calls the protocol's
+> [`CyberCorpFactory`](../reference/factories.md), which deploys your
+> [`CyberCorp`](../reference/contracts/CyberCorp.md) contract and its suite
+> (issuance, deal, and round managers) and a `BorgAuth` access-control
+> contract in one transaction. The “founder identity” address becomes an
+> officer in [BorgAuth](../reference/access-control.md). For the full
+> walkthrough at the contract level, see the tutorial
+> [Incorporate a cyberCORP](../tutorials/incorporate-a-cybercorp.md); for
+> *why* the chain can be the official register, see
+> [Constitutive vs. pointer tokenization](../explanation/constitutive-vs-pointer.md).
+
 ## The company home
 
 Once your cyberCORP exists, the app home shows your **company overview** —
@@ -97,6 +108,14 @@ it.
 Two buttons at the top of the Mainframe: **Create new Security Class** and
 **Issue new security**.
 
+> **Under the hood.** Each security *class* is a
+> [`CyberCertPrinter`](../reference/contracts/CyberCertPrinter.md) contract.
+> Each *certificate* is a **cyberCERT** — an ERC-721 “Ledger Entry Token” —
+> and the set of them is your register of holders. Each scrip token is a
+> [`CyberScrip`](../reference/contracts/CyberScrip.md) ERC-20. A cyberCERT
+> and its cyberSCRIP are the same security in two forms; see
+> [The dual-token model](../explanation/dual-token-model.md).
+
 ## Creating a security class
 
 Before you can issue a security, its class must exist. The *Create New
@@ -112,6 +131,10 @@ Class / Series* form asks for:
 * the **legal document** — either upload a PDF or paste a link to it.
 
 Submitting deploys the class onchain and returns you to the Mainframe.
+
+> **Under the hood.** This deploys a new `CyberCertPrinter` for the chosen
+> [security type](../reference/security-types.md). The instrument-specific
+> terms are handled by a [certificate extension](../reference/extensions.md).
 
 ## Issuing a certificate
 
@@ -130,6 +153,12 @@ Issuing takes **two approvals**: first the signing officer signs the
 certificate (a free signature), then you confirm the onchain transaction
 that mints it.
 
+> **Under the hood.** The transaction calls the
+> [`IssuanceManager`](../reference/contracts/IssuanceManager.md), which
+> mints the cyberCERT on the class's `CyberCertPrinter` and records the
+> holder as the registered owner. See the how-to
+> [Issue a cyberCERT](../how-to/issue-a-cybercert.md).
+
 ## Enabling scrip (scripify)
 
 To give a security a tradable, fungible form, you *scripify* its class. The
@@ -146,6 +175,13 @@ To give a security a tradable, fungible form, you *scripify* its class. The
 Scripify requires your Issuance Manager to be on the latest version; if it
 isn't, the form points you to the **Upgrade** page first.
 
+> **Under the hood.** Scripify deploys a
+> [`CyberScrip`](../reference/contracts/CyberScrip.md) ERC-20 for the class.
+> Holders can then convert certificate units to scrip and back. The
+> mechanics — partial scripification, the scrip ratio, and the two
+> recertification paths — are covered in the tutorial
+> [Scripify and settle a secondary trade](../tutorials/scripify-and-settle.md).
+
 ## Approving de-scripification
 
 When a scrip holder wants to become a registered holder, they request
@@ -153,6 +189,11 @@ de-scripification. You approve it from the Mainframe's pending-request
 banner: the *Approve De-scripification* screen pre-fills the holder and
 share amount, you complete and sign the certificate details, and confirm.
 The holder is then put on the register.
+
+> **Under the hood.** Issuer approval is the moment that matters legally —
+> it is when a new holder is added to the register of record. See
+> [The dual-token model](../explanation/dual-token-model.md) and
+> [Compliance architecture](../explanation/compliance-architecture.md).
 
 ## Admin
 
@@ -166,14 +207,19 @@ The **upgrade** area lists your company's contracts — CyberCorp, Deal
 Manager, Issuance Manager, Round Manager, and the cyberCERT/cyberSCRIP
 implementations — and shows, for each, whether a newer MetaLeX-published
 version is available. You upgrade each one individually, and only when you
-choose; upgrades are never forced. (Background:
-[Co-approval upgradeability](../explanation/co-approval-upgradeability.md).)
+choose; upgrades are never forced.
+
+> **Under the hood.** Upgrades use a **co-approval** model: MetaLeX
+> publishes a new implementation, and your company opts in — neither side
+> can act alone. See [Upgrade model](../reference/upgrade-model.md) and
+> [Co-approval upgradeability](../explanation/co-approval-upgradeability.md).
 
 ## Good to know
 
 * **Every change is a transaction.** Issuing, transferring, scripifying, and
   approving cost a small amount of gas.
 * **You keep control.** MetaLeX cannot issue your securities, move your
-  funds, or change your register.
+  funds, or change your register — see
+  [The role of MetaLeX](../explanation/role-of-metalex.md).
 * **Nothing is hidden offchain.** Anyone you authorise can verify the
   register directly.

--- a/docs/webapp/metadao.md
+++ b/docs/webapp/metadao.md
@@ -40,12 +40,19 @@ The only fields you fill in are the **founder/operator name and contact**.
 That's the whole flow. Once the entity is formed, you manage it like any
 other cyberCORP — see [The cyberCORPs app](mainframe.md).
 
+## Under the hood
+
+Submitting forms a cyberCORP structured as a Cayman Segregated Portfolio
+Company. At the protocol level this is the **MetaDAO / SPC** path — see the
+[MetaDAOFactory](../reference/factories.md) reference and, for how a single
+legal entity can hold multiple independently-governed portfolios,
+[Legal mappings across jurisdictions](../explanation/legal-mappings.md). The
+futarchy *governance* of the entity happens on MetaDAO's own platform; this
+page only handles the onchain legal-entity formation.
+
 ## Good to know
 
 * This page is a **handoff**, not an app you spend time in.
-* The futarchy *governance* of a MetaDAO entity happens on MetaDAO's own
-  platform; this page only handles the onchain legal-entity formation.
-* For the protocol-level view of MetaDAO-style segregated portfolio
-  companies, see
-  [Legal mappings](../explanation/legal-mappings.md) and the
-  [MetaDAOFactory](../reference/factories.md) reference.
+* For everything you do *after* formation — issuing securities, raising —
+  you use the [cyberCORPs app](mainframe.md) and [cyberRAISE](cyberraise.md)
+  like any other company.

--- a/docs/webapp/profile.md
+++ b/docs/webapp/profile.md
@@ -51,6 +51,12 @@ Safe's own interface, where your co-signers approve it.
 After that, the delegated wallet can sign cyberAgreements on the Safe's
 behalf until the delegation expires.
 
+> **Under the hood.** Delegation registers the delegate against the
+> protocol's agreement layer, so a signature from the delegate counts as a
+> signature from the Safe when executing a cyberAgreement. Background:
+> [CyberAgreementRegistry](../reference/contracts/CyberAgreementRegistry.md)
+> and [Sign a cyberAgreement](../how-to/sign-a-cyberagreement.md).
+
 ## Notifications
 
 A **notifications** page exists but is **not yet functional** — it is a


### PR DESCRIPTION
## Summary

One commit, made after PR #101 was merged: it adds protocol cross-links to
the web app guides.

Every web app guide now connects its user-facing actions to the smart-
contract layer beneath them, via short **"Under the hood"** callouts and
inline links into Part 1 (Protocol):

- **README** — a "How the apps relate to the protocol" section.
- **cyberCORPs app** — callouts on deploy (`CyberCorpFactory`, constitutive
  tokenization), security classes/certificates (`CyberCertPrinter`, the
  dual-token model), issuance (`IssuanceManager`), scripify (`CyberScrip`),
  de-scripification, and upgrades (co-approval).
- **cyberRAISE** — rounds (`RoundManager`), EOIs/allocation (escrow,
  `CyberAgreementRegistry`), and the investor's cyberCERT.
- **ACE** — an "Under the hood" section on the ACE/PumpCorp path, the ACE
  SAFE security type, and zkPassport conditions.
- **profile** — delegation linked to the agreement registry.
- **LeXcheX** — linked to the `LexChex` contracts and `lexchexCondition`.
- **MetaDAO** — linked to `MetaDAOFactory` and the SPC legal mapping.

The links are light-touch; the guides stay user-facing.

## Why a new PR

PR #101 was merged before this commit was pushed; commits added to a merged
PR's branch do not re-open it.

https://claude.ai/code/session_01XhDPyCY5oezwHF8RDRQvPk

---
_Generated by [Claude Code](https://claude.ai/code/session_01XhDPyCY5oezwHF8RDRQvPk)_