### PR TITLE
docs: NatSpec for ShareExtension payment fields vs base investmentAmountUSD

### DIFF
--- a/src/storage/extensions/ShareExtension.sol
+++ b/src/storage/extensions/ShareExtension.sol
@@ -185,8 +185,27 @@ struct CertificateData {
     uint256 certificateNumber;
     uint256 numberOfShares;
     uint256 issueDate;
+    /// @notice Flags the cert as partly paid stock under DGCL §156.
+    /// @dev Switches `_getPaymentPercentage` between the fully paid early return
+    ///      (`PERCENTAGE_PRECISION`) and the `amountPaid`/`totalConsideration` ratio.
     bool isPartlyPaid;
+    /// @notice Consideration received to date for the cert.
+    /// @dev Equals `totalConsideration` when the cert is fully paid. The difference
+    ///      `totalConsideration - amountPaid` is the unpaid subscription balance.
     uint256 amountPaid;
+    /// @notice Full subscription price agreed for the cert under the issuance terms.
+    /// @dev Pairs with `amountPaid` and `isPartlyPaid` to model DGCL §156 partly paid
+    ///      stock. Distinct from `CertificateDetails.investmentAmountUSD` (defined in
+    ///      `src/CertificateUriBuilder.sol`), which records the USD amount actually
+    ///      paid at issuance and is the value consumed by converters such as
+    ///      `SafeCertificateConverter` for share-count math.
+    /// @dev Fully paid cert invariant: `amountPaid == totalConsideration`, and both
+    ///      are expected to equal the base `CertificateDetails.investmentAmountUSD`.
+    ///      Partly paid cert: `amountPaid < totalConsideration`; the gap is the
+    ///      outstanding subscription liability callable by the corporation under §156.
+    /// @dev Seam: consumers reading the base `CertificateDetails` alone see only the
+    ///      paid-to-date amount and miss the unpaid subscription balance. Tooling that
+    ///      needs full subscription context must read the share extension data.
     uint256 totalConsideration;
     string sourceAuthorityURI;
     ShareRepresentationType representationType;
@@ -374,6 +393,10 @@ contract ShareExtension is UUPSUpgradeable, ICertificateExtension, BorgAuthACL {
         ratio = (terms.originalIssuePrice * PRICE_PRECISION) / terms.conversionPrice;
     }
 
+    /// @notice Returns the paid fraction of the cert scaled by `PERCENTAGE_PRECISION` (10**4).
+    /// @dev Early returns `PERCENTAGE_PRECISION` (treated as fully paid) when the cert is
+    ///      not partly paid or `totalConsideration` is zero; otherwise returns the
+    ///      `amountPaid`/`totalConsideration` ratio scaled by `PERCENTAGE_PRECISION`.
     function _getPaymentPercentage(CertificateData memory cert) internal pure returns (uint256 percentage) {
         if (!cert.isPartlyPaid || cert.totalConsideration == 0) return PERCENTAGE_PRECISION;
         percentage = (cert.amountPaid * PERCENTAGE_PRECISION) / cert.totalConsideration;


### PR DESCRIPTION
## Summary

Comments-only change. Adds `///` NatSpec to `src/storage/extensions/ShareExtension.sol` clarifying how the extension's payment fields relate to the base `CertificateDetails.investmentAmountUSD` field. No logic changes.

Documented:
- `CertificateData.totalConsideration`: full subscription price under the issuance terms; pairs with `amountPaid`/`isPartlyPaid` to model DGCL §156 partly paid stock; distinct from `CertificateDetails.investmentAmountUSD` (defined in `src/CertificateUriBuilder.sol`), which records the USD amount actually paid at issuance and is the value consumed by converters such as `SafeCertificateConverter` for share-count math. Includes the fully paid invariant, the partly paid case, and the seam where consumers reading the base `CertificateDetails` alone miss the unpaid subscription balance.
- `CertificateData.amountPaid`: consideration received to date; equals `totalConsideration` when fully paid; the difference is the unpaid subscription balance.
- `CertificateData.isPartlyPaid`: switches `_getPaymentPercentage` between the fully paid early return and the paid/total ratio.
- `_getPaymentPercentage`: precision basis (`PERCENTAGE_PRECISION = 10**4`) and early-return semantics.

## Test plan

- [x] `forge build --via-ir` compiles with no errors and no new warnings referencing `ShareExtension.sol` (matches CI's build command).
- [x] Verified the doc-only diff via `git diff`.
- [x] Confirmed the plain-build stack-too-deep (`CyberCertPrinterStorage.sol`) and the `--sizes` EIP-170 failures are pre-existing and independent of this change.

https://claude.ai/code/session_018NHzYXcmRnWsqhpEWGvK2J

---
_Generated by [Claude Code](https://claude.ai/code/session_018NHzYXcmRnWsqhpEWGvK2J)_