### PR TITLE
Feat/cert legal owner indexing

### DIFF
--- a/src/CyberCertPrinter.sol
+++ b/src/CyberCertPrinter.sol
@@ -505,4 +505,12 @@ contract CyberCertPrinter is Initializable, ERC721EnumerableUpgradeable {
         return s.legalOwnedTokens[owner][index];
     }
 
+    /// @notice Backfill the legal-owner enumeration for tokens in [startIndex, startIndex+count) of the supply.
+    /// For printers deployed before the enumeration existed: permissionless and idempotent (already-tracked
+    /// tokens are skipped), call in batches over [0, totalSupply()) after a beacon upgrade. New printers need it
+    /// only if you want to (harmlessly) re-run it.
+    function backfillLegalOwners(uint256 startIndex, uint256 count) external {
+        CyberCertPrinterStorage.backfillLegalOwnerEnumeration(startIndex, count);
+    }
+
 }

--- a/src/CyberCertPrinter.sol
+++ b/src/CyberCertPrinter.sol
@@ -67,6 +67,7 @@ contract CyberCertPrinter is Initializable, ERC721EnumerableUpgradeable {
     error InvalidEndorsement();
     error InvalidLegendIndex();
     error SignatureRequired();
+    error LegalOwnerIndexOutOfBounds();
     // Reverted from the storage library via delegatecall; declared here for the ABI
     error ExceedsAvailableUnits();
     error ExceedsReservedUnits();
@@ -207,7 +208,10 @@ contract CyberCertPrinter is Initializable, ERC721EnumerableUpgradeable {
     // Restricted burning
     function burn(uint256 tokenId) external onlyIssuanceManager {
         _burn(tokenId);
-        
+
+        // No transfer hook fires for a burn (to == 0), so drop the legal-owner enumeration entry explicitly.
+        CyberCertPrinterStorage.recordBurnLegalOwner(tokenId);
+
         // Clear agreement details
         delete CyberCertPrinterStorage.cyberCertStorage().certificateDetails[tokenId];
         delete CyberCertPrinterStorage.cyberCertStorage().issuerSignatures[tokenId];
@@ -486,6 +490,19 @@ contract CyberCertPrinter is Initializable, ERC721EnumerableUpgradeable {
     function legalOwnerOf(uint256 tokenId) external view returns (address) {
         if (!_exists(tokenId)) revert TokenDoesNotExist();
         return CyberCertPrinterStorage.cyberCertStorage().owners[tokenId].ownerAddress;
+    }
+
+    /// @notice Number of certificates `owner` is the legal owner of record for (distinct from ERC-721 custody).
+    function balanceOfLegalOwner(address owner) external view returns (uint256) {
+        return CyberCertPrinterStorage.cyberCertStorage().legalOwnerTokenCount[owner];
+    }
+
+    /// @notice The `index`-th certificate `owner` is the legal owner of record for. Enumerates by legal owner,
+    /// so it lists a holder's certs even when a custodian (e.g. an admin multisig) holds the NFTs.
+    function tokenOfLegalOwnerByIndex(address owner, uint256 index) external view returns (uint256) {
+        CyberCertPrinterStorage.CyberCertStorage storage s = CyberCertPrinterStorage.cyberCertStorage();
+        if (index >= s.legalOwnerTokenCount[owner]) revert LegalOwnerIndexOutOfBounds();
+        return s.legalOwnedTokens[owner][index];
     }
 
 }

--- a/src/interfaces/ICyberCertPrinter.sol
+++ b/src/interfaces/ICyberCertPrinter.sol
@@ -191,7 +191,12 @@ interface ICyberCertPrinter is IERC721 {
     function totalSupply() external view returns (uint256);
     function tokenByIndex(uint256 index) external view returns (uint256);
     function tokenOfOwnerByIndex(address owner, uint256 index) external view returns (uint256);
+
+    // ERC721-like APIs for legal owner
     function legalOwnerOf(uint256 tokenId) external view returns (address);
+    function balanceOfLegalOwner(address owner) external view returns (uint256);
+    function tokenOfLegalOwnerByIndex(address owner, uint256 index) external view returns (uint256);
+
     function setTokenTransferable(uint256 tokenId, bool value) external;
     function increaseUnitsReserved(uint256 tokenId, uint256 amount) external;
     function decreaseUnitsReserved(uint256 tokenId, uint256 amount) external;

--- a/src/storage/CyberCertPrinterStorage.sol
+++ b/src/storage/CyberCertPrinterStorage.sol
@@ -87,6 +87,7 @@ library CyberCertPrinterStorage {
         // Token data
         mapping(uint256 => CertificateDetails) certificateDetails;
         mapping(uint256 => Endorsement[]) endorsements;
+        // use `_setLegalOwner()` to set. DO NOT set `owners[tokenId]` directly or otherwise its indexes would break
         mapping(uint256 => OwnerDetails) owners;
         mapping(uint256 => SecurityStatus) securityStatus;
         mapping(uint256 => string[]) certLegend;
@@ -111,7 +112,11 @@ library CyberCertPrinterStorage {
         RestrictiveLegend[] defaultLegendsV2;
         mapping(address => uint256) holderTokenCount;
         uint256 uniqueHolderCount;
-        
+
+        // ERC721Enumerable-like implementation for legal owners
+        mapping(address => mapping(uint256 => uint256)) legalOwnedTokens; // owner => index => tokenId
+        mapping(uint256 => uint256) legalOwnedTokensIndex; // tokenId => index within its owner's list
+        mapping(address => uint256) legalOwnerTokenCount; // owner => number of certs held of record
     }
 
     // Returns the storage layout
@@ -196,14 +201,14 @@ library CyberCertPrinterStorage {
         if (from == ownerAddress) {
             if (!s.endorsementRequired) {
                 emit CertificateAssigned(tokenId, to, "", IIssuanceManager(s.issuanceManager).companyName());
-                s.owners[tokenId] = OwnerDetails("", to);
+                _setLegalOwner(s, tokenId, to, "");
             }
             else if (endorsementCount > 0) {
                 Endorsement memory endorsement = s.endorsements[tokenId][endorsementCount - 1];
                 if (endorsement.endorsee == to) {
                     // Endorsement exists; ownership will be updated
                     emit CertificateAssigned(tokenId, to, endorsement.endorseeName, IIssuanceManager(s.issuanceManager).companyName());
-                    s.owners[tokenId] = OwnerDetails(endorsement.endorseeName, endorsement.endorsee);
+                    _setLegalOwner(s, tokenId, endorsement.endorsee, endorsement.endorseeName);
                 }
             }
         // NOTE: we don't revert in this block: Owner is able to transfer to another address without an endorsement, but it does not update the owner
@@ -214,7 +219,7 @@ library CyberCertPrinterStorage {
             if (endorsement.endorsee != to && ownerAddress != to) revert EndorsementNotSignedOrInvalid();
 
             emit CertificateAssigned(tokenId, to, endorsement.endorseeName, IIssuanceManager(s.issuanceManager).companyName());
-            s.owners[tokenId] = OwnerDetails(endorsement.endorseeName, endorsement.endorsee);
+            _setLegalOwner(s, tokenId, endorsement.endorsee, endorsement.endorseeName);
         }
         else revert EndorsementNotSignedOrInvalid();
     }
@@ -225,7 +230,7 @@ library CyberCertPrinterStorage {
         s.certLegend[tokenId] = s.defaultLegend;
         copyDefaultRestrictiveLegendsToCert(s, tokenId);
         s.certificateDetails[tokenId] = details;
-        s.owners[tokenId] = OwnerDetails("", to);
+        _setLegalOwner(s, tokenId, to, "");
         emit CyberCertPrinter_CertificateCreated(tokenId);
     }
 
@@ -240,7 +245,7 @@ library CyberCertPrinterStorage {
         s.certLegend[tokenId] = s.defaultLegend;
         copyDefaultRestrictiveLegendsToCert(s, tokenId);
         s.certificateDetails[tokenId] = details;
-        s.owners[tokenId] = OwnerDetails(investorName, to);
+        _setLegalOwner(s, tokenId, to, investorName);
         emit CertificateAssigned(tokenId, to, investorName, IIssuanceManager(s.issuanceManager).companyName());
         emit CyberCertPrinter_CertificateCreated(tokenId);
     }
@@ -249,7 +254,7 @@ library CyberCertPrinterStorage {
     function recordAssign(uint256 tokenId, address to, CertificateDetails memory details) external {
         CyberCertStorage storage s = cyberCertStorage();
         s.certificateDetails[tokenId] = details;
-        s.owners[tokenId] = OwnerDetails("", to);
+        _setLegalOwner(s, tokenId, to, "");
         emit CertificateAssigned(tokenId, to, "", IIssuanceManager(s.issuanceManager).companyName());
     }
 
@@ -267,6 +272,47 @@ library CyberCertPrinterStorage {
             s.endorsements[tokenId].length - 1,
             block.timestamp
         );
+    }
+
+    /// @dev Single chokepoint for every owners[] write: reassign tokenId's legal owner to `newOwner`
+    /// (holder-of-record name `name`) while keeping the per-legal-owner enumeration in sync.
+    function _setLegalOwner(CyberCertStorage storage s, uint256 tokenId, address newOwner, string memory name) private {
+        address current = s.owners[tokenId].ownerAddress;
+        if (current != newOwner) {
+            if (current != address(0)) _removeFromLegalOwnerEnumeration(s, current, tokenId);
+            if (newOwner != address(0)) _addToLegalOwnerEnumeration(s, newOwner, tokenId);
+        }
+        s.owners[tokenId] = OwnerDetails(name, newOwner);
+    }
+
+    function _addToLegalOwnerEnumeration(CyberCertStorage storage s, address owner, uint256 tokenId) private {
+        uint256 index = s.legalOwnerTokenCount[owner];
+        s.legalOwnedTokens[owner][index] = tokenId;
+        s.legalOwnedTokensIndex[tokenId] = index;
+        s.legalOwnerTokenCount[owner] = index + 1;
+    }
+
+    /// @dev Swap-and-pop removal, mirroring OZ ERC721Enumerable's _removeTokenFromOwnerEnumeration.
+    function _removeFromLegalOwnerEnumeration(CyberCertStorage storage s, address owner, uint256 tokenId) private {
+        uint256 lastIndex = s.legalOwnerTokenCount[owner] - 1;
+        uint256 tokenIndex = s.legalOwnedTokensIndex[tokenId];
+        if (tokenIndex != lastIndex) {
+            uint256 lastTokenId = s.legalOwnedTokens[owner][lastIndex];
+            s.legalOwnedTokens[owner][tokenIndex] = lastTokenId;
+            s.legalOwnedTokensIndex[lastTokenId] = tokenIndex;
+        }
+        delete s.legalOwnedTokensIndex[tokenId];
+        delete s.legalOwnedTokens[owner][lastIndex];
+        s.legalOwnerTokenCount[owner] = lastIndex;
+    }
+
+    /// @dev Drop tokenId from its legal owner's enumeration on burn — no transfer hook fires for to==0,
+    /// so the printer calls this explicitly.
+    function recordBurnLegalOwner(uint256 tokenId) external {
+        CyberCertStorage storage s = cyberCertStorage();
+        address owner = s.owners[tokenId].ownerAddress;
+        if (owner != address(0)) _removeFromLegalOwnerEnumeration(s, owner, tokenId);
+        delete s.owners[tokenId];
     }
 
     /// @dev Reserve units against a pending deal/loan. Reverts if the total reserved
@@ -457,7 +503,7 @@ library CyberCertPrinterStorage {
     }
 
     function setOwnerDetails(uint256 tokenId, OwnerDetails memory details) internal {
-        cyberCertStorage().owners[tokenId] = details;
+        _setLegalOwner(cyberCertStorage(), tokenId, details.ownerAddress, details.name);
     }
 
     function setSecurityStatus(uint256 tokenId, SecurityStatus status) internal {

--- a/src/storage/CyberCertPrinterStorage.sol
+++ b/src/storage/CyberCertPrinterStorage.sol
@@ -45,6 +45,7 @@ import "../CyberCorpConstants.sol";
 import {
     CertificateDetails,
     Endorsement,
+    ICyberCertPrinter,
     OwnerDetails,
     RestrictiveLegend,
     RestrictionType
@@ -117,6 +118,7 @@ library CyberCertPrinterStorage {
         mapping(address => mapping(uint256 => uint256)) legalOwnedTokens; // owner => index => tokenId
         mapping(uint256 => uint256) legalOwnedTokensIndex; // tokenId => index within its owner's list
         mapping(address => uint256) legalOwnerTokenCount; // owner => number of certs held of record
+        mapping(uint256 => bool) legalOwnedTokenTracked; // token is present in its legal owner's enumeration
     }
 
     // Returns the storage layout
@@ -278,22 +280,34 @@ library CyberCertPrinterStorage {
     /// (holder-of-record name `name`) while keeping the per-legal-owner enumeration in sync.
     function _setLegalOwner(CyberCertStorage storage s, uint256 tokenId, address newOwner, string memory name) private {
         address current = s.owners[tokenId].ownerAddress;
-        if (current != newOwner) {
-            if (current != address(0)) _removeFromLegalOwnerEnumeration(s, current, tokenId);
-            if (newOwner != address(0)) _addToLegalOwnerEnumeration(s, newOwner, tokenId);
+        // Always end with tokenId tracked under newOwner. The add is idempotent and the remove is a no-op for
+        // un-tracked tokens, so this both maintains live state and lazily backfills a legacy token (one minted
+        // before this enumeration existed) the moment any owner-write touches it.
+        if (current != newOwner && current != address(0)) {
+            _removeFromLegalOwnerEnumeration(s, current, tokenId);
+        }
+        if (newOwner != address(0)) {
+            _addToLegalOwnerEnumeration(s, newOwner, tokenId);
         }
         s.owners[tokenId] = OwnerDetails(name, newOwner);
     }
 
+    /// @dev Idempotent: a token already in an owner's enumeration is left alone (so backfilling a tracked token
+    /// is a no-op and we never double-count).
     function _addToLegalOwnerEnumeration(CyberCertStorage storage s, address owner, uint256 tokenId) private {
+        if (s.legalOwnedTokenTracked[tokenId]) return;
         uint256 index = s.legalOwnerTokenCount[owner];
         s.legalOwnedTokens[owner][index] = tokenId;
         s.legalOwnedTokensIndex[tokenId] = index;
         s.legalOwnerTokenCount[owner] = index + 1;
+        s.legalOwnedTokenTracked[tokenId] = true;
     }
 
-    /// @dev Swap-and-pop removal, mirroring OZ ERC721Enumerable's _removeTokenFromOwnerEnumeration.
+    /// @dev Swap-and-pop removal, mirroring OZ ERC721Enumerable's _removeTokenFromOwnerEnumeration. No-op for an
+    /// un-tracked token — this is what keeps a legacy printer's first owner-change/burn from underflowing
+    /// `legalOwnerTokenCount` (which is 0 until the token is backfilled).
     function _removeFromLegalOwnerEnumeration(CyberCertStorage storage s, address owner, uint256 tokenId) private {
+        if (!s.legalOwnedTokenTracked[tokenId]) return;
         uint256 lastIndex = s.legalOwnerTokenCount[owner] - 1;
         uint256 tokenIndex = s.legalOwnedTokensIndex[tokenId];
         if (tokenIndex != lastIndex) {
@@ -304,6 +318,7 @@ library CyberCertPrinterStorage {
         delete s.legalOwnedTokensIndex[tokenId];
         delete s.legalOwnedTokens[owner][lastIndex];
         s.legalOwnerTokenCount[owner] = lastIndex;
+        s.legalOwnedTokenTracked[tokenId] = false;
     }
 
     /// @dev Drop tokenId from its legal owner's enumeration on burn — no transfer hook fires for to==0,
@@ -313,6 +328,22 @@ library CyberCertPrinterStorage {
         address owner = s.owners[tokenId].ownerAddress;
         if (owner != address(0)) _removeFromLegalOwnerEnumeration(s, owner, tokenId);
         delete s.owners[tokenId];
+    }
+
+    /// @dev One-time/idempotent migration for printers deployed before the legal-owner enumeration existed:
+    /// adds each live token in [startIndex, startIndex+count) to its legal owner's enumeration. Permissionless
+    /// and safe to re-run — already-tracked tokens are skipped. Call in batches over [0, totalSupply()).
+    function backfillLegalOwnerEnumeration(uint256 startIndex, uint256 count) external {
+        CyberCertStorage storage s = cyberCertStorage();
+        ICyberCertPrinter self = ICyberCertPrinter(address(this)); // delegatecalled: address(this) is the printer
+        uint256 supply = self.totalSupply();
+        uint256 end = startIndex + count;
+        if (end > supply) end = supply;
+        for (uint256 i = startIndex; i < end; i++) {
+            uint256 tokenId = self.tokenByIndex(i); // enumerates live tokens only (burned are excluded)
+            address owner = s.owners[tokenId].ownerAddress;
+            if (owner != address(0)) _addToLegalOwnerEnumeration(s, owner, tokenId);
+        }
     }
 
     /// @dev Reserve units against a pending deal/loan. Reverts if the total reserved

--- a/test/CyberCertPrinterTest.t.sol
+++ b/test/CyberCertPrinterTest.t.sol
@@ -5,6 +5,7 @@ import {Test} from "forge-std/Test.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {CertificateUriBuilder} from "../src/CertificateUriBuilder.sol";
 import {CyberCertPrinter} from "../src/CyberCertPrinter.sol";
+import {CyberCertPrinterStorage} from "../src/storage/CyberCertPrinterStorage.sol";
 import {SecurityClass, SecuritySeries} from "../src/CyberCorpConstants.sol";
 import {IUriBuilder} from "../src/interfaces/IUriBuilder.sol";
 import {
@@ -168,6 +169,24 @@ contract MockUriBuilder is IUriBuilder {
     }
 }
 
+/// @dev Test-only subclass exposing a hook to recreate the pre-enumeration ("legacy") storage state directly —
+/// owners[] populated but the legal-owner enumeration empty — so tests don't have to vm.store into the diamond
+/// storage by hand. It only ADDS a function; all production CyberCertPrinter logic is inherited unchanged.
+contract CyberCertPrinterEnhanced is CyberCertPrinter {
+    /// @dev Clear the legal-owner enumeration for `owner`/`tokenIds`, mimicking certs minted before the
+    /// enumeration existed (owners[] stays; count/index/tracked are zeroed).
+    function debugClearLegalOwnerEnumeration(address owner, uint256[] calldata tokenIds) external {
+        CyberCertPrinterStorage.CyberCertStorage storage s = CyberCertPrinterStorage.cyberCertStorage();
+        for (uint256 i = 0; i < tokenIds.length; i++) {
+            uint256 tokenId = tokenIds[i];
+            delete s.legalOwnedTokens[owner][s.legalOwnedTokensIndex[tokenId]];
+            delete s.legalOwnedTokensIndex[tokenId];
+            s.legalOwnedTokenTracked[tokenId] = false;
+        }
+        s.legalOwnerTokenCount[owner] = 0;
+    }
+}
+
 contract CyberCertPrinterTest is Test {
     CyberCertPrinter private printer;
     MockIssuanceManager private issuanceManager;
@@ -188,7 +207,7 @@ contract CyberCertPrinterTest is Test {
         string[] memory defaultLegend = new string[](1);
         defaultLegend[0] = "Default legend";
 
-        CyberCertPrinter implementation = new CyberCertPrinter();
+        CyberCertPrinter implementation = new CyberCertPrinterEnhanced();
         bytes memory initData = abi.encodeCall(
             CyberCertPrinter.initialize,
             (
@@ -436,6 +455,86 @@ contract CyberCertPrinterTest is Test {
         assertEq(printer.ownerOf(1), investor);
         assertEq(printer.legalOwnerOf(1), investor);
         assertEq(printer.getCertLegendAt(1, 0), "Default legend");
+    }
+
+    // ── Legal-owner enumeration: backward compatibility for legacy printers ──
+
+    // Re-running the backfill on a printer that already tracks every token is a no-op (idempotent), never
+    // double-counting.
+    function test_BackfillLegalOwners_IdempotentOnTrackedPrinter() public {
+        _mintCert(1, investor, 100, bytes(""));
+        _mintCert(2, investor, 100, bytes(""));
+        _mintCert(3, recipient, 100, bytes(""));
+
+        printer.backfillLegalOwners(0, printer.totalSupply());
+        printer.backfillLegalOwners(0, 100); // over-wide range clamps to supply
+
+        assertEq(printer.balanceOfLegalOwner(investor), 2);
+        assertEq(printer.balanceOfLegalOwner(recipient), 1);
+        assertEq(printer.tokenOfLegalOwnerByIndex(investor, 0), 1);
+        assertEq(printer.tokenOfLegalOwnerByIndex(investor, 1), 2);
+    }
+
+    // A legacy token (enumeration never populated) must not underflow legalOwnerTokenCount when it is burned.
+    function test_LegalOwnerEnumeration_LegacyBurnDoesNotUnderflow() public {
+        _mintCert(1, investor, 100, bytes(""));
+        _mintCert(2, investor, 100, bytes(""));
+        uint256[] memory ids = new uint256[](2);
+        ids[0] = 1;
+        ids[1] = 2;
+        CyberCertPrinterEnhanced(address(printer)).debugClearLegalOwnerEnumeration(investor, ids);
+        assertEq(printer.balanceOfLegalOwner(investor), 0, "legacy enumeration starts empty");
+
+        vm.prank(address(issuanceManager));
+        printer.burn(1); // must not revert (guarded no-op remove)
+
+        assertEq(printer.balanceOfLegalOwner(investor), 0);
+    }
+
+    // An owner-write (endorsed transfer) on a legacy token lazily backfills it under the new owner — and the
+    // implicit remove from the old owner is a safe no-op (no underflow).
+    function test_LegalOwnerEnumeration_LegacyOwnerWriteLazilyBackfills() public {
+        _mintCert(1, investor, 100, bytes(""));
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = 1;
+        CyberCertPrinterEnhanced(address(printer)).debugClearLegalOwnerEnumeration(investor, ids);
+        assertEq(printer.balanceOfLegalOwner(investor), 0);
+
+        vm.prank(address(issuanceManager));
+        printer.setGlobalTransferable(true);
+        vm.prank(investor);
+        printer.addEndorsement(1, _endorsement(investor, recipient));
+        vm.prank(investor);
+        printer.transferFrom(investor, recipient, 1);
+
+        assertEq(printer.legalOwnerOf(1), recipient);
+        assertEq(printer.balanceOfLegalOwner(recipient), 1, "lazily tracked under new owner");
+        assertEq(printer.tokenOfLegalOwnerByIndex(recipient, 0), 1);
+        assertEq(printer.balanceOfLegalOwner(investor), 0, "old owner stays empty, no underflow add");
+    }
+
+    // The explicit batched backfill repopulates the enumeration from owners[] for all live tokens, in batches,
+    // and is safe to re-run.
+    function test_BackfillLegalOwners_RepopulatesLegacyEnumeration() public {
+        _mintCert(1, investor, 100, bytes(""));
+        _mintCert(2, investor, 100, bytes(""));
+        _mintCert(3, investor, 100, bytes(""));
+        uint256[] memory ids = new uint256[](3);
+        ids[0] = 1;
+        ids[1] = 2;
+        ids[2] = 3;
+        CyberCertPrinterEnhanced(address(printer)).debugClearLegalOwnerEnumeration(investor, ids);
+        assertEq(printer.balanceOfLegalOwner(investor), 0);
+
+        printer.backfillLegalOwners(0, 2);
+        assertEq(printer.balanceOfLegalOwner(investor), 2);
+        printer.backfillLegalOwners(2, 10); // clamps to supply
+        assertEq(printer.balanceOfLegalOwner(investor), 3);
+
+        printer.backfillLegalOwners(0, 3); // re-run safe
+        assertEq(printer.balanceOfLegalOwner(investor), 3);
+        assertEq(printer.tokenOfLegalOwnerByIndex(investor, 0), 1);
+        assertEq(printer.tokenOfLegalOwnerByIndex(investor, 2), 3);
     }
 
     function test_AddDefaultRestrictiveLegend_StoresAndCopiesOnMint() public {

--- a/test/ScripPOC.t.sol
+++ b/test/ScripPOC.t.sol
@@ -72,6 +72,15 @@ contract POCMockCertPrinter {
         return _ownedTokens[owner_][index];
     }
 
+    // In this mock custody owner == legal owner, so the per-legal-owner enumeration is the same backing data.
+    function balanceOfLegalOwner(address owner_) external view returns (uint256) {
+        return _balances[owner_];
+    }
+
+    function tokenOfLegalOwnerByIndex(address owner_, uint256 index) external view returns (uint256) {
+        return _ownedTokens[owner_][index];
+    }
+
     function getCertificateDetails(uint256 tokenId) external view returns (CertificateDetails memory) {
         return _details[tokenId];
     }


### PR DESCRIPTION
## Added

- support indexes for legal owner (so `IssuanceManagerStorage._selectRecertToken()` could use it to enumerate existing tokens in the future)
- extra protection for backward compatibility (legacy `CyberCertPrinters` won't revert immediately after upgrade)
- permissionless backfill function `backfillLegalOwners()` (so we could backfill legacy `CyberCertPrinters` async as needed)