### PR TITLE
Add issue/acquisitionTimestamps and refactor cert holder caps

### DIFF
--- a/specs/analysis/dealManager secondary trades — exemption path test coverage map.md
+++ b/specs/analysis/dealManager secondary trades — exemption path test coverage map.md
@@ -45,34 +45,34 @@ settlement period).
 
 ## Closing-condition behavior tests
 
-| Test fn                                   | What it proves                                                                                                                                                                           |
-|-------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Test fn                                       | What it proves                                                                                                                                                                                                                     |
+|-----------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `test_GlobalKill_BlocksFinalize_UntilLowered` | Either admin raises unilaterally mid-deal → finalize reverts `SecondaryConditionsNotMet(globalKill)`; the proposer alone cannot confirm the lower (two-call, two-admin lowering); once the other admin confirms, finalize succeeds |
-| `test_TimeSettlement_BlocksEarlyFinalize`     | `finalizableAt == acceptance + 24h`; finalize before the window reverts `SecondaryConditionsNotMet(timeSettlement)`; after the warp it succeeds                                        |
+| `test_TimeSettlement_BlocksEarlyFinalize`     | `finalizableAt == acceptance + 24h`; finalize before the window reverts `SecondaryConditionsNotMet(timeSettlement)`; after the warp it succeeds                                                                                    |
 
 ## Condition → coverage
 
-| Condition                             | Real? | Covered by                     | Notes                                                                                                     |
-|---------------------------------------|:-----:|--------------------------------|-----------------------------------------------------------------------------------------------------------|
-| KYCAMLCondition                       |   ✓   | all 5                          | both buyer & seller hold a valid KYC_AML badge                                                            |
-| TaxInfoCondition                      |   ✓   | all 5                          | admin records `setTaxForm(buyer, W9, …)`                                                                  |
-| HolderCapCondition                    |   ✓   | all 5                          | §3(c)(1), cap 100; buyer is a fresh holder (+1 ≤ 100)                                                     |
-| ERISACondition                        |   ✓   | 144, 4a7, 4a1½, 144A (○ Reg S) | buyer's attestation recorded as a signer value on the settlement agreement                                |
-| USStateOfResidenceCondition           |   ✓   | 144, 4a7, 4a1½, 144A (○ Reg S) | buyer state CA (NY is default-blocked, unused); silent for the non-US Reg S buyer                         |
-| LegionSoulboundCondition              |   ✓   | all 5                          | buyer holds the Legion custom-category credential                                                         |
-| AgreementSignedCondition              |   ✓   | all 5 (SPV-layer)              | `registry.allPartiesSigned(settlementId)`; silent at posting, satisfied from acceptance onward            |
-| HoldingPeriodCondition                |   ✓   | 144                            | reads `FundInterestData.acquisitionDate` from the seller cert                                             |
-| LexChexBadgeKind(ACCREDITED_INVESTOR) |   ✓   | 4a7                            | buyer-only                                                                                                |
-| LexChexBadgeKind(QIB)                 |   ✓   | 144A                           | buyer-only                                                                                                |
-| LexChexBadgeKind(NON_US_PERSON)       |   ✓   | Reg S                          | buyer-only; approximates the spec's zkPassport `NonUSPersonCondition` (a generic `ICondition`, not typed) |
-| RegSDistributionComplianceCondition   |   ✓   | Reg S                          | `setRegSConfig(corp, 3, 365 d)`; reads acquisitionDate                                                    |
-| Rule144DisclosureCondition            |   ✓   | 144                            | SPV admin records `setDisclosurePackage(corp, uri, asOf)`; 16-month freshness policy                      |
-| Section4a7DisclosureCondition         |   ✓   | 4a7                            | package freshness (from posting) + buyer's acknowledgment-of-receipt signer value (from acceptance)       |
-| LegalOpinionCondition                 |   ✓   | 4a1½                           | GP records `recordGPSignOff(dm, offerId)` between post and accept, pre-approving the offer's settlements  |
-| GlobalKillCondition                   |   ✓   | all 5 (closing) + kill test    | plain singleton; two admin slots (MetaLeX + Legion), raise unilateral, lower two-call                     |
-| TimeSettlementPeriodCondition         |   ✓   | all 5 (closing) + timing test  | 24h default from acceptance (reconstructed as `escrow.expiry − settlementWindow`); happy paths warp past  |
-| CFIUSCondition                        |   ✓   | none                           | implemented; optional per-SPV, out of scope for these happy paths                                         |
-| GPLPApprovalCondition                 |   ✓   | none                           | implemented; optional per-SPV, out of scope                                                               |
+| Condition                             | Real? | Covered by                     | Notes                                                                                                                                            |
+|---------------------------------------|:-----:|--------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
+| KYCAMLCondition                       |   ✓   | all 5                          | both buyer & seller hold a valid KYC_AML badge                                                                                                   |
+| TaxInfoCondition                      |   ✓   | all 5                          | admin records `setTaxForm(buyer, W9, …)`                                                                                                         |
+| HolderCapCondition                    |   ✓   | all 5                          | §3(c)(1), cap 100; buyer is a fresh holder (+1 ≤ 100)                                                                                            |
+| ERISACondition                        |   ✓   | 144, 4a7, 4a1½, 144A (○ Reg S) | buyer's attestation recorded as a signer value on the settlement agreement                                                                       |
+| USStateOfResidenceCondition           |   ✓   | 144, 4a7, 4a1½, 144A (○ Reg S) | buyer state CA (NY is default-blocked, unused); silent for the non-US Reg S buyer                                                                |
+| LegionSoulboundCondition              |   ✓   | all 5                          | buyer holds the Legion custom-category credential                                                                                                |
+| AgreementSignedCondition              |   ✓   | all 5 (SPV-layer)              | `registry.allPartiesSigned(settlementId)`; silent at posting, satisfied from acceptance onward                                                   |
+| HoldingPeriodCondition                |   ✓   | 144                            | reads the seller cert's base `acquisitionTimestamp` (tacking anchor still from the extension); seller lot aged past HOLD by minting then warping |
+| LexChexBadgeKind(ACCREDITED_INVESTOR) |   ✓   | 4a7                            | buyer-only                                                                                                                                       |
+| LexChexBadgeKind(QIB)                 |   ✓   | 144A                           | buyer-only                                                                                                                                       |
+| LexChexBadgeKind(NON_US_PERSON)       |   ✓   | Reg S                          | buyer-only; approximates the spec's zkPassport `NonUSPersonCondition` (a generic `ICondition`, not typed)                                        |
+| RegSDistributionComplianceCondition   |   ✓   | Reg S                          | `setRegSConfig(corp, 3, 365 d)`; reads the seller cert's base `acquisitionTimestamp`                                                             |
+| Rule144DisclosureCondition            |   ✓   | 144                            | SPV admin records `setDisclosurePackage(corp, uri, asOf)`; 16-month freshness policy                                                             |
+| Section4a7DisclosureCondition         |   ✓   | 4a7                            | package freshness (from posting) + buyer's acknowledgment-of-receipt signer value (from acceptance)                                              |
+| LegalOpinionCondition                 |   ✓   | 4a1½                           | GP records `recordGPSignOff(dm, offerId)` between post and accept, pre-approving the offer's settlements                                         |
+| GlobalKillCondition                   |   ✓   | all 5 (closing) + kill test    | plain singleton; two admin slots (MetaLeX + Legion), raise unilateral, lower two-call                                                            |
+| TimeSettlementPeriodCondition         |   ✓   | all 5 (closing) + timing test  | 24h default from acceptance (reconstructed as `escrow.expiry − settlementWindow`); happy paths warp past                                         |
+| CFIUSCondition                        |   ✓   | none                           | implemented; optional per-SPV, out of scope for these happy paths                                                                                |
+| GPLPApprovalCondition                 |   ✓   | none                           | implemented; optional per-SPV, out of scope                                                                                                      |
 
 ## Test-fixture notes
 

--- a/src/CyberCertPrinter.sol
+++ b/src/CyberCertPrinter.sol
@@ -254,14 +254,22 @@ contract CyberCertPrinter is Initializable, ERC721EnumerableUpgradeable {
         return CyberCertPrinterStorage.cyberCertStorage().issuerSignatures[tokenId][index];
     }
 
+    // Note voiding a cert does not impact legal owner accounting (the legal-owner enumeration keeps the
+    // voided lot; that is why `_removeFromLegalOwnerEnumeration()` is not called here). It DOES impact the
+    // look-through holder tally: a fully-voided lot no longer counts its owner as a live holder, so the
+    // tally is decremented via `recordVoidLegalOwner` (after the status flip).
     function voidCert(uint256 tokenId) external onlyIssuanceManager {
         CyberCertPrinterStorage.setSecurityStatus(tokenId, SecurityStatus.Void);
+        CyberCertPrinterStorage.recordVoidLegalOwner(tokenId);
         emit ICyberCertPrinter.CertificateVoided(tokenId, block.timestamp);
     }
 
+    // As explained in `voidCert()`. Un-voiding restores the lot's contribution to the look-through tally,
+    // so `recordUnvoidLegalOwner` runs after the status is set back to Assigned.
     function unvoidCert(uint256 tokenId) external onlyIssuanceManager {
         if (!_exists(tokenId)) revert ICyberCertPrinter.TokenDoesNotExist();
         CyberCertPrinterStorage.setSecurityStatus(tokenId, SecurityStatus.Assigned);
+        CyberCertPrinterStorage.recordUnvoidLegalOwner(tokenId);
         emit ICyberCertPrinter.CertificateUnvoided(tokenId, block.timestamp);
     }
 
@@ -347,7 +355,27 @@ contract CyberCertPrinter is Initializable, ERC721EnumerableUpgradeable {
     function holderCount() external view returns (uint256) {
         return CyberCertPrinterStorage.getHolderCount();
     }
-    
+
+    /// @notice §3(c)(1)(A) look-through holder count: Σ over live holders of max(beneficialOwnerCount, 1).
+    function lookThroughHolderCount() external view returns (uint256) {
+        return CyberCertPrinterStorage.getLookThroughHolderCount();
+    }
+
+    /// @notice The U.S.-resident subset of `lookThroughHolderCount` (Touche Remnant counting).
+    function usLookThroughHolderCount() external view returns (uint256) {
+        return CyberCertPrinterStorage.getUsLookThroughHolderCount();
+    }
+
+    /// @notice True when `owner` currently holds at least one live (non-void) lot of record.
+    function isLegalHolder(address owner) external view returns (bool) {
+        return CyberCertPrinterStorage.isLegalHolder(owner);
+    }
+
+    /// @notice The LeXcheXBadge the look-through tally samples for beneficial-owner counts and US residency.
+    function lookThroughBadge() external view returns (address) {
+        return CyberCertPrinterStorage.getLookThroughBadge();
+    }
+
     function _exists(uint256 tokenId) internal view virtual returns (bool) {
         return _ownerOf(tokenId) != address(0);
     }
@@ -520,6 +548,29 @@ contract CyberCertPrinter is Initializable, ERC721EnumerableUpgradeable {
     /// idempotent; batch over the supply. See CyberCertPrinterStorage.backfillAcquisitionTimestamp.
     function backfillAcquisitionTimestamps(uint256 startIndex, uint256 count) external {
         CyberCertPrinterStorage.backfillAcquisitionTimestamp(startIndex, count);
+    }
+
+    /// @notice Wire the LeXcheXBadge the look-through tally samples. Set before the first mint on a new
+    /// printer (and before `backfillLookThroughTally` on an upgraded one).
+    function setLookThroughBadge(address badge) external onlyIssuanceManager {
+        CyberCertPrinterStorage.setLookThroughBadge(badge);
+        emit ICyberCertPrinter.LookThroughBadgeSet(badge);
+    }
+
+    /// @notice Re-read the badge and reconcile a live holder's look-through contribution (e.g. after a
+    /// re-credential). Permissionless: it can only pull the tally toward authoritative badge state.
+    function resyncHolder(address owner) external {
+        CyberCertPrinterStorage.resyncHolder(owner);
+    }
+
+    function resyncHolders(address[] calldata owners) external {
+        CyberCertPrinterStorage.resyncHolders(owners);
+    }
+
+    /// @notice Backfill the look-through tally for tokens in [startIndex, startIndex+count) after a beacon
+    /// upgrade. Set the badge first; permissionless and idempotent. Batch over [0, totalSupply()).
+    function backfillLookThroughTally(uint256 startIndex, uint256 count) external {
+        CyberCertPrinterStorage.backfillLookThroughTally(startIndex, count);
     }
 
 }

--- a/src/CyberCertPrinter.sol
+++ b/src/CyberCertPrinter.sol
@@ -480,6 +480,12 @@ contract CyberCertPrinter is Initializable, ERC721EnumerableUpgradeable {
         return CyberCertPrinterStorage.getAcquisitionTimestamp(tokenId);
     }
 
+    /// @notice Admin override of a cert's acquisition timestamp (e.g. to seed a seasoned migrated position).
+    function setAcquisitionTimestamp(uint256 tokenId, uint64 ts) external onlyIssuanceManager {
+        if (!_exists(tokenId)) revert ICyberCertPrinter.TokenDoesNotExist();
+        CyberCertPrinterStorage.setAcquisitionTimestamp(tokenId, ts);
+    }
+
     function isTokenTransferable(uint256 tokenId) external view returns (bool) {
         return CyberCertPrinterStorage.cyberCertStorage().tokenTransferable[tokenId];
     }

--- a/src/CyberCertPrinter.sol
+++ b/src/CyberCertPrinter.sol
@@ -40,11 +40,12 @@ mechanical, including photocopying, recording, or by any information storage and
 except with the express prior written permission of the copyright holder.*/
 pragma solidity 0.8.28;
 
-import "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "openzeppelin-contracts-upgradeable/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol";
+import "openzeppelin-contracts-upgradeable/proxy/utils/Initializable.sol";
 import "./interfaces/IIssuanceManager.sol";
 import "./interfaces/ITransferRestrictionHook.sol";
 import "./storage/CyberCertPrinterStorage.sol";
+import "./interfaces/ICyberCertPrinter.sol";
 import "./interfaces/IUriBuilder.sol";
 import "./interfaces/ICyberAgreementRegistry.sol";
 
@@ -54,56 +55,8 @@ contract CyberCertPrinter is Initializable, ERC721EnumerableUpgradeable {
 
     string public constant DEPLOY_VERSION = "4"; // For version-tracking on all deployment and future upgrades
 
-    // Custom errors
-    error NotIssuanceManager();
-    error TokenNotTransferable();
-    error TokenDoesNotExist();
-    error InvalidTokenId();
-    error URIQueryForNonexistentToken();
-    error URISetForNonexistentToken();
-    error ConversionNotImplemented();
-    error TransferRestricted(string reason);
-    error EndorsementNotSignedOrInvalid();
-    error InvalidEndorsement();
-    error InvalidLegendIndex();
-    error SignatureRequired();
-    error LegalOwnerIndexOutOfBounds();
-    // Cert has units reserved (in escrow for a pending deal/loan); its legal ownership is frozen
-    error CertificateReserved();
-    // Reverted from the storage library via delegatecall; declared here for the ABI
-    error ExceedsAvailableUnits();
-    error ExceedsReservedUnits();
-
-    //events
-    event CertificateCreated(uint256 indexed tokenId, address indexed investor, uint256 amount, uint256 cap);
-    event Converted(uint256 indexed oldTokenId, uint256 indexed newTokenId);
-    event CertificateSigned(uint256 indexed tokenId, bytes signature);
-    event CertificateEndorsed(
-        uint256 indexed tokenId,
-        address indexed endorser,
-        address indexed endorsee,
-        string endorseeName,
-        address registry,
-        bytes32 agreementId,
-        uint256 index,
-        uint256 timestamp
-    );
-    event HookStatusChanged(bool enabled);
-    event WhitelistUpdated(address indexed account, bool whitelisted);
-    event CyberCertPrinter_CertificateCreated(uint256 indexed tokenId);
-    event CyberCertTransfer(address indexed from, address indexed to, uint256 indexed tokenId);
-    event CertificateAssigned(uint256 indexed tokenId, address indexed newOwner, string newOwnerName, string issuerName);
-    event CertificateVoided(uint256 indexed tokenId, uint256 timestamp);
-    event CertificateUnvoided(uint256 indexed tokenId, uint256 timestamp);
-    event RestrictionHookSet(uint256 indexed id, address indexed hookAddress);
-    event GlobalRestrictionHookSet(address indexed hookAddress);
-    event GlobalTransferableSet(bool indexed transferable);
-    // Emitted from the storage library via delegatecall; declared here for the ABI
-    event UnitsReservedUpdated(uint256 indexed tokenId, uint256 unitsReserved);
-    
-    
     modifier onlyIssuanceManager() {
-        if (msg.sender != CyberCertPrinterStorage.cyberCertStorage().issuanceManager) revert NotIssuanceManager();
+        if (msg.sender != CyberCertPrinterStorage.cyberCertStorage().issuanceManager) revert ICyberCertPrinter.NotIssuanceManager();
         _;
     }
 
@@ -133,18 +86,18 @@ contract CyberCertPrinter is Initializable, ERC721EnumerableUpgradeable {
     // Set a restriction hook for a specific security type
     function setRestrictionHook(uint256 _id, address _hookAddress) external onlyIssuanceManager {
         CyberCertPrinterStorage.cyberCertStorage().restrictionHooksById[_id] = ITransferRestrictionHook(_hookAddress);
-        emit RestrictionHookSet(_id, _hookAddress);
+        emit ICyberCertPrinter.RestrictionHookSet(_id, _hookAddress);
     }
     
     // Set a global restriction hook that applies to all tokens
     function setGlobalRestrictionHook(address hookAddress) external onlyIssuanceManager {
         CyberCertPrinterStorage.cyberCertStorage().globalRestrictionHook = ITransferRestrictionHook(hookAddress);
-        emit GlobalRestrictionHookSet(hookAddress);
+        emit ICyberCertPrinter.GlobalRestrictionHookSet(hookAddress);
     }
 
     function setGlobalTransferable(bool _transferable) external onlyIssuanceManager {
         CyberCertPrinterStorage.cyberCertStorage().transferable = _transferable;
-        emit GlobalTransferableSet(_transferable);
+        emit ICyberCertPrinter.GlobalTransferableSet(_transferable);
     }
 
     function safeMint(
@@ -190,16 +143,16 @@ contract CyberCertPrinter is Initializable, ERC721EnumerableUpgradeable {
         address to,
         CertificateDetails memory details
     ) external onlyIssuanceManager returns (uint256) {
-        if(ownerOf(tokenId) != from) revert InvalidTokenId();
+        if(ownerOf(tokenId) != from) revert ICyberCertPrinter.InvalidTokenId();
         // Reserved units are escrowed for a pending deal; legal ownership can't be reassigned while on escrow.
-        if (CyberCertPrinterStorage.getUnitsReserved(tokenId) > 0) revert CertificateReserved();
+        if (CyberCertPrinterStorage.getUnitsReserved(tokenId) > 0) revert ICyberCertPrinter.CertificateReserved();
         CyberCertPrinterStorage.recordAssign(tokenId, to, details);
         return tokenId;
     }
     
     // Add endorsement (for transfers in secondary market)
     function addEndorsement(uint256 tokenId, Endorsement memory newEndorsement) public {
-        if(msg.sender != CyberCertPrinterStorage.cyberCertStorage().issuanceManager && msg.sender != ownerOf(tokenId)) revert InvalidEndorsement();
+        if(msg.sender != CyberCertPrinterStorage.cyberCertStorage().issuanceManager && msg.sender != ownerOf(tokenId)) revert ICyberCertPrinter.InvalidEndorsement();
         CyberCertPrinterStorage.recordEndorsement(tokenId, newEndorsement);
     }
 
@@ -207,10 +160,10 @@ contract CyberCertPrinter is Initializable, ERC721EnumerableUpgradeable {
         uint256 tokenId,
         bytes calldata signature
     ) external onlyIssuanceManager {
-        if (!_exists(tokenId)) revert TokenDoesNotExist();
-        if (signature.length == 0) revert SignatureRequired();
+        if (!_exists(tokenId)) revert ICyberCertPrinter.TokenDoesNotExist();
+        if (signature.length == 0) revert ICyberCertPrinter.SignatureRequired();
         CyberCertPrinterStorage.cyberCertStorage().issuerSignatures[tokenId].push(signature);
-        emit CertificateSigned(tokenId, signature);
+        emit ICyberCertPrinter.CertificateSigned(tokenId, signature);
     }
 
     function endorseAndTransfer(uint256 tokenId, Endorsement memory newEndorsement, address from, address to) external {
@@ -223,7 +176,7 @@ contract CyberCertPrinter is Initializable, ERC721EnumerableUpgradeable {
         // Enforce the reserved-units invariant at the single write chokepoint: raw unitsRepresented may never
         // drop below the units locked in pending deals. Guards against a caller writing back an effective
         // (scripified-inflated) or otherwise under-counted balance.
-        if (details.unitsRepresented < CyberCertPrinterStorage.getUnitsReserved(tokenId)) revert ExceedsAvailableUnits();
+        if (details.unitsRepresented < CyberCertPrinterStorage.getUnitsReserved(tokenId)) revert ICyberCertPrinter.ExceedsAvailableUnits();
         CyberCertPrinterStorage.cyberCertStorage().certificateDetails[tokenId] = details;
     }
 
@@ -251,13 +204,13 @@ contract CyberCertPrinter is Initializable, ERC721EnumerableUpgradeable {
             // A cert with reserved units is escrowed for a pending deal/loan: its legal ownership is frozen
             // until the reservation is released at settlement or void. Blocks the transfer vector; assignCert
             // guards the reassignment vector.
-            if (CyberCertPrinterStorage.getUnitsReserved(tokenId) > 0) revert CertificateReserved();
+            if (CyberCertPrinterStorage.getUnitsReserved(tokenId) > 0) revert ICyberCertPrinter.CertificateReserved();
             // Restriction + endorsement logic lives in the external library (delegatecall)
             // to keep this contract under the bytecode size limit
             CyberCertPrinterStorage.processTransfer(from, to, tokenId);
         }
         // Emit custom transfer event for indexing
-        emit CyberCertTransfer(
+        emit ICyberCertPrinter.CyberCertTransfer(
             from,
             to,
             tokenId
@@ -272,14 +225,14 @@ contract CyberCertPrinter is Initializable, ERC721EnumerableUpgradeable {
     ///         If you need raw `unitsRepresented`, use `getActiveCertificateDetails()` instead
     // Get full agreement details
     function getCertificateDetails(uint256 tokenId) external view returns (CertificateDetails memory) {
-        if (ownerOf(tokenId) == address(0)) revert TokenDoesNotExist();
+        if (ownerOf(tokenId) == address(0)) revert ICyberCertPrinter.TokenDoesNotExist();
         return CyberCertPrinterStorage.getCertificateDetails(tokenId);
     }
 
     function getActiveCertificateDetails(
         uint256 tokenId
     ) external view returns (CertificateDetails memory) {
-        if (ownerOf(tokenId) == address(0)) revert TokenDoesNotExist();
+        if (ownerOf(tokenId) == address(0)) revert ICyberCertPrinter.TokenDoesNotExist();
         return CyberCertPrinterStorage.getActiveCertificateDetails(tokenId);
     }
 
@@ -287,33 +240,33 @@ contract CyberCertPrinter is Initializable, ERC721EnumerableUpgradeable {
     function getEndorsementHistory(uint256 tokenId, uint256 index) external view returns (
         Endorsement memory details
     ) {
-        if (ownerOf(tokenId) == address(0)) revert TokenDoesNotExist();
+        if (ownerOf(tokenId) == address(0)) revert ICyberCertPrinter.TokenDoesNotExist();
              details = CyberCertPrinterStorage.cyberCertStorage().endorsements[tokenId][index];
     }
 
     function getIssuerSignatureCount(uint256 tokenId) external view returns (uint256) {
-        if (!_exists(tokenId)) revert TokenDoesNotExist();
+        if (!_exists(tokenId)) revert ICyberCertPrinter.TokenDoesNotExist();
         return CyberCertPrinterStorage.cyberCertStorage().issuerSignatures[tokenId].length;
     }
 
     function getIssuerSignatureAt(uint256 tokenId, uint256 index) external view returns (bytes memory) {
-        if (!_exists(tokenId)) revert TokenDoesNotExist();
+        if (!_exists(tokenId)) revert ICyberCertPrinter.TokenDoesNotExist();
         return CyberCertPrinterStorage.cyberCertStorage().issuerSignatures[tokenId][index];
     }
 
     function voidCert(uint256 tokenId) external onlyIssuanceManager {
         CyberCertPrinterStorage.setSecurityStatus(tokenId, SecurityStatus.Void);
-        emit CertificateVoided(tokenId, block.timestamp);
+        emit ICyberCertPrinter.CertificateVoided(tokenId, block.timestamp);
     }
 
     function unvoidCert(uint256 tokenId) external onlyIssuanceManager {
-        if (!_exists(tokenId)) revert TokenDoesNotExist();
+        if (!_exists(tokenId)) revert ICyberCertPrinter.TokenDoesNotExist();
         CyberCertPrinterStorage.setSecurityStatus(tokenId, SecurityStatus.Assigned);
-        emit CertificateUnvoided(tokenId, block.timestamp);
+        emit ICyberCertPrinter.CertificateUnvoided(tokenId, block.timestamp);
     }
 
     function isVoided(uint256 tokenId) external view returns (bool) {
-        if (ownerOf(tokenId) == address(0)) revert TokenDoesNotExist();
+        if (ownerOf(tokenId) == address(0)) revert ICyberCertPrinter.TokenDoesNotExist();
         return
             CyberCertPrinterStorage.getSecurityStatus(tokenId) ==
             SecurityStatus.Void;
@@ -321,13 +274,13 @@ contract CyberCertPrinter is Initializable, ERC721EnumerableUpgradeable {
     
     // URI storage functionality
     function tokenURI(uint256 tokenId) public view virtual override returns (string memory) {
-        if (!_exists(tokenId)) revert URIQueryForNonexistentToken();
+        if (!_exists(tokenId)) revert ICyberCertPrinter.URIQueryForNonexistentToken();
         return CyberCertPrinterStorage.tokenURI(tokenId);
     }
 
    /* // URI storage functionality
     function tokenURIJson(uint256 tokenId) public view virtual returns (string memory) {
-        if (!_exists(tokenId)) revert URIQueryForNonexistentToken();
+        if (!_exists(tokenId)) revert ICyberCertPrinter.URIQueryForNonexistentToken();
 
         CyberCertPrinterStorage.CyberCertStorage storage s = CyberCertPrinterStorage.cyberCertStorage();
         string[] memory certLegend = s.certLegend[tokenId];
@@ -413,7 +366,7 @@ contract CyberCertPrinter is Initializable, ERC721EnumerableUpgradeable {
 
     function getDefaultLegendAt(uint256 index) external view returns (string memory) {
         CyberCertPrinterStorage.CyberCertStorage storage s = CyberCertPrinterStorage.cyberCertStorage();
-        if (index >= s.defaultLegend.length) revert InvalidLegendIndex();
+        if (index >= s.defaultLegend.length) revert ICyberCertPrinter.InvalidLegendIndex();
         
         return s.defaultLegend[index];
     }
@@ -432,7 +385,7 @@ contract CyberCertPrinter is Initializable, ERC721EnumerableUpgradeable {
 
     function getDefaultRestrictiveLegendAt(uint256 index) external view returns (RestrictiveLegend memory) {
         CyberCertPrinterStorage.CyberCertStorage storage s = CyberCertPrinterStorage.cyberCertStorage();
-        if (index >= s.defaultLegendsV2.length) revert InvalidLegendIndex();
+        if (index >= s.defaultLegendsV2.length) revert ICyberCertPrinter.InvalidLegendIndex();
 
         return s.defaultLegendsV2[index];
     }
@@ -451,7 +404,7 @@ contract CyberCertPrinter is Initializable, ERC721EnumerableUpgradeable {
 
     function getCertLegendAt(uint256 tokenId, uint256 index) external view returns (string memory) {
         CyberCertPrinterStorage.CyberCertStorage storage s = CyberCertPrinterStorage.cyberCertStorage();
-        if (index >= s.certLegend[tokenId].length) revert InvalidLegendIndex();
+        if (index >= s.certLegend[tokenId].length) revert ICyberCertPrinter.InvalidLegendIndex();
         
         return s.certLegend[tokenId][index];
     }   
@@ -470,7 +423,7 @@ contract CyberCertPrinter is Initializable, ERC721EnumerableUpgradeable {
 
     function getCertRestrictiveLegendAt(uint256 tokenId, uint256 index) external view returns (RestrictiveLegend memory) {
         CyberCertPrinterStorage.CyberCertStorage storage s = CyberCertPrinterStorage.cyberCertStorage();
-        if (index >= s.certLegendsV2[tokenId].length) revert InvalidLegendIndex();
+        if (index >= s.certLegendsV2[tokenId].length) revert ICyberCertPrinter.InvalidLegendIndex();
 
         return s.certLegendsV2[tokenId][index];
     }
@@ -497,13 +450,13 @@ contract CyberCertPrinter is Initializable, ERC721EnumerableUpgradeable {
 
     /// @notice Reserve units of a certificate against a pending deal/loan; cannot exceed the cert's units
     function increaseUnitsReserved(uint256 tokenId, uint256 amount) external onlyIssuanceManager {
-        if (!_exists(tokenId)) revert TokenDoesNotExist();
+        if (!_exists(tokenId)) revert ICyberCertPrinter.TokenDoesNotExist();
         CyberCertPrinterStorage.increaseUnitsReserved(tokenId, amount);
     }
 
     /// @notice Release previously reserved units; cannot release more than is reserved
     function decreaseUnitsReserved(uint256 tokenId, uint256 amount) external onlyIssuanceManager {
-        if (!_exists(tokenId)) revert TokenDoesNotExist();
+        if (!_exists(tokenId)) revert ICyberCertPrinter.TokenDoesNotExist();
         CyberCertPrinterStorage.decreaseUnitsReserved(tokenId, amount);
     }
 
@@ -511,12 +464,28 @@ contract CyberCertPrinter is Initializable, ERC721EnumerableUpgradeable {
         return CyberCertPrinterStorage.getUnitsReserved(tokenId);
     }
 
+    /// @notice Timestamp the certificate was issued (set at mint; admin-overridable via setIssueTimestamp).
+    function issueTimestamp(uint256 tokenId) external view returns (uint64) {
+        return CyberCertPrinterStorage.getIssueTimestamp(tokenId);
+    }
+
+    /// @notice Admin override of a cert's issue timestamp (for off-chain-issued positions).
+    function setIssueTimestamp(uint256 tokenId, uint64 ts) external onlyIssuanceManager {
+        if (!_exists(tokenId)) revert ICyberCertPrinter.TokenDoesNotExist();
+        CyberCertPrinterStorage.setIssueTimestamp(tokenId, ts);
+    }
+
+    /// @notice Timestamp the current legal owner acquired the certificate; (re)stamped on each legal-owner change.
+    function acquisitionTimestamp(uint256 tokenId) external view returns (uint64) {
+        return CyberCertPrinterStorage.getAcquisitionTimestamp(tokenId);
+    }
+
     function isTokenTransferable(uint256 tokenId) external view returns (bool) {
         return CyberCertPrinterStorage.cyberCertStorage().tokenTransferable[tokenId];
     }
 
     function legalOwnerOf(uint256 tokenId) external view returns (address) {
-        if (!_exists(tokenId)) revert TokenDoesNotExist();
+        if (!_exists(tokenId)) revert ICyberCertPrinter.TokenDoesNotExist();
         return CyberCertPrinterStorage.cyberCertStorage().owners[tokenId].ownerAddress;
     }
 
@@ -529,7 +498,7 @@ contract CyberCertPrinter is Initializable, ERC721EnumerableUpgradeable {
     /// so it lists a holder's certs even when a custodian (e.g. an admin multisig) holds the NFTs.
     function tokenOfLegalOwnerByIndex(address owner, uint256 index) external view returns (uint256) {
         CyberCertPrinterStorage.CyberCertStorage storage s = CyberCertPrinterStorage.cyberCertStorage();
-        if (index >= s.legalOwnerTokenCount[owner]) revert LegalOwnerIndexOutOfBounds();
+        if (index >= s.legalOwnerTokenCount[owner]) revert ICyberCertPrinter.LegalOwnerIndexOutOfBounds();
         return s.legalOwnedTokens[owner][index];
     }
 
@@ -539,6 +508,12 @@ contract CyberCertPrinter is Initializable, ERC721EnumerableUpgradeable {
     /// only if you want to (harmlessly) re-run it.
     function backfillLegalOwners(uint256 startIndex, uint256 count) external {
         CyberCertPrinterStorage.backfillLegalOwnerEnumeration(startIndex, count);
+    }
+
+    /// @notice Backfill the base acquisitionTimestamp from FundInterestExtension data. Permissionless and
+    /// idempotent; batch over the supply. See CyberCertPrinterStorage.backfillAcquisitionTimestamp.
+    function backfillAcquisitionTimestamps(uint256 startIndex, uint256 count) external {
+        CyberCertPrinterStorage.backfillAcquisitionTimestamp(startIndex, count);
     }
 
 }

--- a/src/IssuanceManager.sol
+++ b/src/IssuanceManager.sol
@@ -429,6 +429,18 @@ contract IssuanceManager is Initializable, BorgAuthACL, UUPSUpgradeable {
         IssuanceManagerStorage.executeSetIssueTimestamp(certAddress, tokenId, ts);
     }
 
+    /// @notice Overrides a certificate's acquisition timestamp, e.g. to seed a seasoned migrated position (admin only)
+    /// @param certAddress Address of the certificate printer contract
+    /// @param tokenId ID of the certificate
+    /// @param ts Acquisition timestamp to set
+    function setAcquisitionTimestamp(
+        address certAddress,
+        uint256 tokenId,
+        uint64 ts
+    ) external onlyAdmin {
+        IssuanceManagerStorage.executeSetAcquisitionTimestamp(certAddress, tokenId, ts);
+    }
+
     /// @notice Voids a certificate
     /// @dev Only callable by admin
     /// @param certAddress Address of the certificate printer contract

--- a/src/IssuanceManager.sol
+++ b/src/IssuanceManager.sol
@@ -417,6 +417,18 @@ contract IssuanceManager is Initializable, BorgAuthACL, UUPSUpgradeable {
         certificate.updateCertificateDetails(tokenId, _details);
     }*/
 
+    /// @notice Overrides a certificate's issue timestamp for a position issued off-chain (admin only)
+    /// @param certAddress Address of the certificate printer contract
+    /// @param tokenId ID of the certificate
+    /// @param ts True (historical) issuance timestamp
+    function setIssueTimestamp(
+        address certAddress,
+        uint256 tokenId,
+        uint64 ts
+    ) external onlyAdmin {
+        IssuanceManagerStorage.executeSetIssueTimestamp(certAddress, tokenId, ts);
+    }
+
     /// @notice Voids a certificate
     /// @dev Only callable by admin
     /// @param certAddress Address of the certificate printer contract

--- a/src/IssuanceManager.sol
+++ b/src/IssuanceManager.sol
@@ -192,11 +192,16 @@ contract IssuanceManager is Initializable, BorgAuthACL, UUPSUpgradeable {
         _;
     }
 
-    /// @dev Restricts execution to contract itself or AUTH.OWNER_ROLE callers
-    modifier onlyOwnerOrSelf() {
+    /// @dev Restricts execution to contract itself or AUTH.OWNER_ROLE callers. Body in a shared private helper
+    /// (not inlined per call site) to keep this contract under the EIP-170 size limit.
+    function _requireOwnerOrSelf() private view {
         if (msg.sender != address(this)) {
             AUTH.onlyRole(AUTH.OWNER_ROLE(), msg.sender);
         }
+    }
+
+    modifier onlyOwnerOrSelf() {
+        _requireOwnerOrSelf();
         _;
     }
 
@@ -439,6 +444,19 @@ contract IssuanceManager is Initializable, BorgAuthACL, UUPSUpgradeable {
         uint64 ts
     ) external onlyAdmin {
         IssuanceManagerStorage.executeSetAcquisitionTimestamp(certAddress, tokenId, ts);
+    }
+
+    /// @notice Overrides a certificate's Rule 144(d)(3) tacking anchor (admin only)
+    /// @dev Rewrites only tackedFromAcquisitionDate in the cert's FundInterestData; other fields are preserved.
+    /// @param certAddress Address of the certificate printer contract
+    /// @param tokenId ID of the certificate
+    /// @param ts Tacking anchor to set (0 = no tacking asserted)
+    function updateCertificateTackedFromAcquisitionDate(
+        address certAddress,
+        uint256 tokenId,
+        uint64 ts
+    ) external onlyAdmin {
+        IssuanceManagerStorage.executeSetTackedFromAcquisitionDate(certAddress, tokenId, ts);
     }
 
     /// @notice Voids a certificate

--- a/src/IssuanceManager.sol
+++ b/src/IssuanceManager.sol
@@ -495,6 +495,18 @@ contract IssuanceManager is Initializable, BorgAuthACL, UUPSUpgradeable {
         );
     }
 
+    /// @notice Wires the LeXcheXBadge the printer samples for its §3(c)(1)(A) look-through holder tally
+    /// @dev Only callable by admin. Set before the first mint on a new printer, and before
+    ///      backfillLookThroughTally on an upgraded one.
+    /// @param certAddress Address of the certificate printer contract
+    /// @param badge Address of the LeXcheXBadge credential contract
+    function setCertLookThroughBadge(
+        address certAddress,
+        address badge
+    ) external onlyAdmin {
+        IssuanceManagerStorage.executeSetLookThroughBadge(certAddress, badge);
+    }
+
     /// @notice Upgrades the implementation of the certificate printer
     /// @dev Only callable by company owner, only upgradeable to the current reference implementation
     /// @param _newImplementation Address of the new implementation

--- a/src/creds/lexchexBadge.sol
+++ b/src/creds/lexchexBadge.sol
@@ -312,6 +312,13 @@ contract LeXcheXBadge is
         return found ? LeXcheXBadgeStorage.getCredential(tokenId).investorJurisdiction : "";
     }
 
+    /// @notice True when the owner's credentialed jurisdiction marks them a U.S. investor. Single source
+    /// of truth for the rule (previously inlined in HolderCapCondition).
+    function isUSInvestor(address owner) public view returns (bool) {
+        bytes32 h = keccak256(bytes(getInvestorJurisdiction(owner)));
+        return h == keccak256("US") || h == keccak256("USA") || h == keccak256("United States");
+    }
+
     /// @notice Seasoning reference for the UI (§11.1B): earliest valid issuance of the given kind.
     /// The seasoning policy (30 vs 45 days) stays at the UI layer; this only supplies the timestamp.
     function earliestValidIssuance(address owner, CategoryKind kind) public view returns (uint64) {

--- a/src/interfaces/ICyberCertPrinter.sol
+++ b/src/interfaces/ICyberCertPrinter.sol
@@ -110,6 +110,7 @@ interface ICyberCertPrinter is IERC721 {
     error CertificateReserved();
     error ExceedsAvailableUnits();
     error ExceedsReservedUnits();
+    error ExtensionTypeNotSupported();
 
     // Shared events — declared once here so CyberCertPrinter and its storage library (via delegatecall) emit
     // with identical topics.
@@ -218,6 +219,7 @@ interface ICyberCertPrinter is IERC721 {
     function getActiveCertificateDetails(
         uint256 tokenId
     ) external view returns (CertificateDetails memory);
+    function getExtension(uint256 tokenId) external view returns (address);
     function getIssuerSignatureCount(uint256 tokenId) external view returns (uint256);
     function getIssuerSignatureAt(uint256 tokenId, uint256 index) external view returns (bytes memory);
     function addCertLegend(uint256 tokenId, string memory newLegend) external;

--- a/src/interfaces/ICyberCertPrinter.sol
+++ b/src/interfaces/ICyberCertPrinter.sol
@@ -92,6 +92,60 @@ struct RestrictiveLegend {
 }
 
 interface ICyberCertPrinter is IERC721 {
+    // Shared errors — declared once here so CyberCertPrinter and its storage library (via delegatecall) revert
+    // with identical selectors.
+    error NotIssuanceManager();
+    error TokenNotTransferable();
+    error TokenDoesNotExist();
+    error InvalidTokenId();
+    error URIQueryForNonexistentToken();
+    error URISetForNonexistentToken();
+    error ConversionNotImplemented();
+    error TransferRestricted(string reason);
+    error EndorsementNotSignedOrInvalid();
+    error InvalidEndorsement();
+    error InvalidLegendIndex();
+    error SignatureRequired();
+    error LegalOwnerIndexOutOfBounds();
+    error CertificateReserved();
+    error ExceedsAvailableUnits();
+    error ExceedsReservedUnits();
+
+    // Shared events — declared once here so CyberCertPrinter and its storage library (via delegatecall) emit
+    // with identical topics.
+    event CertificateCreated(uint256 indexed tokenId, address indexed investor, uint256 amount, uint256 cap);
+    event Converted(uint256 indexed oldTokenId, uint256 indexed newTokenId);
+    event CertificateSigned(uint256 indexed tokenId, bytes signature);
+    event CertificateEndorsed(
+        uint256 indexed tokenId,
+        address indexed endorser,
+        address indexed endorsee,
+        string endorseeName,
+        address registry,
+        bytes32 agreementId,
+        uint256 index,
+        uint256 timestamp
+    );
+    event HookStatusChanged(bool enabled);
+    event WhitelistUpdated(address indexed account, bool whitelisted);
+    event CyberCertPrinter_CertificateCreated(uint256 indexed tokenId);
+    event CyberCertTransfer(address indexed from, address indexed to, uint256 indexed tokenId);
+    event CertificateAssigned(uint256 indexed tokenId, address indexed newOwner, string newOwnerName, string issuerName);
+    event CertificateVoided(uint256 indexed tokenId, uint256 timestamp);
+    event CertificateUnvoided(uint256 indexed tokenId, uint256 timestamp);
+    event RestrictionHookSet(uint256 indexed id, address indexed hookAddress);
+    event GlobalRestrictionHookSet(address indexed hookAddress);
+    event GlobalTransferableSet(bool indexed transferable);
+    event UnitsReservedUpdated(uint256 indexed tokenId, uint256 unitsReserved);
+    event IssueTimestampSet(uint256 indexed tokenId, uint64 issueTimestamp);
+    event LegalOwnerChanged(
+        uint256 indexed tokenId,
+        address indexed previousOwner,
+        address indexed newOwner,
+        string newOwnerName,
+        uint64 acquisitionTimestamp
+    );
+
     function initialize(
         string[] memory defaultLegend,
         string memory name,
@@ -208,4 +262,8 @@ interface ICyberCertPrinter is IERC721 {
     function increaseUnitsReserved(uint256 tokenId, uint256 amount) external;
     function decreaseUnitsReserved(uint256 tokenId, uint256 amount) external;
     function unitsReserved(uint256 tokenId) external view returns (uint256);
+    function issueTimestamp(uint256 tokenId) external view returns (uint64);
+    function setIssueTimestamp(uint256 tokenId, uint64 ts) external;
+    function acquisitionTimestamp(uint256 tokenId) external view returns (uint64);
+    function backfillAcquisitionTimestamps(uint256 startIndex, uint256 count) external;
 }

--- a/src/interfaces/ICyberCertPrinter.sol
+++ b/src/interfaces/ICyberCertPrinter.sol
@@ -137,6 +137,7 @@ interface ICyberCertPrinter is IERC721 {
     event RestrictionHookSet(uint256 indexed id, address indexed hookAddress);
     event GlobalRestrictionHookSet(address indexed hookAddress);
     event GlobalTransferableSet(bool indexed transferable);
+    event LookThroughBadgeSet(address indexed badge);
     event UnitsReservedUpdated(uint256 indexed tokenId, uint256 unitsReserved);
     event IssueTimestampSet(uint256 indexed tokenId, uint64 issueTimestamp);
     event AcquisitionTimestampSet(uint256 indexed tokenId, uint64 acquisitionTimestamp);
@@ -260,6 +261,16 @@ interface ICyberCertPrinter is IERC721 {
     function legalOwnerOf(uint256 tokenId) external view returns (address);
     function balanceOfLegalOwner(address owner) external view returns (uint256);
     function tokenOfLegalOwnerByIndex(address owner, uint256 index) external view returns (uint256);
+
+    // §3(c)(1)(A) look-through holder tally (maintained incrementally; read O(1))
+    function lookThroughHolderCount() external view returns (uint256);
+    function usLookThroughHolderCount() external view returns (uint256);
+    function isLegalHolder(address owner) external view returns (bool); // note the distinction vs legal owner: a legal holder must have live lots
+    function lookThroughBadge() external view returns (address);
+    function setLookThroughBadge(address badge) external;
+    function resyncHolder(address owner) external;
+    function resyncHolders(address[] calldata owners) external;
+    function backfillLookThroughTally(uint256 startIndex, uint256 count) external;
 
     function setTokenTransferable(uint256 tokenId, bool value) external;
     function increaseUnitsReserved(uint256 tokenId, uint256 amount) external;

--- a/src/interfaces/ICyberCertPrinter.sol
+++ b/src/interfaces/ICyberCertPrinter.sol
@@ -138,6 +138,7 @@ interface ICyberCertPrinter is IERC721 {
     event GlobalTransferableSet(bool indexed transferable);
     event UnitsReservedUpdated(uint256 indexed tokenId, uint256 unitsReserved);
     event IssueTimestampSet(uint256 indexed tokenId, uint64 issueTimestamp);
+    event AcquisitionTimestampSet(uint256 indexed tokenId, uint64 acquisitionTimestamp);
     event LegalOwnerChanged(
         uint256 indexed tokenId,
         address indexed previousOwner,
@@ -265,5 +266,6 @@ interface ICyberCertPrinter is IERC721 {
     function issueTimestamp(uint256 tokenId) external view returns (uint64);
     function setIssueTimestamp(uint256 tokenId, uint64 ts) external;
     function acquisitionTimestamp(uint256 tokenId) external view returns (uint64);
+    function setAcquisitionTimestamp(uint256 tokenId, uint64 ts) external;
     function backfillAcquisitionTimestamps(uint256 startIndex, uint256 count) external;
 }

--- a/src/interfaces/IIssuanceManager.sol
+++ b/src/interfaces/IIssuanceManager.sol
@@ -421,7 +421,7 @@ interface IIssuanceManager {
         address seller,
         uint256 units,
         uint256 sellerUnitsAfter, // 0 when the seller token is voided (full sale)
-        uint256 buyerUnitsAfter, // == units on a fresh mint; existing balance + units on a fold
+        uint256 buyerUnitsAfter, // == units on a fresh mint; existing balance + units on a fold (no-op atm because every secondary transfer is a new mint)
         bool sellerVoided,
         bool buyerTokenIsMinted // indicates whether it's a freshly minted token or folded into an existing one
     );

--- a/src/interfaces/IIssuanceManager.sol
+++ b/src/interfaces/IIssuanceManager.sol
@@ -192,6 +192,11 @@ interface IIssuanceManager {
         bool transferable
     ) external;
 
+    function setCertLookThroughBadge(
+        address certAddress,
+        address badge
+    ) external;
+
     function getUpgradeFactory() external view returns (address);
 
     function upgradeCertPrinterBeaconImplementation(

--- a/src/interfaces/ILexChexBadge.sol
+++ b/src/interfaces/ILexChexBadge.sol
@@ -33,6 +33,9 @@ interface ILexChexBadge is IERC5484 {
     function getUsState(address owner) external view returns (bytes2);
     function getBeneficialOwnerCount(address owner) external view returns (uint32);
     function getInvestorJurisdiction(address owner) external view returns (string memory);
+    /// @notice True when the owner's most recent valid credential marks them a U.S. investor. Sole home
+    /// for the jurisdiction rule so consumers don't reimplement it.
+    function isUSInvestor(address owner) external view returns (bool);
 
     /// @notice Seasoning reference (§11.1B): earliest valid issuance of the given kind; 0 when none.
     function earliestValidIssuance(address owner, CategoryKind kind) external view returns (uint64);

--- a/src/libs/conditions/secondary/ERISACondition.sol
+++ b/src/libs/conditions/secondary/ERISACondition.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity 0.8.28;
 
-import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import "openzeppelin-contracts-upgradeable/proxy/utils/Initializable.sol";
+import "openzeppelin-contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "./SecondaryTradingConditionBase.sol";
 import "../../auth.sol";
 import "../../../interfaces/ICyberAgreementRegistry.sol";
@@ -71,6 +71,7 @@ contract ERISACondition is SecondaryTradingConditionBase, UUPSUpgradeable, BorgA
         // The attestation lives on the settlement agreement, which only exists from acceptance onward
         if (agreementId == bytes32(0) || buyer == address(0)) return true;
 
+        // TODO review: do we want to check it as CyberAgreement strings?
         string[] memory values = registry.getSignerValues(agreementId, buyer);
         bytes32 expected = keccak256(bytes(attestationValue));
         for (uint256 i = 0; i < values.length; i++) {

--- a/src/libs/conditions/secondary/HolderCapCondition.sol
+++ b/src/libs/conditions/secondary/HolderCapCondition.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity 0.8.28;
 
-import "openzeppelin-contracts-upgradeable/proxy/utils/Initializable.sol";
-import "openzeppelin-contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "./SecondaryTradingConditionBase.sol";
 import "../../auth.sol";
 import "../../../interfaces/ILexChexBadge.sol";
@@ -11,13 +11,14 @@ import {Offer} from "../../../interfaces/ISecondaryTradeStorage.sol";
 
 /// @title  HolderCapCondition - ICA §3(c)(1) / §3(c)(1)(C) / §3(c)(7) holder limits at transfer time
 /// @author MetaLeX Labs, Inc.
-/// @notice Per-SPV deployment. Reads the onchain holder count from the SPV's ownership ledger (the
-/// offer's cert printer) at acceptance/finalization — not offer time — to avoid stale-count races, and
-/// the acquirer's entity-beneficial-owner-count credential attribute from LeXcheXBadge (§4.1.3A).
-/// If the acquirer is an entity that triggers §3(c)(1)(A) look-through (determined offchain during
-/// credentialing; reflected by a non-zero credentialed beneficial-owner count), the entity's credentialed
-/// count is added instead of counting it as one holder. A buyer who already holds interests in the SPV
-/// (position increase, not new holder) does not implicate the cap.
+/// @notice Per-SPV deployment. Reads the cert printer's maintained O(1) §3(c)(1)(A) look-through holder
+/// tally at acceptance/finalization — not offer time — to avoid stale-count races, plus the acquirer's
+/// entity-beneficial-owner-count credential attribute from LeXcheXBadge (§4.1.3A). Look-through applies to
+/// both sides on one basis: each existing holder already contributes its credentialed beneficial-owner
+/// count in the printer's tally, and the incoming acquirer's credentialed count (non-zero for a
+/// look-through entity, determined offchain during credentialing) is added on top instead of counting it
+/// as one holder. A buyer who already holds live interests in the SPV (position increase, not new holder)
+/// does not implicate the cap.
 contract HolderCapCondition is SecondaryTradingConditionBase, UUPSUpgradeable, BorgAuthACL {
     /// @notice The ICA exception the SPV relies on (informational for the indexer/UI; the cap value and
     /// counting mode below drive the enforcement)
@@ -104,56 +105,34 @@ contract HolderCapCondition is SecondaryTradingConditionBase, UUPSUpgradeable, B
         // No acquirer yet (posting context) — the cap is evaluated at acceptance and finalization
         if (buyer == address(0)) return true;
 
-        bool buyerIsUS = _isUSBuyer(buyer);
+        bool buyerIsUS = badge.isUSInvestor(buyer);
         if (blockUsInvestors && buyerIsUS) return false;
 
         if (cap == 0) return true;
 
         ICyberCertPrinter printer = ICyberCertPrinter(offer.certPrinter);
 
-        // Position increase, not a new holder: the cap is not implicated
-        if (printer.balanceOfLegalOwner(buyer) > 0) return true;
+        // Note threshold conditions are checked BEFORE the transaction happens, so we need to consider the fact
+        // that the holder counts we get from `CyberCertPrinter` are BEFORE the buyer bought it
 
-        // Touche Remnant: a non-U.S. acquirer does not add to the U.S.-resident-only count
+        // Early termination: Position increase, not a new holder: the cap is not implicated. Uses the live-holder tally, so a
+        // holder who fully sold out (and re-enters) is correctly treated as new rather than bypassing the cap.
+        if (printer.isLegalHolder(buyer)) return true;
+
+        // Early termination: Touche Remnant: a non-U.S. acquirer does not add to the U.S.-resident-only count
         if (usResidentOnlyCount && !buyerIsUS) return true;
 
+        // Base is the printer's maintained O(1) look-through tally (both counts share the look-through basis).
         uint256 currentCount = usResidentOnlyCount
-            ? _usResidentHolderCount(printer)
-            : printer.holderCount(); // TODO review: does it report look-through holder count?
+            ? printer.usLookThroughHolderCount()
+            : printer.lookThroughHolderCount();
 
-        // §3(c)(1)(A) look-through: a credentialed entity BO count flows through instead of 1
+        // §3(c)(1)(A) look-through for the incoming buyer (not yet a holder at check time): a credentialed
+        // entity BO count flows through instead of 1
         uint32 boCount = badge.getBeneficialOwnerCount(buyer);
         uint256 addition = boCount > 0 ? boCount : 1;
 
         return currentCount + addition <= cap;
-    }
-
-    /// @dev Counts unique legal owners whose credential marks them U.S.-resident. O(n²) over the token
-    /// set, acceptable at holder-cap scale (n ≤ 250 by construction).
-    // TODO review: could be too expensive
-    function _usResidentHolderCount(ICyberCertPrinter printer) internal view returns (uint256 count) {
-        uint256 supply = printer.totalSupply();
-        address[] memory seen = new address[](supply);
-        uint256 seenLen;
-        for (uint256 i = 0; i < supply; i++) {
-            address holder = printer.legalOwnerOf(printer.tokenByIndex(i));
-            if (holder == address(0)) continue;
-            bool duplicate = false;
-            for (uint256 j = 0; j < seenLen; j++) {
-                if (seen[j] == holder) {
-                    duplicate = true;
-                    break;
-                }
-            }
-            if (duplicate) continue;
-            seen[seenLen++] = holder;
-            if (_isUSBuyer(holder)) count++;
-        }
-    }
-
-    function _isUSBuyer(address account) internal view returns (bool) {
-        bytes32 h = keccak256(bytes(badge.getInvestorJurisdiction(account)));
-        return h == keccak256("US") || h == keccak256("USA") || h == keccak256("United States");
     }
 
     function _authorizeUpgrade(address) internal override onlyOwner {}

--- a/src/libs/conditions/secondary/HolderCapCondition.sol
+++ b/src/libs/conditions/secondary/HolderCapCondition.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity 0.8.28;
 
-import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import "openzeppelin-contracts-upgradeable/proxy/utils/Initializable.sol";
+import "openzeppelin-contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "./SecondaryTradingConditionBase.sol";
 import "../../auth.sol";
 import "../../../interfaces/ILexChexBadge.sol";
@@ -119,7 +119,7 @@ contract HolderCapCondition is SecondaryTradingConditionBase, UUPSUpgradeable, B
 
         uint256 currentCount = usResidentOnlyCount
             ? _usResidentHolderCount(printer)
-            : printer.holderCount();
+            : printer.holderCount(); // TODO review: does it report look-through holder count?
 
         // §3(c)(1)(A) look-through: a credentialed entity BO count flows through instead of 1
         uint32 boCount = badge.getBeneficialOwnerCount(buyer);
@@ -130,6 +130,7 @@ contract HolderCapCondition is SecondaryTradingConditionBase, UUPSUpgradeable, B
 
     /// @dev Counts unique legal owners whose credential marks them U.S.-resident. O(n²) over the token
     /// set, acceptable at holder-cap scale (n ≤ 250 by construction).
+    // TODO review: could be too expensive
     function _usResidentHolderCount(ICyberCertPrinter printer) internal view returns (uint256 count) {
         uint256 supply = printer.totalSupply();
         address[] memory seen = new address[](supply);

--- a/src/libs/conditions/secondary/HoldingPeriodCondition.sol
+++ b/src/libs/conditions/secondary/HoldingPeriodCondition.sol
@@ -58,17 +58,17 @@ contract HoldingPeriodCondition is SecondaryTradingConditionBase, UUPSUpgradeabl
 
         (,, uint256 sellerTokenId) = _resolveParties(dealManager, offer, agreementId);
 
-        bytes memory extensionData =
-            ICyberCertPrinter(offer.certPrinter).getCertificateDetails(sellerTokenId).extensionData;
-        // No fund-interest record = the holding period cannot be verified: fail closed
-        if (extensionData.length == 0) return false;
-
-        FundInterestData memory data = abi.decode(extensionData, (FundInterestData));
-        uint64 anchor = data.acquisitionDate;
-        if (data.tackedFromAcquisitionDate != 0 && data.tackedFromAcquisitionDate < anchor) {
-            anchor = data.tackedFromAcquisitionDate;
-        }
+        ICyberCertPrinter cert = ICyberCertPrinter(offer.certPrinter);
+        // Base acquisitionTimestamp; no record = fail closed.
+        uint64 anchor = cert.acquisitionTimestamp(sellerTokenId);
         if (anchor == 0) return false;
+
+        // Rule 144(d)(3) tacking anchor (extension) governs where present and earlier.
+        bytes memory extensionData = cert.getCertificateDetails(sellerTokenId).extensionData;
+        if (extensionData.length != 0) {
+            uint64 tackedFrom = abi.decode(extensionData, (FundInterestData)).tackedFromAcquisitionDate;
+            if (tackedFrom != 0 && tackedFrom < anchor) anchor = tackedFrom;
+        }
 
         return block.timestamp >= uint256(anchor) + holdingPeriod;
     }

--- a/src/libs/conditions/secondary/RegSDistributionComplianceCondition.sol
+++ b/src/libs/conditions/secondary/RegSDistributionComplianceCondition.sol
@@ -5,7 +5,6 @@ import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "./SecondaryTradingConditionBase.sol";
 import "../../auth.sol";
-import {FundInterestData} from "../../../storage/extensions/FundInterestExtension.sol";
 import {ICyberCertPrinter} from "../../../interfaces/ICyberCertPrinter.sol";
 import {Offer, OfferSide} from "../../../interfaces/ISecondaryTradeStorage.sol";
 
@@ -72,14 +71,11 @@ contract RegSDistributionComplianceCondition is SecondaryTradingConditionBase, U
 
         (,, uint256 sellerTokenId) = _resolveParties(dealManager, offer, agreementId);
 
-        bytes memory extensionData =
-            ICyberCertPrinter(offer.certPrinter).getCertificateDetails(sellerTokenId).extensionData;
-        if (extensionData.length == 0) return false;
+        // Base acquisitionTimestamp; no record = fail closed.
+        uint64 acquisition = ICyberCertPrinter(offer.certPrinter).acquisitionTimestamp(sellerTokenId);
+        if (acquisition == 0) return false;
 
-        FundInterestData memory data = abi.decode(extensionData, (FundInterestData));
-        if (data.acquisitionDate == 0) return false;
-
-        return block.timestamp >= uint256(data.acquisitionDate) + config.compliancePeriod;
+        return block.timestamp >= uint256(acquisition) + config.compliancePeriod;
     }
 
     function _authorizeUpgrade(address) internal override onlyOwner {}

--- a/src/libs/conditions/secondary/Section4a7DisclosureCondition.sol
+++ b/src/libs/conditions/secondary/Section4a7DisclosureCondition.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity 0.8.28;
 
-import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import "openzeppelin-contracts-upgradeable/proxy/utils/Initializable.sol";
+import "openzeppelin-contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "./SecondaryTradingConditionBase.sol";
 import "../../auth.sol";
 import "../../../interfaces/ICyberAgreementRegistry.sol";
@@ -112,6 +112,7 @@ contract Section4a7DisclosureCondition is SecondaryTradingConditionBase, UUPSUpg
         // Part 1 — SPV-wide, enforced from posting onward: the package must exist and be fresh
         if (!isDisclosureCurrent(offer.spvAddress)) return false;
 
+        // TODO review: do we want to check it as CyberAgreement strings?
         // Part 2 — buyer acknowledgment, which lives on the settlement agreement (acceptance onward)
         (, address buyer,) = _resolveParties(dealManager, offer, agreementId);
         if (agreementId == bytes32(0) || buyer == address(0)) return true;

--- a/src/libs/conditions/secondary/Section4a7DisclosureCondition.sol
+++ b/src/libs/conditions/secondary/Section4a7DisclosureCondition.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity 0.8.28;
 
-import "openzeppelin-contracts-upgradeable/proxy/utils/Initializable.sol";
-import "openzeppelin-contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "./SecondaryTradingConditionBase.sol";
 import "../../auth.sol";
 import "../../../interfaces/ICyberAgreementRegistry.sol";

--- a/src/libs/conditions/secondary/TaxInfoCondition.sol
+++ b/src/libs/conditions/secondary/TaxInfoCondition.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity 0.8.28;
 
-import "openzeppelin-contracts-upgradeable/proxy/utils/Initializable.sol";
-import "openzeppelin-contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "./SecondaryTradingConditionBase.sol";
 import "../../auth.sol";
 import {Offer} from "../../../interfaces/ISecondaryTradeStorage.sol";

--- a/src/libs/conditions/secondary/TaxInfoCondition.sol
+++ b/src/libs/conditions/secondary/TaxInfoCondition.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity 0.8.28;
 
-import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import "openzeppelin-contracts-upgradeable/proxy/utils/Initializable.sol";
+import "openzeppelin-contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "./SecondaryTradingConditionBase.sol";
 import "../../auth.sol";
 import {Offer} from "../../../interfaces/ISecondaryTradeStorage.sol";
@@ -78,6 +78,7 @@ contract TaxInfoCondition is SecondaryTradingConditionBase, UUPSUpgradeable, Bor
         // No buyer yet (posting context) — nothing to gate
         if (buyer == address(0)) return true;
 
+        // TODO do we need to gate tax form types by buyer status?
         return hasTaxFormOnFile(buyer);
     }
 

--- a/src/storage/CyberCertPrinterStorage.sol
+++ b/src/storage/CyberCertPrinterStorage.sol
@@ -55,33 +55,14 @@ import "../interfaces/IIssuanceManager.sol";
 import "../interfaces/IUriBuilder.sol";
 import "../interfaces/ITransferRestrictionHook.sol";
 import "./extensions/ICertificateExtension.sol";
+import {FundInterestData} from "./extensions/FundInterestExtension.sol";
 
 library CyberCertPrinterStorage {
     // Storage slot for our struct
     bytes32 constant STORAGE_POSITION = keccak256("cybercorp.cert.printer.storage.v1");
 
-    // Mirrors of the printer's error/event signatures; identical selectors/topics,
-    // so reverts and logs surface exactly as if they came from the printer (delegatecall).
-    error TokenNotTransferable();
-    error TransferRestricted(string reason);
-    error EndorsementNotSignedOrInvalid();
-    error InvalidLegendIndex();
-    error ExceedsAvailableUnits();
-    error ExceedsReservedUnits();
-
-    event CertificateAssigned(uint256 indexed tokenId, address indexed newOwner, string newOwnerName, string issuerName);
-    event CyberCertPrinter_CertificateCreated(uint256 indexed tokenId);
-    event UnitsReservedUpdated(uint256 indexed tokenId, uint256 unitsReserved);
-    event CertificateEndorsed(
-        uint256 indexed tokenId,
-        address indexed endorser,
-        address indexed endorsee,
-        string endorseeName,
-        address registry,
-        bytes32 agreementId,
-        uint256 index,
-        uint256 timestamp
-    );
+    // Errors and events are shared: declared once on ICyberCertPrinter and referenced as ICyberCertPrinter.X
+    // (below), so library reverts/logs carry the same selectors/topics as the printer's under delegatecall.
 
     // Main storage layout struct
     struct CyberCertStorage {
@@ -119,6 +100,11 @@ library CyberCertPrinterStorage {
         mapping(uint256 => uint256) legalOwnedTokensIndex; // tokenId => index within its owner's list
         mapping(address => uint256) legalOwnerTokenCount; // owner => number of certs held of record
         mapping(uint256 => bool) legalOwnedTokenTracked; // token is present in its legal owner's enumeration
+
+        // Per-lot timestamps (spec §12B.3). issueTimestamp is set once at mint; acquisitionTimestamp is
+        // (re)stamped on each legal-owner change and drives the Rule 144 / Reg S holding-period conditions.
+        mapping(uint256 => uint64) issueTimestamp;
+        mapping(uint256 => uint64) acquisitionTimestamp;
     }
 
     // Returns the storage layout
@@ -177,7 +163,7 @@ library CyberCertPrinterStorage {
         // Check built-in transferability flag and per-token override
         if (!s.transferable && !s.tokenTransferable[tokenId]) {
             ICyberCorp corp = ICyberCorp(IIssuanceManager(s.issuanceManager).CORP());
-            if (from != corp.dealManager() && from != corp.roundManager()) revert TokenNotTransferable();
+            if (from != corp.dealManager() && from != corp.roundManager()) revert ICyberCertPrinter.TokenNotTransferable();
         }
 
         // Check global hook if it exists
@@ -185,7 +171,7 @@ library CyberCertPrinterStorage {
             (bool allowed, string memory reason) = s.globalRestrictionHook.checkTransferRestriction(
                 from, to, tokenId, ""
             );
-            if (!allowed) revert TransferRestricted(reason);
+            if (!allowed) revert ICyberCertPrinter.TransferRestricted(reason);
         }
 
         ITransferRestrictionHook typeHook = CyberCertPrinterStorage.cyberCertStorage().restrictionHooksById[tokenId];
@@ -194,7 +180,7 @@ library CyberCertPrinterStorage {
             (bool allowed, string memory reason) = typeHook.checkTransferRestriction(
                 from, to, tokenId, ""
             );
-            if (!allowed) revert TransferRestricted(reason);
+            if (!allowed) revert ICyberCertPrinter.TransferRestricted(reason);
         }
 
         address ownerAddress = s.owners[tokenId].ownerAddress;
@@ -202,14 +188,14 @@ library CyberCertPrinterStorage {
         //check endorsement and update owners
         if (from == ownerAddress) {
             if (!s.endorsementRequired) {
-                emit CertificateAssigned(tokenId, to, "", IIssuanceManager(s.issuanceManager).companyName());
+                emit ICyberCertPrinter.CertificateAssigned(tokenId, to, "", IIssuanceManager(s.issuanceManager).companyName());
                 _setLegalOwner(s, tokenId, to, "");
             }
             else if (endorsementCount > 0) {
                 Endorsement memory endorsement = s.endorsements[tokenId][endorsementCount - 1];
                 if (endorsement.endorsee == to) {
                     // Endorsement exists; ownership will be updated
-                    emit CertificateAssigned(tokenId, to, endorsement.endorseeName, IIssuanceManager(s.issuanceManager).companyName());
+                    emit ICyberCertPrinter.CertificateAssigned(tokenId, to, endorsement.endorseeName, IIssuanceManager(s.issuanceManager).companyName());
                     _setLegalOwner(s, tokenId, endorsement.endorsee, endorsement.endorseeName);
                 }
             }
@@ -218,12 +204,12 @@ library CyberCertPrinterStorage {
         else if (endorsementCount > 0) {
             // Token is not being transferred from the current owner. It can only be transferrred to the latest endorsee, or the current owner
             Endorsement memory endorsement = s.endorsements[tokenId][endorsementCount - 1];
-            if (endorsement.endorsee != to && ownerAddress != to) revert EndorsementNotSignedOrInvalid();
+            if (endorsement.endorsee != to && ownerAddress != to) revert ICyberCertPrinter.EndorsementNotSignedOrInvalid();
 
-            emit CertificateAssigned(tokenId, to, endorsement.endorseeName, IIssuanceManager(s.issuanceManager).companyName());
+            emit ICyberCertPrinter.CertificateAssigned(tokenId, to, endorsement.endorseeName, IIssuanceManager(s.issuanceManager).companyName());
             _setLegalOwner(s, tokenId, endorsement.endorsee, endorsement.endorseeName);
         }
-        else revert EndorsementNotSignedOrInvalid();
+        else revert ICyberCertPrinter.EndorsementNotSignedOrInvalid();
     }
 
     /// @dev Post-mint bookkeeping for CyberCertPrinter.safeMint (the _safeMint itself stays in the printer).
@@ -233,7 +219,7 @@ library CyberCertPrinterStorage {
         copyDefaultRestrictiveLegendsToCert(s, tokenId);
         s.certificateDetails[tokenId] = details;
         _setLegalOwner(s, tokenId, to, "");
-        emit CyberCertPrinter_CertificateCreated(tokenId);
+        emit ICyberCertPrinter.CyberCertPrinter_CertificateCreated(tokenId);
     }
 
     /// @dev Post-mint bookkeeping for CyberCertPrinter.safeMintAndAssign.
@@ -248,8 +234,8 @@ library CyberCertPrinterStorage {
         copyDefaultRestrictiveLegendsToCert(s, tokenId);
         s.certificateDetails[tokenId] = details;
         _setLegalOwner(s, tokenId, to, investorName);
-        emit CertificateAssigned(tokenId, to, investorName, IIssuanceManager(s.issuanceManager).companyName());
-        emit CyberCertPrinter_CertificateCreated(tokenId);
+        emit ICyberCertPrinter.CertificateAssigned(tokenId, to, investorName, IIssuanceManager(s.issuanceManager).companyName());
+        emit ICyberCertPrinter.CyberCertPrinter_CertificateCreated(tokenId);
     }
 
     /// @dev Bookkeeping for CyberCertPrinter.assignCert (the ownerOf check stays in the printer).
@@ -257,14 +243,14 @@ library CyberCertPrinterStorage {
         CyberCertStorage storage s = cyberCertStorage();
         s.certificateDetails[tokenId] = details;
         _setLegalOwner(s, tokenId, to, "");
-        emit CertificateAssigned(tokenId, to, "", IIssuanceManager(s.issuanceManager).companyName());
+        emit ICyberCertPrinter.CertificateAssigned(tokenId, to, "", IIssuanceManager(s.issuanceManager).companyName());
     }
 
     /// @dev Endorsement push + event for CyberCertPrinter.addEndorsement (the auth check stays in the printer).
     function recordEndorsement(uint256 tokenId, Endorsement memory newEndorsement) external {
         CyberCertStorage storage s = cyberCertStorage();
         s.endorsements[tokenId].push(newEndorsement);
-        emit CertificateEndorsed(
+        emit ICyberCertPrinter.CertificateEndorsed(
             tokenId,
             newEndorsement.endorser,
             newEndorsement.endorsee,
@@ -279,17 +265,41 @@ library CyberCertPrinterStorage {
     /// @dev Single chokepoint for every owners[] write: reassign tokenId's legal owner to `newOwner`
     /// (holder-of-record name `name`) while keeping the per-legal-owner enumeration in sync.
     function _setLegalOwner(CyberCertStorage storage s, uint256 tokenId, address newOwner, string memory name) private {
-        address current = s.owners[tokenId].ownerAddress;
-        // Always end with tokenId tracked under newOwner. The add is idempotent and the remove is a no-op for
-        // un-tracked tokens, so this both maintains live state and lazily backfills a legacy token (one minted
-        // before this enumeration existed) the moment any owner-write touches it.
-        if (current != newOwner && current != address(0)) {
-            _removeFromLegalOwnerEnumeration(s, current, tokenId);
+        OwnerDetails storage record = s.owners[tokenId];
+        address current = record.ownerAddress;
+
+        // Same owner of record: not an acquisition, so leave the clock and the enumeration move alone. Still
+        // lazily backfill a legacy token's enumeration entry, and emit if the holder-of-record name changed.
+        if (current == newOwner) {
+            if (newOwner != address(0)) {
+                _addToLegalOwnerEnumeration(s, newOwner, tokenId);
+                if (keccak256(bytes(record.name)) != keccak256(bytes(name))) {
+                    emit ICyberCertPrinter.LegalOwnerChanged(tokenId, current, newOwner, name, s.acquisitionTimestamp[tokenId]);
+                }
+            }
+            record.name = name;
+            return;
         }
+
+        // Genuine change of legal owner, emitted either way. A move to a real holder is an acquisition: (re)stamp
+        // the clock and, on the first assignment (current == 0), the immutable issue timestamp. A move to
+        // address(0) clears the record and its clock (keeping acquisitionTimestamp != 0 iff there is an owner).
+        uint64 ts;
         if (newOwner != address(0)) {
-            _addToLegalOwnerEnumeration(s, newOwner, tokenId);
+            ts = uint64(block.timestamp);
+            s.acquisitionTimestamp[tokenId] = ts;
+            if (current == address(0)) s.issueTimestamp[tokenId] = ts;
+        } else {
+            s.acquisitionTimestamp[tokenId] = 0;
         }
-        s.owners[tokenId] = OwnerDetails(name, newOwner);
+        emit ICyberCertPrinter.LegalOwnerChanged(tokenId, current, newOwner, name, ts);
+
+        // The remove is a no-op for an un-tracked token and the add is idempotent, so this keeps live state and
+        // lazily backfills a legacy token (minted before the enumeration existed).
+        if (current != address(0)) _removeFromLegalOwnerEnumeration(s, current, tokenId);
+        if (newOwner != address(0)) _addToLegalOwnerEnumeration(s, newOwner, tokenId);
+        record.ownerAddress = newOwner;
+        record.name = name;
     }
 
     /// @dev Idempotent: a token already in an owner's enumeration is left alone (so backfilling a tracked token
@@ -351,24 +361,59 @@ library CyberCertPrinterStorage {
     function increaseUnitsReserved(uint256 tokenId, uint256 amount) external {
         CyberCertStorage storage s = cyberCertStorage();
         uint256 newReserved = s.unitsReserved[tokenId] + amount;
-        if (newReserved > s.certificateDetails[tokenId].unitsRepresented) revert ExceedsAvailableUnits();
+        if (newReserved > s.certificateDetails[tokenId].unitsRepresented) revert ICyberCertPrinter.ExceedsAvailableUnits();
         s.unitsReserved[tokenId] = newReserved;
-        emit UnitsReservedUpdated(tokenId, newReserved);
+        emit ICyberCertPrinter.UnitsReservedUpdated(tokenId, newReserved);
     }
 
     /// @dev Release previously reserved units. Reverts if releasing more than is reserved.
     function decreaseUnitsReserved(uint256 tokenId, uint256 amount) external {
         CyberCertStorage storage s = cyberCertStorage();
         uint256 reserved = s.unitsReserved[tokenId];
-        if (amount > reserved) revert ExceedsReservedUnits();
+        if (amount > reserved) revert ICyberCertPrinter.ExceedsReservedUnits();
         uint256 newReserved;
         unchecked { newReserved = reserved - amount; }
         s.unitsReserved[tokenId] = newReserved;
-        emit UnitsReservedUpdated(tokenId, newReserved);
+        emit ICyberCertPrinter.UnitsReservedUpdated(tokenId, newReserved);
     }
 
     function getUnitsReserved(uint256 tokenId) internal view returns (uint256) {
         return cyberCertStorage().unitsReserved[tokenId];
+    }
+
+    function getIssueTimestamp(uint256 tokenId) internal view returns (uint64) {
+        return cyberCertStorage().issueTimestamp[tokenId];
+    }
+
+    /// @dev Admin override of issueTimestamp for positions issued off-chain before being recorded on-chain.
+    function setIssueTimestamp(uint256 tokenId, uint64 ts) external {
+        cyberCertStorage().issueTimestamp[tokenId] = ts;
+        emit ICyberCertPrinter.IssueTimestampSet(tokenId, ts);
+    }
+
+    function getAcquisitionTimestamp(uint256 tokenId) internal view returns (uint64) {
+        return cyberCertStorage().acquisitionTimestamp[tokenId];
+    }
+
+    /// @dev Idempotent migration for tokens minted before acquisitionTimestamp became a base field: copies each
+    /// live token's FundInterestExtension acquisitionDate into the base mapping over [startIndex, +count).
+    /// Permissionless; already-set tokens skipped; no-op on non-FUND_INTEREST printers. Batch over the supply.
+    function backfillAcquisitionTimestamp(uint256 startIndex, uint256 count) external {
+        CyberCertStorage storage s = cyberCertStorage();
+        address ext = s.extension;
+        if (ext == address(0) || !ICertificateExtension(ext).supportsExtensionType(keccak256("FUND_INTEREST"))) return;
+        ICyberCertPrinter self = ICyberCertPrinter(address(this)); // delegatecalled: address(this) is the printer
+        uint256 supply = self.totalSupply();
+        uint256 end = startIndex + count;
+        if (end > supply) end = supply;
+        for (uint256 i = startIndex; i < end; i++) {
+            uint256 tokenId = self.tokenByIndex(i); // live tokens only (burned excluded)
+            if (s.acquisitionTimestamp[tokenId] != 0) continue;
+            bytes memory data = s.certificateDetails[tokenId].extensionData;
+            if (data.length == 0) continue;
+            FundInterestData memory fid = abi.decode(data, (FundInterestData));
+            if (fid.acquisitionDate != 0) s.acquisitionTimestamp[tokenId] = fid.acquisitionDate;
+        }
     }
 
     function recordHolderChange(address from, address to) internal {
@@ -411,7 +456,7 @@ library CyberCertPrinterStorage {
     function removeLegendAt(uint256 tokenId, bool isDefault, uint256 index) external {
         string[] storage arr = _legendArray(tokenId, isDefault);
         uint256 len = arr.length;
-        if (index >= len) revert InvalidLegendIndex();
+        if (index >= len) revert ICyberCertPrinter.InvalidLegendIndex();
 
         // Move the last element to the index being removed (if it's not the last element)
         // and then pop the last element
@@ -445,7 +490,7 @@ library CyberCertPrinterStorage {
     function removeRestrictiveLegendAt(uint256 tokenId, bool isDefault, uint256 index) external {
         RestrictiveLegend[] storage arr = _restrictiveLegendArray(tokenId, isDefault);
         uint256 len = arr.length;
-        if (index >= len) revert InvalidLegendIndex();
+        if (index >= len) revert ICyberCertPrinter.InvalidLegendIndex();
 
         uint256 lastIndex = len - 1;
         if (index != lastIndex) {

--- a/src/storage/CyberCertPrinterStorage.sol
+++ b/src/storage/CyberCertPrinterStorage.sol
@@ -395,6 +395,12 @@ library CyberCertPrinterStorage {
         return cyberCertStorage().acquisitionTimestamp[tokenId];
     }
 
+    /// @dev Admin override of acquisitionTimestamp, e.g. to seed a seasoned position migrated on-chain.
+    function setAcquisitionTimestamp(uint256 tokenId, uint64 ts) external {
+        cyberCertStorage().acquisitionTimestamp[tokenId] = ts;
+        emit ICyberCertPrinter.AcquisitionTimestampSet(tokenId, ts);
+    }
+
     /// @dev Idempotent migration for tokens minted before acquisitionTimestamp became a base field: copies each
     /// live token's FundInterestExtension acquisitionDate into the base mapping over [startIndex, +count).
     /// Permissionless; already-set tokens skipped; no-op on non-FUND_INTEREST printers. Batch over the supply.

--- a/src/storage/CyberCertPrinterStorage.sol
+++ b/src/storage/CyberCertPrinterStorage.sol
@@ -55,7 +55,7 @@ import "../interfaces/IIssuanceManager.sol";
 import "../interfaces/IUriBuilder.sol";
 import "../interfaces/ITransferRestrictionHook.sol";
 import "./extensions/ICertificateExtension.sol";
-import {FundInterestData} from "./extensions/FundInterestExtension.sol";
+import {FundInterestData, FUND_INTEREST_EXTENSION_TYPE} from "./extensions/FundInterestExtension.sol";
 
 library CyberCertPrinterStorage {
     // Storage slot for our struct
@@ -407,7 +407,7 @@ library CyberCertPrinterStorage {
     function backfillAcquisitionTimestamp(uint256 startIndex, uint256 count) external {
         CyberCertStorage storage s = cyberCertStorage();
         address ext = s.extension;
-        if (ext == address(0) || !ICertificateExtension(ext).supportsExtensionType(keccak256("FUND_INTEREST"))) return;
+        if (ext == address(0) || !ICertificateExtension(ext).supportsExtensionType(FUND_INTEREST_EXTENSION_TYPE)) return;
         ICyberCertPrinter self = ICyberCertPrinter(address(this)); // delegatecalled: address(this) is the printer
         uint256 supply = self.totalSupply();
         uint256 end = startIndex + count;

--- a/src/storage/CyberCertPrinterStorage.sol
+++ b/src/storage/CyberCertPrinterStorage.sol
@@ -52,6 +52,7 @@ import {
 } from "../interfaces/ICyberCertPrinter.sol";
 import "../interfaces/ICyberCorp.sol";
 import "../interfaces/IIssuanceManager.sol";
+import {ILexChexBadge} from "../interfaces/ILexChexBadge.sol";
 import "../interfaces/IUriBuilder.sol";
 import "../interfaces/ITransferRestrictionHook.sol";
 import "./extensions/ICertificateExtension.sol";
@@ -63,6 +64,14 @@ library CyberCertPrinterStorage {
 
     // Errors and events are shared: declared once on ICyberCertPrinter and referenced as ICyberCertPrinter.X
     // (below), so library reverts/logs carry the same selectors/topics as the printer's under delegatecall.
+
+    /// @dev Per-legal-owner account for the §3(c)(1)(A) look-through holder tally. Packs into one slot.
+    /// `weight`/`isUS` are critical snapshots of LeXcheXBadge so we could do incremental updates on resyncs
+    struct HolderAcct {
+        uint32 liveLots; // live (non-void) lots held of record; holder is live iff > 0
+        uint32 weight;   // look-through weight currently accumulated into the totals (max(boCount,1))
+        bool isUS;       // whether this holder's weight is currently accumulated into the US subtotal
+    }
 
     // Main storage layout struct
     struct CyberCertStorage {
@@ -96,6 +105,8 @@ library CyberCertPrinterStorage {
         uint256 uniqueHolderCount;
 
         // ERC721Enumerable-like implementation for legal owners
+        // Note it includes voided-but-not-burnt certs. Technically one could transfer a voided cert to another,
+        // and its legal owner change would still be tracked
         mapping(address => mapping(uint256 => uint256)) legalOwnedTokens; // owner => index => tokenId
         mapping(uint256 => uint256) legalOwnedTokensIndex; // tokenId => index within its owner's list
         mapping(address => uint256) legalOwnerTokenCount; // owner => number of certs held of record
@@ -105,6 +116,16 @@ library CyberCertPrinterStorage {
         // (re)stamped on each legal-owner change and drives the Rule 144 / Reg S holding-period conditions.
         mapping(uint256 => uint64) issueTimestamp;
         mapping(uint256 => uint64) acquisitionTimestamp;
+
+        // §3(c)(1)(A) look-through holder tally (read O(1) by HolderCapCondition). Maintained incrementally
+        // at every legal-owner change / void / unvoid / burn. Parallel to the enumeration above; the
+        // enumeration's `legalOwnerTokenCount` (which includes voided lots) is left untouched for other
+        // consumers. See _countLot / _uncountLot / _resyncHolder.
+        mapping(address => HolderAcct) holderAcct;
+        mapping(uint256 => bool) liveCounted;  // token currently contributes to its owner's liveLots
+        uint256 lookThroughHolderCount;        // Σ holderAcct.weight over all live holders
+        uint256 usLookThroughHolderCount;      // Σ holderAcct.weight over US-resident live holders (subset)
+        address lookThroughBadge;              // ILexChexBadge sampled for look-through weight + US residency
     }
 
     // Returns the storage layout
@@ -294,12 +315,18 @@ library CyberCertPrinterStorage {
         }
         emit ICyberCertPrinter.LegalOwnerChanged(tokenId, current, newOwner, name, ts);
 
+        // Look-through tally: this lot leaves `current` and joins `newOwner` (both no-ops when the address
+        // is 0 or the token is void/untracked).
+        _uncountLot(s, tokenId, current);
+
         // The remove is a no-op for an un-tracked token and the add is idempotent, so this keeps live state and
         // lazily backfills a legacy token (minted before the enumeration existed).
         if (current != address(0)) _removeFromLegalOwnerEnumeration(s, current, tokenId);
         if (newOwner != address(0)) _addToLegalOwnerEnumeration(s, newOwner, tokenId);
         record.ownerAddress = newOwner;
         record.name = name;
+
+        _countLot(s, tokenId, newOwner);
     }
 
     /// @dev Idempotent: a token already in an owner's enumeration is left alone (so backfilling a tracked token
@@ -336,6 +363,8 @@ library CyberCertPrinterStorage {
     function recordBurnLegalOwner(uint256 tokenId) external {
         CyberCertStorage storage s = cyberCertStorage();
         address owner = s.owners[tokenId].ownerAddress;
+        // Drop the lot from the look-through tally (no-op if already uncounted, e.g. the token was voided).
+        _uncountLot(s, tokenId, owner);
         if (owner != address(0)) _removeFromLegalOwnerEnumeration(s, owner, tokenId);
         delete s.owners[tokenId];
     }
@@ -354,6 +383,132 @@ library CyberCertPrinterStorage {
             address owner = s.owners[tokenId].ownerAddress;
             if (owner != address(0)) _addToLegalOwnerEnumeration(s, owner, tokenId);
         }
+    }
+
+    // ── §3(c)(1)(A) look-through holder tally ────────────────────────────────────────────────────────
+
+    /// @dev A lot counts toward its owner's holder weight iff it is not voided (freshly-minted lots are
+    /// Unassigned, which is live). Burned tokens never reach here — they are uncounted at burn.
+    function _isLive(CyberCertStorage storage s, uint256 tokenId) private view returns (bool) {
+        return s.securityStatus[tokenId] != SecurityStatus.Void;
+    }
+
+    /// @dev Sample the look-through weight and US flag from the configured badge; if no badge is wired the
+    /// tally degrades to address-level (weight 1, non-US).
+    function _sample(CyberCertStorage storage s, address owner) private view returns (uint32 weight, bool isUS) {
+        address badge = s.lookThroughBadge;
+        if (badge == address(0)) return (1, false);
+        uint32 bo = ILexChexBadge(badge).getBeneficialOwnerCount(owner);
+        weight = bo > 0 ? bo : 1;
+        isUS = ILexChexBadge(badge).isUSInvestor(owner);
+    }
+
+    /// @dev Re-read the badge for a live holder and reconcile the totals by the delta, so
+    /// `total == Σ holderAcct.weight` stays exact across BO-count or jurisdiction changes. No-op otherwise.
+    function _resyncHolder(CyberCertStorage storage s, address owner) private {
+        HolderAcct storage a = s.holderAcct[owner];
+        if (a.liveLots == 0) return;
+        (uint32 newWeight, bool newIsUS) = _sample(s, owner);
+        s.lookThroughHolderCount = s.lookThroughHolderCount - a.weight + newWeight;
+        uint256 usCount = s.usLookThroughHolderCount;
+        if (a.isUS) usCount -= a.weight;
+        if (newIsUS) usCount += newWeight;
+        s.usLookThroughHolderCount = usCount;
+        a.weight = newWeight;
+        a.isUS = newIsUS;
+    }
+
+    /// @dev Mark tokenId as a live lot for `owner`. On the owner's 0→1 transition, sample and add their
+    /// weight to the totals; a further acquisition resyncs their (possibly re-credentialed) weight.
+    /// Idempotent via `liveCounted`; no-op for the zero address or a voided token.
+    function _countLot(CyberCertStorage storage s, uint256 tokenId, address owner) private {
+        if (owner == address(0) || s.liveCounted[tokenId] || !_isLive(s, tokenId)) return;
+        s.liveCounted[tokenId] = true;
+        HolderAcct storage a = s.holderAcct[owner];
+        if (a.liveLots == 0) {
+            (uint32 weight, bool isUS) = _sample(s, owner);
+            a.liveLots = 1;
+            a.weight = weight;
+            a.isUS = isUS;
+            s.lookThroughHolderCount += weight;
+            if (isUS) s.usLookThroughHolderCount += weight;
+        } else {
+            a.liveLots += 1;
+            _resyncHolder(s, owner);
+        }
+    }
+
+    /// @dev Un-mark tokenId as a live lot for `owner`. On the owner's 1→0 transition, subtract their stored
+    /// weight and clear the account. Idempotent via `liveCounted`.
+    function _uncountLot(CyberCertStorage storage s, uint256 tokenId, address owner) private {
+        if (!s.liveCounted[tokenId]) return;
+        s.liveCounted[tokenId] = false;
+        HolderAcct storage a = s.holderAcct[owner];
+        if (a.liveLots == 0) return; // defensive
+        a.liveLots -= 1;
+        if (a.liveLots == 0) {
+            s.lookThroughHolderCount -= a.weight;
+            if (a.isUS) s.usLookThroughHolderCount -= a.weight;
+            delete s.holderAcct[owner];
+        }
+    }
+
+    /// @dev Tally maintenance for voidCert — drop the lot's live contribution. Call after status is set Void.
+    function recordVoidLegalOwner(uint256 tokenId) external {
+        CyberCertStorage storage s = cyberCertStorage();
+        _uncountLot(s, tokenId, s.owners[tokenId].ownerAddress);
+    }
+
+    /// @dev Tally maintenance for unvoidCert — restore the lot's live contribution. Call after status is
+    /// set back to Assigned (so `_isLive` is true).
+    function recordUnvoidLegalOwner(uint256 tokenId) external {
+        CyberCertStorage storage s = cyberCertStorage();
+        _countLot(s, tokenId, s.owners[tokenId].ownerAddress);
+    }
+
+    /// @dev Keeper/admin refresh after a re-credential: reconcile a live holder's contribution to the badge.
+    function resyncHolder(address owner) external {
+        _resyncHolder(cyberCertStorage(), owner);
+    }
+
+    function resyncHolders(address[] calldata owners) external {
+        CyberCertStorage storage s = cyberCertStorage();
+        for (uint256 i = 0; i < owners.length; i++) _resyncHolder(s, owners[i]);
+    }
+
+    /// @dev One-time/idempotent backfill for printers upgraded to add the look-through tally: count each
+    /// live token in [startIndex, startIndex+count). Set the badge first. Permissionless, safe to re-run
+    /// (already-counted tokens are skipped). Call in batches over [0, totalSupply()).
+    function backfillLookThroughTally(uint256 startIndex, uint256 count) external {
+        CyberCertStorage storage s = cyberCertStorage();
+        ICyberCertPrinter self = ICyberCertPrinter(address(this)); // delegatecalled: address(this) is the printer
+        uint256 supply = self.totalSupply();
+        uint256 end = startIndex + count;
+        if (end > supply) end = supply;
+        for (uint256 i = startIndex; i < end; i++) {
+            uint256 tokenId = self.tokenByIndex(i);
+            _countLot(s, tokenId, s.owners[tokenId].ownerAddress);
+        }
+    }
+
+    function setLookThroughBadge(address badge) internal {
+        cyberCertStorage().lookThroughBadge = badge;
+    }
+
+    function getLookThroughBadge() internal view returns (address) {
+        return cyberCertStorage().lookThroughBadge;
+    }
+
+    function getLookThroughHolderCount() internal view returns (uint256) {
+        return cyberCertStorage().lookThroughHolderCount;
+    }
+
+    function getUsLookThroughHolderCount() internal view returns (uint256) {
+        return cyberCertStorage().usLookThroughHolderCount;
+    }
+
+    function isLegalHolder(address owner) internal view returns (bool) {
+        return cyberCertStorage().holderAcct[owner].liveLots > 0;
     }
 
     /// @dev Reserve units against a pending deal/loan. Reverts if the total reserved

--- a/src/storage/IssuanceManagerStorage.sol
+++ b/src/storage/IssuanceManagerStorage.sol
@@ -788,43 +788,23 @@ library IssuanceManagerStorage {
         if (sellerVoided) {
             cert.voidCert(tokenId);
         }
-        // (c) Deliver the buyer's units. By default we consolidate: if the buyer already holds an active
-        // (non-voided) Ledger Entry Token on this printer, fold the purchased units into it rather than
-        // fragmenting their position across one cert per fill; mint a fresh token only when they hold none.
-        // A printer is scoped to one security class/series, so consolidation never merges across security types
-        // (the folded units inherit the existing cert's terms). We look the buyer up by legal owner of record,
-        // so this is correct under both hosting modes — including Administered, where the multisig custodies the
-        // NFT but the buyer is the registered owner.
-        RecertSelection memory existing = _selectFirstLegalOwnedToken(certPrinter, buyer);
-        bool buyerTokenIsMinted = !existing.foundActive;
-        uint256 buyerUnitsAfter; // absolute post-mutation balance on the buyer token, reported in the event
-        if (existing.foundActive) {
-            // Fold the purchased units into the buyer's existing cert, leaving its basis fields
-            // (investmentAmountUSD / issuerUSDValuationAtTimeOfInvestment) unchanged: they stay a snapshot of
-            // that cert's primary issuance, regardless of how many secondary lots accumulate into it.
-            buyerTokenId = existing.activeTokenId;
-            CertificateDetails memory accDetails = cert.getActiveCertificateDetails(buyerTokenId);
-            accDetails.unitsRepresented += units;
-            cert.updateCertificateDetails(buyerTokenId, accDetails);
-            buyerUnitsAfter = accDetails.unitsRepresented;
-        } else {
-            // Mint a fresh token for the sold units. It inherits the seller's non-basis terms (signing officer,
-            // legalDetails, extensionData); cost basis stays blank since a secondary acquisition has no
-            // primary-issuance basis of its own. The custodian only decides where the NFT lands: the admin
-            // multisig under Administered hosting, otherwise the buyer (who is the legal owner either way).
-            address custodian = buyerHostingMode == HostingMode.ADMINISTERED ? adminMultisig : buyer;
-            CertificateDetails memory buyerDetails = CertificateDetails({
-                signingOfficerName: sellerDetails.signingOfficerName,
-                signingOfficerTitle: sellerDetails.signingOfficerTitle,
-                investmentAmountUSD: 0,
-                issuerUSDValuationAtTimeOfInvestment: 0,
-                unitsRepresented: units,
-                legalDetails: sellerDetails.legalDetails,
-                extensionData: sellerDetails.extensionData
-            });
-            (, buyerTokenId) = _mintAssignedCert(certPrinter, custodian, buyer, buyerDetails, buyerName);
-            buyerUnitsAfter = units;
-        }
+        // (c) Deliver the buyer's units as a fresh lot (fresh-mint-per-lot): each acquisition mints its own
+        // Ledger Entry Token carrying its own acquisitionTimestamp (per-lot holding-period clock, stamped at
+        // mint). The lot inherits the seller's non-basis terms; cost basis stays blank (no primary-issuance
+        // basis). Custodian is the admin multisig under Administered hosting, otherwise the buyer.
+        bool buyerTokenIsMinted = true;
+        address custodian = buyerHostingMode == HostingMode.ADMINISTERED ? adminMultisig : buyer;
+        CertificateDetails memory buyerDetails = CertificateDetails({
+            signingOfficerName: sellerDetails.signingOfficerName,
+            signingOfficerTitle: sellerDetails.signingOfficerTitle,
+            investmentAmountUSD: 0,
+            issuerUSDValuationAtTimeOfInvestment: 0,
+            unitsRepresented: units,
+            legalDetails: sellerDetails.legalDetails,
+            extensionData: sellerDetails.extensionData
+        });
+        (, buyerTokenId) = _mintAssignedCert(certPrinter, custodian, buyer, buyerDetails, buyerName);
+        uint256 buyerUnitsAfter = units; // absolute post-mutation balance on the buyer token, reported in the event
 
         // (d) Mirror the seller's endorsement onto the buyer's token: both tokens carry the identical
         // chain-of-title record (endorser = seller, endorsee = buyer, this agreement), so reuse the (b) struct.
@@ -834,6 +814,10 @@ library IssuanceManagerStorage {
             settlementAgreementId, certPrinter, buyer, tokenId, buyerTokenId, seller, units,
             sellerDetails.unitsRepresented, buyerUnitsAfter, sellerVoided, buyerTokenIsMinted
         );
+    }
+
+    function executeSetIssueTimestamp(address certAddress, uint256 tokenId, uint64 ts) external {
+        ICyberCertPrinter(certAddress).setIssueTimestamp(tokenId, ts);
     }
 
     function executeVoidCertificate(address certAddress, uint256 tokenId) external {

--- a/src/storage/IssuanceManagerStorage.sol
+++ b/src/storage/IssuanceManagerStorage.sol
@@ -859,6 +859,13 @@ library IssuanceManagerStorage {
         ICyberCertPrinter(certAddress).setGlobalTransferable(transferable);
     }
 
+    function executeSetLookThroughBadge(
+        address certAddress,
+        address badge
+    ) external {
+        ICyberCertPrinter(certAddress).setLookThroughBadge(badge);
+    }
+
     function executeSetRestrictionHook(
         address certAddress,
         uint256 id,

--- a/src/storage/IssuanceManagerStorage.sol
+++ b/src/storage/IssuanceManagerStorage.sol
@@ -52,6 +52,8 @@ import "../interfaces/IIssuanceManager.sol";
 import "../interfaces/IIssuanceManagerFactory.sol";
 import "../interfaces/ITransferRestrictionHook.sol";
 import {ExemptionPathway, HostingMode} from "../interfaces/ISecondaryTradeStorage.sol";
+import {FundInterestData, FUND_INTEREST_EXTENSION_TYPE} from "./extensions/FundInterestExtension.sol";
+import "./extensions/ICertificateExtension.sol";
 import "./CyberCertPrinterStorage.sol";
 
 library IssuanceManagerStorage {
@@ -822,6 +824,24 @@ library IssuanceManagerStorage {
 
     function executeSetAcquisitionTimestamp(address certAddress, uint256 tokenId, uint64 ts) external {
         ICyberCertPrinter(certAddress).setAcquisitionTimestamp(tokenId, ts);
+    }
+
+    /// @dev Rewrites only the Rule 144(d)(3) tacking anchor in the cert's FundInterestData, leaving every other
+    /// field (including acquisitionDate) untouched, then writes the re-encoded blob back through the printer's
+    /// updateCertificateDetails chokepoint.
+    function executeSetTackedFromAcquisitionDate(address certAddress, uint256 tokenId, uint64 ts) external {
+        ICyberCertPrinter cert = ICyberCertPrinter(certAddress);
+        // Only FUND_INTEREST certs carry a FundInterestData blob; guard before decoding so we never misread or
+        // clobber another extension's extensionData (mirrors CyberCertPrinterStorage.backfillAcquisitionTimestamp).
+        address ext = cert.getExtension(tokenId);
+        if (ext == address(0) || !ICertificateExtension(ext).supportsExtensionType(FUND_INTEREST_EXTENSION_TYPE)) {
+            revert ICyberCertPrinter.ExtensionTypeNotSupported();
+        }
+        CertificateDetails memory details = cert.getActiveCertificateDetails(tokenId);
+        FundInterestData memory fid = abi.decode(details.extensionData, (FundInterestData));
+        fid.tackedFromAcquisitionDate = ts;
+        details.extensionData = abi.encode(fid);
+        cert.updateCertificateDetails(tokenId, details);
     }
 
     function executeVoidCertificate(address certAddress, uint256 tokenId) external {

--- a/src/storage/IssuanceManagerStorage.sol
+++ b/src/storage/IssuanceManagerStorage.sol
@@ -820,6 +820,10 @@ library IssuanceManagerStorage {
         ICyberCertPrinter(certAddress).setIssueTimestamp(tokenId, ts);
     }
 
+    function executeSetAcquisitionTimestamp(address certAddress, uint256 tokenId, uint64 ts) external {
+        ICyberCertPrinter(certAddress).setAcquisitionTimestamp(tokenId, ts);
+    }
+
     function executeVoidCertificate(address certAddress, uint256 tokenId) external {
         ICyberCertPrinter(certAddress).voidCert(tokenId);
     }

--- a/src/storage/extensions/FundInterestExtension.sol
+++ b/src/storage/extensions/FundInterestExtension.sol
@@ -39,10 +39,14 @@ struct FundInterestData {
     string customProvisions;
 }
 
+/// @dev Canonical FUND_INTEREST extension-type key. File-level so guards elsewhere reference it by name
+/// instead of re-hashing the literal (the contract's EXTENSION_TYPE and every supportsExtensionType check).
+bytes32 constant FUND_INTEREST_EXTENSION_TYPE = keccak256("FUND_INTEREST");
+
 /// @title FundInterestExtension - certificate extension for SPV fund interests
 /// @author MetaLeX Labs, Inc.
 contract FundInterestExtension is UUPSUpgradeable, ICertificateExtension, BorgAuthACL {
-    bytes32 public constant EXTENSION_TYPE = keccak256("FUND_INTEREST");
+    bytes32 public constant EXTENSION_TYPE = FUND_INTEREST_EXTENSION_TYPE;
 
     //offset to leave for future upgrades
     uint256[30] private __gap;

--- a/test/CyberCertPrinterTest.t.sol
+++ b/test/CyberCertPrinterTest.t.sol
@@ -17,7 +17,7 @@ import {
     RestrictiveLegend
 } from "../src/interfaces/ICyberCertPrinter.sol";
 import {ICertificateExtension} from "../src/storage/extensions/ICertificateExtension.sol";
-import {FundInterestData} from "../src/storage/extensions/FundInterestExtension.sol";
+import {FundInterestData, FUND_INTEREST_EXTENSION_TYPE} from "../src/storage/extensions/FundInterestExtension.sol";
 
 contract MockCyberCorp {
     address public dealManager;
@@ -197,7 +197,7 @@ contract CyberCertPrinterEnhanced is CyberCertPrinter {
 
 contract MockFundInterestExtension is ICertificateExtension {
     function supportsExtensionType(bytes32 extensionType) external pure returns (bool) {
-        return extensionType == keccak256("FUND_INTEREST");
+        return extensionType == FUND_INTEREST_EXTENSION_TYPE;
     }
     function getExtensionURI(bytes memory) external pure returns (string memory) { return ""; }
 }
@@ -508,6 +508,28 @@ contract CyberCertPrinterTest is Test {
 
         assertEq(printer.legalOwnerOf(1), address(0), "legal owner cleared");
         assertEq(printer.acquisitionTimestamp(1), 0, "clock cleared with the owner");
+    }
+
+    // A genuine in-place legal-owner change (current != newOwner, both non-zero) restamps the acquisition clock
+    // to now while leaving the immutable issue timestamp untouched.
+    function test_SetLegalOwner_GenuineChange_RestampsAcquisitionKeepsIssue() public {
+        vm.prank(address(issuanceManager));
+        printer.safeMintAndAssign(investor, 1, _details(100, bytes("")), "Alice");
+        uint64 issuedAt = printer.issueTimestamp(1);
+        uint64 acquiredAt = printer.acquisitionTimestamp(1);
+
+        vm.warp(block.timestamp + 30 days);
+        CertificateDetails memory d = _details(100, bytes(""));
+
+        vm.expectEmit(true, true, true, true, address(printer));
+        emit ICyberCertPrinter.LegalOwnerChanged(1, investor, recipient, "", uint64(block.timestamp));
+        vm.prank(address(issuanceManager));
+        printer.assignCert(investor, 1, recipient, d);
+
+        assertEq(printer.legalOwnerOf(1), recipient, "legal owner reassigned");
+        assertEq(printer.acquisitionTimestamp(1), uint64(block.timestamp), "acquisition clock restamped to now");
+        assertGt(uint64(block.timestamp), acquiredAt, "precondition: time advanced past original acquisition");
+        assertEq(printer.issueTimestamp(1), issuedAt, "issue timestamp is immutable across owner changes");
     }
 
     function test_HolderCount_TracksUniqueHoldersOnBurn() public {

--- a/test/CyberCertPrinterTest.t.sol
+++ b/test/CyberCertPrinterTest.t.sol
@@ -207,6 +207,18 @@ contract MockNonFundExtension is ICertificateExtension {
     function getExtensionURI(bytes memory) external pure returns (string memory) { return ""; }
 }
 
+/// @notice Minimal LeXcheXBadge surface the look-through tally samples: beneficial-owner count + US flag.
+contract MockLookThroughBadge {
+    mapping(address => uint32) internal bo;
+    mapping(address => bool) internal us;
+
+    function setBo(address a, uint32 c) external { bo[a] = c; }
+    function setUs(address a, bool v) external { us[a] = v; }
+
+    function getBeneficialOwnerCount(address a) external view returns (uint32) { return bo[a]; }
+    function isUSInvestor(address a) external view returns (bool) { return us[a]; }
+}
+
 contract CyberCertPrinterTest is Test {
     CyberCertPrinter private printer;
     MockIssuanceManager private issuanceManager;
@@ -856,6 +868,157 @@ contract CyberCertPrinterTest is Test {
 
         assertEq(printer.ownerOf(1), recipient);
         assertEq(printer.legalOwnerOf(1), recipient);
+    }
+
+    // ───────────────── §3(c)(1)(A) look-through holder tally ─────────────────
+
+    function _setBadge(MockLookThroughBadge b) private {
+        vm.prank(address(issuanceManager));
+        printer.setLookThroughBadge(address(b));
+    }
+
+    function _void(uint256 tokenId) private {
+        vm.prank(address(issuanceManager));
+        printer.voidCert(tokenId);
+    }
+
+    function _unvoid(uint256 tokenId) private {
+        vm.prank(address(issuanceManager));
+        printer.unvoidCert(tokenId);
+    }
+
+    function _burnCert(uint256 tokenId) private {
+        vm.prank(address(issuanceManager));
+        printer.burn(tokenId);
+    }
+
+    function test_LookThrough_IndividualCountsAsOne() public {
+        MockLookThroughBadge b = new MockLookThroughBadge();
+        _setBadge(b);
+        _mintCert(1, investor, 100, bytes(""));
+        assertEq(printer.lookThroughHolderCount(), 1);
+        assertEq(printer.usLookThroughHolderCount(), 0);
+        assertTrue(printer.isLegalHolder(investor));
+    }
+
+    function test_LookThrough_NoBadgeDegradesToOne() public {
+        _mintCert(1, investor, 100, bytes(""));
+        assertEq(printer.lookThroughHolderCount(), 1);
+        assertEq(printer.usLookThroughHolderCount(), 0);
+    }
+
+    function test_LookThrough_UsEntityFlowsThroughBothTotals() public {
+        MockLookThroughBadge b = new MockLookThroughBadge();
+        b.setBo(investor, 5);
+        b.setUs(investor, true);
+        _setBadge(b);
+        _mintCert(1, investor, 100, bytes(""));
+        assertEq(printer.lookThroughHolderCount(), 5);
+        assertEq(printer.usLookThroughHolderCount(), 5);
+    }
+
+    function test_LookThrough_ForeignEntityOnlyTotal() public {
+        MockLookThroughBadge b = new MockLookThroughBadge();
+        b.setBo(investor, 3);
+        _setBadge(b);
+        _mintCert(1, investor, 100, bytes(""));
+        assertEq(printer.lookThroughHolderCount(), 3);
+        assertEq(printer.usLookThroughHolderCount(), 0);
+    }
+
+    function test_LookThrough_SecondLotResamplesWeight() public {
+        MockLookThroughBadge b = new MockLookThroughBadge();
+        b.setBo(investor, 5);
+        b.setUs(investor, true);
+        _setBadge(b);
+        _mintCert(1, investor, 100, bytes(""));
+        assertEq(printer.lookThroughHolderCount(), 5);
+        // Re-credentialed before the next acquisition; the second lot resamples the weight.
+        b.setBo(investor, 7);
+        _mintCert(2, investor, 100, bytes(""));
+        assertEq(printer.lookThroughHolderCount(), 7);
+        assertEq(printer.usLookThroughHolderCount(), 7);
+    }
+
+    function test_LookThrough_VoidAndUnvoidAdjustTally() public {
+        MockLookThroughBadge b = new MockLookThroughBadge();
+        b.setBo(investor, 4);
+        b.setUs(investor, true);
+        _setBadge(b);
+        _mintCert(1, investor, 100, bytes(""));
+        _mintCert(2, investor, 100, bytes(""));
+        assertEq(printer.lookThroughHolderCount(), 4); // one holder, weight 4, two live lots
+
+        _void(1); // still a holder via the other lot
+        assertEq(printer.lookThroughHolderCount(), 4);
+        assertTrue(printer.isLegalHolder(investor));
+
+        _void(2); // last live lot gone: holder drops out
+        assertEq(printer.lookThroughHolderCount(), 0);
+        assertEq(printer.usLookThroughHolderCount(), 0);
+        assertFalse(printer.isLegalHolder(investor));
+
+        _unvoid(2); // restored
+        assertEq(printer.lookThroughHolderCount(), 4);
+        assertEq(printer.usLookThroughHolderCount(), 4);
+        assertTrue(printer.isLegalHolder(investor));
+    }
+
+    function test_LookThrough_BurnDropsHolderAndReentryCountsFresh() public {
+        MockLookThroughBadge b = new MockLookThroughBadge();
+        b.setBo(investor, 2);
+        _setBadge(b);
+        _mintCert(1, investor, 100, bytes(""));
+        assertEq(printer.lookThroughHolderCount(), 2);
+
+        _burnCert(1);
+        assertEq(printer.lookThroughHolderCount(), 0);
+        assertFalse(printer.isLegalHolder(investor));
+
+        _mintCert(2, investor, 100, bytes("")); // re-enter
+        assertEq(printer.lookThroughHolderCount(), 2);
+        assertTrue(printer.isLegalHolder(investor));
+    }
+
+    function test_LookThrough_ResyncReconcilesBoAndJurisdiction() public {
+        MockLookThroughBadge b = new MockLookThroughBadge();
+        b.setBo(investor, 3);
+        b.setUs(investor, true);
+        _setBadge(b);
+        _mintCert(1, investor, 100, bytes(""));
+        assertEq(printer.lookThroughHolderCount(), 3);
+        assertEq(printer.usLookThroughHolderCount(), 3);
+
+        // BO count rises and jurisdiction flips to foreign: weight moves out of the US subtotal.
+        b.setBo(investor, 6);
+        b.setUs(investor, false);
+        printer.resyncHolder(investor);
+        assertEq(printer.lookThroughHolderCount(), 6);
+        assertEq(printer.usLookThroughHolderCount(), 0);
+    }
+
+    function test_LookThrough_ResyncNonHolderIsNoop() public {
+        MockLookThroughBadge b = new MockLookThroughBadge();
+        b.setBo(recipient, 9);
+        _setBadge(b);
+        printer.resyncHolder(recipient); // not a holder
+        assertEq(printer.lookThroughHolderCount(), 0);
+    }
+
+    function test_LookThrough_BackfillIsIdempotent() public {
+        MockLookThroughBadge b = new MockLookThroughBadge();
+        b.setBo(investor, 5);
+        b.setUs(investor, true);
+        _setBadge(b);
+        _mintCert(1, investor, 100, bytes(""));
+        _mintCert(2, recipient, 100, bytes("")); // individual, weight 1
+        uint256 total = printer.lookThroughHolderCount(); // 5 + 1
+
+        // Re-running backfill over the live set must not double-count (liveCounted guards it).
+        printer.backfillLookThroughTally(0, 10);
+        printer.backfillLookThroughTally(0, 10);
+        assertEq(printer.lookThroughHolderCount(), total);
+        assertEq(printer.usLookThroughHolderCount(), 5);
     }
 
     function _mintCert(

--- a/test/CyberCertPrinterTest.t.sol
+++ b/test/CyberCertPrinterTest.t.sol
@@ -11,10 +11,13 @@ import {IUriBuilder} from "../src/interfaces/IUriBuilder.sol";
 import {
     CertificateDetails,
     Endorsement,
+    ICyberCertPrinter,
     OwnerDetails,
     RestrictionType,
     RestrictiveLegend
 } from "../src/interfaces/ICyberCertPrinter.sol";
+import {ICertificateExtension} from "../src/storage/extensions/ICertificateExtension.sol";
+import {FundInterestData} from "../src/storage/extensions/FundInterestExtension.sol";
 
 contract MockCyberCorp {
     address public dealManager;
@@ -185,6 +188,23 @@ contract CyberCertPrinterEnhanced is CyberCertPrinter {
         }
         s.legalOwnerTokenCount[owner] = 0;
     }
+
+    /// @dev Zero a token's base acquisitionTimestamp, mimicking a cert minted before it became a base field.
+    function debugClearAcquisitionTimestamp(uint256 tokenId) external {
+        CyberCertPrinterStorage.cyberCertStorage().acquisitionTimestamp[tokenId] = 0;
+    }
+}
+
+contract MockFundInterestExtension is ICertificateExtension {
+    function supportsExtensionType(bytes32 extensionType) external pure returns (bool) {
+        return extensionType == keccak256("FUND_INTEREST");
+    }
+    function getExtensionURI(bytes memory) external pure returns (string memory) { return ""; }
+}
+
+contract MockNonFundExtension is ICertificateExtension {
+    function supportsExtensionType(bytes32) external pure returns (bool) { return false; }
+    function getExtensionURI(bytes memory) external pure returns (string memory) { return ""; }
 }
 
 contract CyberCertPrinterTest is Test {
@@ -243,13 +263,13 @@ contract CyberCertPrinterTest is Test {
         _mintCert(1, investor, 100, bytes(""));
 
         vm.prank(address(issuanceManager));
-        vm.expectRevert(CyberCertPrinter.SignatureRequired.selector);
+        vm.expectRevert(ICyberCertPrinter.SignatureRequired.selector);
         printer.addIssuerSignature(1, "");
     }
 
     function test_AddIssuerSignature_RevertsForNonexistentToken() public {
         vm.prank(address(issuanceManager));
-        vm.expectRevert(CyberCertPrinter.TokenDoesNotExist.selector);
+        vm.expectRevert(ICyberCertPrinter.TokenDoesNotExist.selector);
         printer.addIssuerSignature(999, hex"123456");
     }
 
@@ -257,7 +277,7 @@ contract CyberCertPrinterTest is Test {
         _mintCert(1, investor, 100, bytes(""));
 
         vm.prank(investor);
-        vm.expectRevert(CyberCertPrinter.NotIssuanceManager.selector);
+        vm.expectRevert(ICyberCertPrinter.NotIssuanceManager.selector);
         printer.addIssuerSignature(1, hex"123456");
     }
 
@@ -280,7 +300,7 @@ contract CyberCertPrinterTest is Test {
 
     function test_SetExtension_RevertsWhenCallerIsNotIssuanceManager() public {
         vm.prank(investor);
-        vm.expectRevert(CyberCertPrinter.NotIssuanceManager.selector);
+        vm.expectRevert(ICyberCertPrinter.NotIssuanceManager.selector);
         printer.setExtension(1, updatedExtension);
     }
 
@@ -300,7 +320,7 @@ contract CyberCertPrinterTest is Test {
         _mintCert(1, investor, 100, bytes(""));
 
         vm.prank(address(issuanceManager));
-        vm.expectRevert(CyberCertPrinter.ExceedsAvailableUnits.selector);
+        vm.expectRevert(ICyberCertPrinter.ExceedsAvailableUnits.selector);
         printer.increaseUnitsReserved(1, 101);
     }
 
@@ -311,17 +331,17 @@ contract CyberCertPrinterTest is Test {
         printer.increaseUnitsReserved(1, 40);
 
         vm.prank(address(issuanceManager));
-        vm.expectRevert(CyberCertPrinter.ExceedsReservedUnits.selector);
+        vm.expectRevert(ICyberCertPrinter.ExceedsReservedUnits.selector);
         printer.decreaseUnitsReserved(1, 41);
     }
 
     function test_UnitsReserved_RevertsForNonexistentTokens() public {
         vm.prank(address(issuanceManager));
-        vm.expectRevert(CyberCertPrinter.TokenDoesNotExist.selector);
+        vm.expectRevert(ICyberCertPrinter.TokenDoesNotExist.selector);
         printer.increaseUnitsReserved(999, 1);
 
         vm.prank(address(issuanceManager));
-        vm.expectRevert(CyberCertPrinter.TokenDoesNotExist.selector);
+        vm.expectRevert(ICyberCertPrinter.TokenDoesNotExist.selector);
         printer.decreaseUnitsReserved(999, 1);
     }
 
@@ -338,7 +358,7 @@ contract CyberCertPrinterTest is Test {
         printer.increaseUnitsReserved(1, 1);
 
         vm.prank(investor);
-        vm.expectRevert(CyberCertPrinter.CertificateReserved.selector);
+        vm.expectRevert(ICyberCertPrinter.CertificateReserved.selector);
         printer.transferFrom(investor, recipient, 1);
 
         // Releasing the reservation (settlement/void) unfreezes the transfer.
@@ -368,13 +388,13 @@ contract CyberCertPrinterTest is Test {
         assertEq(printer.legalOwnerOf(1), recipient);
 
         vm.prank(investor);
-        vm.expectRevert(CyberCertPrinter.TokenNotTransferable.selector);
+        vm.expectRevert(ICyberCertPrinter.TokenNotTransferable.selector);
         printer.transferFrom(investor, recipient, 2);
     }
 
     function test_TokenTransferable_RevertsWhenCallerIsNotIssuanceManager() public {
         vm.prank(investor);
-        vm.expectRevert(CyberCertPrinter.NotIssuanceManager.selector);
+        vm.expectRevert(ICyberCertPrinter.NotIssuanceManager.selector);
         printer.setTokenTransferable(1, true);
     }
 
@@ -456,6 +476,38 @@ contract CyberCertPrinterTest is Test {
         printer.transferFrom(investor, investor, 1);
 
         assertEq(printer.holderCount(), 1);
+    }
+
+    // A same-owner write that changes the holder-of-record name emits LegalOwnerChanged (from == to) and leaves
+    // the acquisition clock untouched.
+    function test_SetLegalOwner_SameOwnerNameChange_EmitsWithoutRestamp() public {
+        vm.prank(address(issuanceManager));
+        printer.safeMintAndAssign(investor, 1, _details(100, bytes("")), "Alice");
+        uint64 acquiredAt = printer.acquisitionTimestamp(1);
+        CertificateDetails memory d = _details(100, bytes(""));
+
+        vm.expectEmit(true, true, true, true, address(printer));
+        emit ICyberCertPrinter.LegalOwnerChanged(1, investor, investor, "", acquiredAt);
+        vm.prank(address(issuanceManager));
+        printer.assignCert(investor, 1, investor, d); // recordAssign resets the name to "" for the same owner
+
+        assertEq(printer.acquisitionTimestamp(1), acquiredAt, "same-owner name change must not reset the clock");
+    }
+
+    // Clearing the legal owner to address(0) is a "negative" change: it emits LegalOwnerChanged and clears the
+    // acquisition clock (acquisitionTimestamp != 0 iff there is an owner of record).
+    function test_SetLegalOwner_ClearToZero_EmitsNegativeEvent() public {
+        vm.prank(address(issuanceManager));
+        printer.safeMintAndAssign(investor, 1, _details(100, bytes("")), "Alice");
+        CertificateDetails memory d = _details(100, bytes(""));
+
+        vm.expectEmit(true, true, true, true, address(printer));
+        emit ICyberCertPrinter.LegalOwnerChanged(1, investor, address(0), "", 0);
+        vm.prank(address(issuanceManager));
+        printer.assignCert(investor, 1, address(0), d);
+
+        assertEq(printer.legalOwnerOf(1), address(0), "legal owner cleared");
+        assertEq(printer.acquisitionTimestamp(1), 0, "clock cleared with the owner");
     }
 
     function test_HolderCount_TracksUniqueHoldersOnBurn() public {
@@ -559,6 +611,46 @@ contract CyberCertPrinterTest is Test {
         assertEq(printer.balanceOfLegalOwner(investor), 3);
         assertEq(printer.tokenOfLegalOwnerByIndex(investor, 0), 1);
         assertEq(printer.tokenOfLegalOwnerByIndex(investor, 2), 3);
+    }
+
+    // Backfill copies a legacy token's acquisitionDate (from FundInterestExtension data) into the base
+    // acquisitionTimestamp mapping, is idempotent, and never overwrites a token whose base value is already set.
+    function test_BackfillAcquisitionTimestamp_CopiesLegacyFromExtension() public {
+        MockFundInterestExtension ext = new MockFundInterestExtension();
+        vm.prank(address(issuanceManager));
+        printer.setExtension(0, address(ext));
+
+        uint64 legacyAcq = 12345;
+        bytes memory fid =
+            abi.encode(FundInterestData({acquisitionDate: legacyAcq, tackedFromAcquisitionDate: 0, customProvisions: ""}));
+        _mintCert(1, investor, 100, fid); // token 1: legacy (base timestamp cleared below)
+        _mintCert(2, investor, 100, fid); // token 2: keeps its mint-time stamp
+        uint64 mintStamp = printer.acquisitionTimestamp(2);
+
+        CyberCertPrinterEnhanced(address(printer)).debugClearAcquisitionTimestamp(1);
+        assertEq(printer.acquisitionTimestamp(1), 0, "precondition: token 1 base timestamp cleared");
+
+        printer.backfillAcquisitionTimestamps(0, 10);
+        assertEq(printer.acquisitionTimestamp(1), legacyAcq, "legacy token backfilled from extensionData");
+        assertEq(printer.acquisitionTimestamp(2), mintStamp, "already-set token is not overwritten");
+
+        printer.backfillAcquisitionTimestamps(0, 10); // idempotent re-run
+        assertEq(printer.acquisitionTimestamp(1), legacyAcq, "backfill is idempotent");
+    }
+
+    // Backfill is a no-op on a printer whose extension is not FUND_INTEREST.
+    function test_BackfillAcquisitionTimestamp_NoOpOnNonFundInterestPrinter() public {
+        MockNonFundExtension ext = new MockNonFundExtension();
+        vm.prank(address(issuanceManager));
+        printer.setExtension(0, address(ext));
+
+        bytes memory fid =
+            abi.encode(FundInterestData({acquisitionDate: 12345, tackedFromAcquisitionDate: 0, customProvisions: ""}));
+        _mintCert(1, investor, 100, fid);
+        CyberCertPrinterEnhanced(address(printer)).debugClearAcquisitionTimestamp(1);
+
+        printer.backfillAcquisitionTimestamps(0, 10);
+        assertEq(printer.acquisitionTimestamp(1), 0, "non-FUND_INTEREST printer: backfill is a no-op");
     }
 
     function test_AddDefaultRestrictiveLegend_StoresAndCopiesOnMint() public {
@@ -668,7 +760,7 @@ contract CyberCertPrinterTest is Test {
 
         CertificateDetails memory updated = _details(39, bytes(""));
         vm.prank(address(issuanceManager));
-        vm.expectRevert(CyberCertPrinter.ExceedsAvailableUnits.selector);
+        vm.expectRevert(ICyberCertPrinter.ExceedsAvailableUnits.selector);
         printer.updateCertificateDetails(1, updated);
     }
 
@@ -709,12 +801,12 @@ contract CyberCertPrinterTest is Test {
     }
 
     function test_GetIssuerSignatureCount_RevertsForNonexistentToken() public {
-        vm.expectRevert(CyberCertPrinter.TokenDoesNotExist.selector);
+        vm.expectRevert(ICyberCertPrinter.TokenDoesNotExist.selector);
         printer.getIssuerSignatureCount(999);
     }
 
     function test_GetIssuerSignatureAt_RevertsForNonexistentToken() public {
-        vm.expectRevert(CyberCertPrinter.TokenDoesNotExist.selector);
+        vm.expectRevert(ICyberCertPrinter.TokenDoesNotExist.selector);
         printer.getIssuerSignatureAt(999, 0);
     }
 

--- a/test/CyberCorpTest.t.sol
+++ b/test/CyberCorpTest.t.sol
@@ -44,6 +44,7 @@ pragma solidity ^0.8.18;
 import {Test, console} from "forge-std/Test.sol";
 import {CyberCorpFactory} from "../src/CyberCorpFactory.sol";
 import {CyberCertPrinter, Endorsement} from "../src/CyberCertPrinter.sol";
+import {ICyberCertPrinter} from "../src/interfaces/ICyberCertPrinter.sol";
 import {CyberScrip} from "../src/CyberScrip.sol";
 import {IIssuanceManager} from "../src/interfaces/IIssuanceManager.sol";
 import {IssuanceManagerFactory, IssuanceManager} from "../src/IssuanceManagerFactory.sol";
@@ -5736,7 +5737,7 @@ contract CyberCorpForkTest is Test {
 
         // Token 0 should be blocked by hook
         vm.startPrank(certOwner);
-        vm.expectRevert(abi.encodeWithSelector(CyberCertPrinter.TransferRestricted.selector, "Transfer disabled by global hook"));
+        vm.expectRevert(abi.encodeWithSelector(ICyberCertPrinter.TransferRestricted.selector, "Transfer disabled by global hook"));
         CyberCertPrinter(certPrinter).transferFrom(certOwner, recipient, 0);
         vm.stopPrank();
 
@@ -5759,7 +5760,7 @@ contract CyberCorpForkTest is Test {
 
         // Token 2 should be blocked
         vm.startPrank(certOwner);
-        vm.expectRevert(abi.encodeWithSelector(CyberCertPrinter.TransferRestricted.selector, "Transfer disabled by global hook"));
+        vm.expectRevert(abi.encodeWithSelector(ICyberCertPrinter.TransferRestricted.selector, "Transfer disabled by global hook"));
         CyberCertPrinter(certPrinter).transferFrom(certOwner, recipient, 2);
         vm.stopPrank();
     }
@@ -6105,7 +6106,7 @@ contract CyberCorpForkTest is Test {
         vm.prank(certOwner);
         CyberCertPrinter(certPrinter).addEndorsement(0, e);
         vm.startPrank(certOwner);
-        vm.expectRevert(abi.encodeWithSelector(CyberCertPrinter.TransferRestricted.selector, "Transfer disabled by global hook"));
+        vm.expectRevert(abi.encodeWithSelector(ICyberCertPrinter.TransferRestricted.selector, "Transfer disabled by global hook"));
         CyberCertPrinter(certPrinter).transferFrom(certOwner, recipient, 0);
         vm.stopPrank();
     }

--- a/test/DealManagerSecondaryTradeExemptionPathwayTest.t.sol
+++ b/test/DealManagerSecondaryTradeExemptionPathwayTest.t.sol
@@ -152,9 +152,6 @@ contract DealManagerSecondaryTradeExemptionPathwayTest is Test {
     uint256 public sellerTokenId;
 
     function setUp() public {
-        // Warp forward so the seller cert's acquisitionDate can sit comfortably in the past.
-        vm.warp(500 days);
-
         (owner, ownerKey) = makeAddrAndKey("owner");
         (seller, sellerKey) = makeAddrAndKey("seller");
         keeper = makeAddr("keeper");
@@ -217,14 +214,9 @@ contract DealManagerSecondaryTradeExemptionPathwayTest is Test {
         vm.prank(owner);
         regS.setRegSConfig(address(corp), 3, HOLD);
 
-        // Disclosure packages on record for the SPV (Rule 144(c)(2) and §4(a)(7)(d)(3)), fresh as of now.
-        vm.startPrank(owner);
-        rule144Disclosure.setDisclosurePackage(address(corp), DISCLOSURE_URI, uint64(block.timestamp));
-        section4a7Disclosure.setDisclosurePackage(address(corp), DISCLOSURE_URI, uint64(block.timestamp));
-        vm.stopPrank();
-
-        // Seller: KYC badge + a Ledger Entry Token whose acquisitionDate is > HOLD in the past.
-        _mintCred(seller, CAT_KYC, "US", CA);
+        // Seller Ledger Entry Token, minted now: its base acquisitionTimestamp is stamped at mint (§12B.3),
+        // so we mint first and then warp forward to age the lot past the holding / Reg S compliance period —
+        // the on-chain-faithful way to represent a seasoned position (no fakeable historical date).
         vm.startPrank(owner);
         certPrinter = ICyberCertPrinter(
             im.createCertPrinter(
@@ -238,6 +230,15 @@ contract DealManagerSecondaryTradeExemptionPathwayTest is Test {
             )
         );
         sellerTokenId = im.createCertAndAssign(address(certPrinter), seller, _sellerCertDetails());
+        vm.stopPrank();
+
+        // Age the seller lot past HOLD, then issue "now" state (seller KYC badge, disclosure packages) so
+        // those are current as of trade time.
+        vm.warp(500 days);
+        _mintCred(seller, CAT_KYC, "US", CA);
+        vm.startPrank(owner);
+        rule144Disclosure.setDisclosurePackage(address(corp), DISCLOSURE_URI, uint64(block.timestamp));
+        section4a7Disclosure.setDisclosurePackage(address(corp), DISCLOSURE_URI, uint64(block.timestamp));
         vm.stopPrank();
     }
 
@@ -637,12 +638,10 @@ contract DealManagerSecondaryTradeExemptionPathwayTest is Test {
             issuerUSDValuationAtTimeOfInvestment: 10000,
             unitsRepresented: UNITS,
             legalDetails: "",
+            // acquisitionDate left 0: the base per-lot acquisitionTimestamp (stamped at mint) is now the
+            // authoritative hold anchor; extensionData carries only the tacking anchor (unused here).
             extensionData: abi.encode(
-                FundInterestData({
-                    acquisitionDate: uint64(block.timestamp - 400 days),
-                    tackedFromAcquisitionDate: 0,
-                    customProvisions: ""
-                })
+                FundInterestData({acquisitionDate: 0, tackedFromAcquisitionDate: 0, customProvisions: ""})
             )
         });
     }

--- a/test/DealManagerSecondaryTradeIndexerTest.t.sol
+++ b/test/DealManagerSecondaryTradeIndexerTest.t.sol
@@ -202,7 +202,7 @@ contract DealManagerSecondaryTradeIndexerTest is Test {
     // Primary/secondary mint events that seed the issuance rows + shares-held balance. CertificateCreated
     // (units, emitter = IssuanceManager) is paired with CertificateAssigned (holder, emitter = CyberCertPrinter).
     bytes32 immutable TOPIC_CERT_CREATED = IIssuanceManager.CertificateCreated.selector;
-    bytes32 immutable TOPIC_CERT_ASSIGNED = CyberCertPrinter.CertificateAssigned.selector;
+    bytes32 immutable TOPIC_CERT_ASSIGNED = ICyberCertPrinter.CertificateAssigned.selector;
 
     // ─────────────────────────────────────────────────────────────────────────
     // Chain fixtures (mirrors DealManagerSecondaryTradeTest setUp)
@@ -1054,8 +1054,8 @@ contract DealManagerSecondaryTradeIndexerTest is Test {
     }
 
     // Stock-ledger reconstruction: a SELL offer filled in two lots (partial then closing) yields two transfer
-    // rows. The buyer's first fill mints a new cert; the second purchase accumulates into that same cert (no new
-    // cert minted), so both transfer rows carry the SAME issued cert number — the default consolidation behavior.
+    // rows. Under fresh-mint-per-lot each fill mints its OWN cert, so the two transfer rows carry DISTINCT issued
+    // cert numbers (one holding-period clock per lot), while the buyer's running balance still sums across them.
     function test_Indexer_StockLedger_DirectHosting_MultipleFills() public {
         uint256 unitsA = 40;
         uint256 unitsB = 60;
@@ -1077,14 +1077,14 @@ contract DealManagerSecondaryTradeIndexerTest is Test {
 
         // The full expected Stock Transfer Ledger once both lots settle — row 0 the founding issue (from
         // setUp), rows 1–2 the two transfers. NUMBER OF SHARES HELD is the row holder's running balance after
-        // that row; the seller's whole position ends up with the buyer, consolidated in a single cert.
+        // that row; the seller's whole position ends up with the buyer, held across one cert per lot (#1, #2).
         //
         //  NO. |              CERTIFICATE ISSUED              |              CERTIFICATE SURRENDERED
         //      | SHAREHOLDER | CERT# | SHARES | HELD |  PAID  | FROM WHOM       | CERT# | SHARES | VOIDED? | HELD
         // -----+-------------+-------+--------+------+--------+-----------------+-------+--------+---------+-----
         //   0  | Alice       |   0   |  100   | 100  |   0    | — (orig. issue) |   —   |   0    |   no    |  —
         //   1  | Bob         |   1   |   40   |  40  | 4 eth  | Alice           |   0   |   40   |   no    |  60
-        //   2  | Bob         |   1   |   60   | 100  | 6 eth  | Alice           |   0   |   60   |   yes   |  0
+        //   2  | Bob         |   2   |   60   | 100  | 6 eth  | Alice           |   0   |   60   |   yes   |  0
         assertEq(idxTransferLedger.length, 3, "ledger has the original issue + two transfers");
         // Row 0 — the original issue is unchanged by the trading that followed.
         _assertLedgerRow(0, true, seller, "Alice", sellerTokenId, UNITS, address(0), 0, 0, false, 0, address(0), UNITS, 0);
@@ -1092,15 +1092,16 @@ contract DealManagerSecondaryTradeIndexerTest is Test {
         _assertLedgerRow(
             1, false, buyer, "Bob", 1, unitsA, seller, sellerTokenId, unitsA, false, paidA, address(paymentToken), unitsA, UNITS - unitsA
         );
-        // Row 2 — lot B, closing the position: the seller cert is voided, and the 60 units accumulate into Bob's
-        // SAME cert (#1), which now represents the full 100.
+        // Row 2 — lot B, closing the position: the seller cert is voided, and the 60 units are delivered as Bob's
+        // OWN second lot (a distinct cert #2); his running balance across both lots is the full 100.
         _assertLedgerRow(
-            2, false, buyer, "Bob", 1, unitsB, seller, sellerTokenId, unitsB, true, paidB, address(paymentToken), UNITS, UNITS - unitsA - unitsB
+            2, false, buyer, "Bob", 2, unitsB, seller, sellerTokenId, unitsB, true, paidB, address(paymentToken), UNITS, UNITS - unitsA - unitsB
         );
 
-        // Both lots surrender the same origin cert and consolidate into one buyer cert — a coherent chain of title.
+        // Both lots surrender the same origin cert but land in DISTINCT buyer certs (one per lot) — a coherent
+        // chain of title with per-lot holding-period clocks.
         assertEq(idxSettlements[lotA].surrenderedTokenId, idxSettlements[lotB].surrenderedTokenId, "same origin cert");
-        assertEq(idxSettlements[lotA].issuedTokenId, idxSettlements[lotB].issuedTokenId, "both fills consolidate into one cert");
+        assertTrue(idxSettlements[lotA].issuedTokenId != idxSettlements[lotB].issuedTokenId, "each fill mints its own lot");
 
         // NUMBER OF SHARES HELD: the whole position moved from the seller to the buyer across the two lots.
         assertEq(sharesHeld[seller], 0, "seller fully divested");
@@ -1131,8 +1132,8 @@ contract DealManagerSecondaryTradeIndexerTest is Test {
         uint256 paidA = CONSIDERATION * unitsA / UNITS; // 4 ether
         uint256 paidB = CONSIDERATION * unitsB / UNITS; // 6 ether
 
-        // On-chain split: the multisig custodies the buyer's (consolidated) cert, but the buyer is the registered
-        // legal owner. Both fills land on the same cert, so the two lookups address one token.
+        // On-chain split: the multisig custodies the buyer's certs, but the buyer is the registered legal owner.
+        // Each fill mints its own lot, so the two lookups address distinct tokens.
         assertEq(
             CyberCertPrinter(address(certPrinter)).ownerOf(idxSettlements[lotA].issuedTokenId),
             adminMultisig,
@@ -1154,7 +1155,7 @@ contract DealManagerSecondaryTradeIndexerTest is Test {
         // -----+-------------+-------+--------+------+--------+-----------------+-------+--------+---------+-----
         //   0  | Alice       |   0   |  100   | 100  |   0    | — (orig. issue) |   —   |   0    |   no    |  —
         //   1  | Bob         |   1   |   40   |  40  | 4 eth  | Alice           |   0   |   40   |   no    |  60
-        //   2  | Bob         |   1   |   60   | 100  | 6 eth  | Alice           |   0   |   60   |   yes   |  0
+        //   2  | Bob         |   2   |   60   | 100  | 6 eth  | Alice           |   0   |   60   |   yes   |  0
         assertEq(idxTransferLedger.length, 3, "ledger has the original issue + two transfers");
         // Row 0 — the original issue is unchanged by the trading that followed.
         _assertLedgerRow(0, true, seller, "Alice", sellerTokenId, UNITS, address(0), 0, 0, false, 0, address(0), UNITS, 0);
@@ -1162,15 +1163,16 @@ contract DealManagerSecondaryTradeIndexerTest is Test {
         _assertLedgerRow(
             1, false, buyer, "Bob", 1, unitsA, seller, sellerTokenId, unitsA, false, paidA, address(paymentToken), unitsA, UNITS - unitsA
         );
-        // Row 2 — lot B, closing the position: the seller cert is voided, and the 60 units accumulate into Bob's
-        // SAME cert (#1), which now represents the full 100.
+        // Row 2 — lot B, closing the position: the seller cert is voided, and the 60 units are delivered as Bob's
+        // OWN second lot (a distinct cert #2); his running balance across both lots is the full 100.
         _assertLedgerRow(
-            2, false, buyer, "Bob", 1, unitsB, seller, sellerTokenId, unitsB, true, paidB, address(paymentToken), UNITS, UNITS - unitsA - unitsB
+            2, false, buyer, "Bob", 2, unitsB, seller, sellerTokenId, unitsB, true, paidB, address(paymentToken), UNITS, UNITS - unitsA - unitsB
         );
 
-        // Both lots surrender the same origin cert and consolidate into one buyer cert — a coherent chain of title.
+        // Both lots surrender the same origin cert but land in DISTINCT buyer certs (one per lot) — a coherent
+        // chain of title with per-lot holding-period clocks.
         assertEq(idxSettlements[lotA].surrenderedTokenId, idxSettlements[lotB].surrenderedTokenId, "same origin cert");
-        assertEq(idxSettlements[lotA].issuedTokenId, idxSettlements[lotB].issuedTokenId, "both fills consolidate into one cert");
+        assertTrue(idxSettlements[lotA].issuedTokenId != idxSettlements[lotB].issuedTokenId, "each fill mints its own lot");
 
         // NUMBER OF SHARES HELD: the whole position moved to the buyer of record; the custodian holds none.
         assertEq(sharesHeld[seller], 0, "seller fully divested");
@@ -1178,11 +1180,10 @@ contract DealManagerSecondaryTradeIndexerTest is Test {
         assertEq(sharesHeld[adminMultisig], 0, "custodian holds no shares of record");
     }
 
-    // Accumulation into a buyer's PRE-EXISTING PRIMARY cert: the buyer already holds a founding cert on this
-    // printer before any trading, then buys a lot from the seller. The contract folds the purchase into that
-    // primary cert (no new cert minted), so the indexer must keep the primary issue row an ORIGINAL ISSUE and
-    // open a SEPARATE secondary-transfer row for the purchase — not mis-enrich the founding row.
-    function test_Indexer_StockLedger_AccumulateIntoPreexistingPrimaryCert() public {
+    // A buyer with a PRE-EXISTING PRIMARY cert who then buys a lot from the seller: under fresh-mint-per-lot the
+    // purchase is delivered as a NEW cert, never folded into the primary. The indexer keeps the primary issue row
+    // an ORIGINAL ISSUE (untouched) and opens a secondary-transfer row on the newly minted cert number.
+    function test_Indexer_StockLedger_DoesNotFoldIntoPreexistingPrimaryCert() public {
         uint256 buyerPrimaryUnits = 50;
         uint256 tradeUnits = 40;
 
@@ -1192,6 +1193,7 @@ contract DealManagerSecondaryTradeIndexerTest is Test {
         uint256 buyerPrimaryTokenId = im.createCertAndAssignWithName(
             address(certPrinter), buyer, _sellerCertDetails(buyerPrimaryUnits), "Bob", "", block.timestamp
         );
+        uint256 secondaryLotTokenId = buyerPrimaryTokenId + 1; // the purchase mints the next id
 
         bytes32 offerId = _postSellOffer();
         bytes32 lot = _acceptSellOfferPartial(offerId, tradeUnits);
@@ -1202,35 +1204,36 @@ contract DealManagerSecondaryTradeIndexerTest is Test {
 
         uint256 paid = CONSIDERATION * tradeUnits / UNITS; // 4 ether
 
-        // The purchase folds into Bob's pre-existing PRIMARY cert (#1): no new cert minted, so that primary row
-        // stays an original issue and the purchase opens its OWN secondary-transfer row on the same cert number.
+        // The purchase mints Bob a fresh lot (#2); his PRIMARY cert (#1) stays an untouched original issue, and
+        // the purchase opens its own secondary-transfer row on the new cert number.
         //
         //  NO. |              CERTIFICATE ISSUED              |              CERTIFICATE SURRENDERED
         //      | SHAREHOLDER | CERT# | SHARES | HELD |  PAID  | FROM WHOM       | CERT# | SHARES | VOIDED? | HELD
         // -----+-------------+-------+--------+------+--------+-----------------+-------+--------+---------+-----
         //   0  | Alice       |   0   |  100   | 100  |   0    | — (orig. issue) |   —   |   0    |   no    |  —
         //   1  | Bob         |   1   |   50   |  50  |   0    | — (orig. issue) |   —   |   0    |   no    |  —
-        //   2  | Bob         |   1   |   40   |  90  | 4 eth  | Alice           |   0   |   40   |   no    |  60
+        //   2  | Bob         |   2   |   40   |  90  | 4 eth  | Alice           |   0   |   40   |   no    |  60
         assertEq(idxTransferLedger.length, 3, "ledger has Alice's + Bob's original issues + one transfer");
         _assertLedgerRow(0, true, seller, "Alice", sellerTokenId, UNITS, address(0), 0, 0, false, 0, address(0), UNITS, 0);
-        // Row 1 — Bob's founding cert stays an original issue, untouched by the trade that folds into it.
+        // Row 1 — Bob's founding cert stays an original issue, untouched by the later purchase.
         _assertLedgerRow(
             1, true, buyer, "Bob", buyerPrimaryTokenId, buyerPrimaryUnits, address(0), 0, 0, false, 0, address(0), buyerPrimaryUnits, 0
         );
-        // Row 2 — the purchase: seller cert decremented (not voided), 40 units accumulate into Bob's primary cert.
+        // Row 2 — the purchase: seller cert decremented (not voided), 40 units delivered as Bob's own new lot.
         _assertLedgerRow(
-            2, false, buyer, "Bob", buyerPrimaryTokenId, tradeUnits, seller, sellerTokenId, tradeUnits, false, paid, address(paymentToken), buyerPrimaryUnits + tradeUnits, UNITS - tradeUnits
+            2, false, buyer, "Bob", secondaryLotTokenId, tradeUnits, seller, sellerTokenId, tradeUnits, false, paid, address(paymentToken), buyerPrimaryUnits + tradeUnits, UNITS - tradeUnits
         );
 
-        // The issued cert is Bob's own founding cert; only the surrender names the seller's cert.
-        assertEq(idxSettlements[lot].issuedTokenId, buyerPrimaryTokenId, "purchase folded into Bob's primary cert");
+        // The issued cert is a fresh lot, distinct from Bob's primary cert; only the surrender names the seller's.
+        assertEq(idxSettlements[lot].issuedTokenId, secondaryLotTokenId, "purchase minted a new lot");
+        assertTrue(idxSettlements[lot].issuedTokenId != buyerPrimaryTokenId, "purchase not folded into the primary cert");
         assertEq(idxSettlements[lot].surrenderedTokenId, sellerTokenId, "seller surrendered the founding cert");
-        // The primary cert keeps its original-issue status despite absorbing a secondary purchase.
-        assertTrue(idxIssuances[buyerPrimaryTokenId].originalIssue, "buyer's cert remains an original issue");
+        // The primary cert keeps its original-issue status; the purchase never touched it.
+        assertTrue(idxIssuances[buyerPrimaryTokenId].originalIssue, "buyer's primary cert remains an original issue");
 
-        // NUMBER OF SHARES HELD: the seller's lot moved into Bob's already-held position.
+        // NUMBER OF SHARES HELD: the seller's lot moved into Bob's position (across two certs now).
         assertEq(sharesHeld[seller], UNITS - tradeUnits, "seller decremented by the sold lot");
-        assertEq(sharesHeld[buyer], buyerPrimaryUnits + tradeUnits, "buyer's primary cert grew by the purchase");
+        assertEq(sharesHeld[buyer], buyerPrimaryUnits + tradeUnits, "buyer's position grew by the purchase");
     }
 
     /// @dev Asserts one Stock Transfer Ledger row (idxTransferLedger[row]) matches expected across every

--- a/test/DealManagerSecondaryTradeTest.t.sol
+++ b/test/DealManagerSecondaryTradeTest.t.sol
@@ -862,7 +862,7 @@ contract DealManagerSecondaryTradeTest is Test {
         _postSellOffer();
 
         vm.prank(owner);
-        vm.expectRevert(CyberCertPrinter.CertificateReserved.selector);
+        vm.expectRevert(ICyberCertPrinter.CertificateReserved.selector);
         im.assignCert(address(certPrinter), seller, sellerTokenId, newOwner, _sellerCertDetails(UNITS));
 
         // Below verifies DealManager does double-check the legal ownership at every step, but we will never reach there if
@@ -2097,7 +2097,7 @@ contract DealManagerSecondaryTradeTest is Test {
         _acceptSellOffer(offerId);
 
         vm.prank(owner);
-        vm.expectRevert(CyberCertPrinter.CertificateReserved.selector);
+        vm.expectRevert(ICyberCertPrinter.CertificateReserved.selector);
         im.assignCert(address(certPrinter), seller, sellerTokenId, newOwner, _sellerCertDetails(UNITS));
 
         // Below verifies DealManager does double-check the legal ownership at every step, but we will never reach there if
@@ -2117,7 +2117,7 @@ contract DealManagerSecondaryTradeTest is Test {
         _acceptBid(offerId);
 
         vm.prank(owner);
-        vm.expectRevert(CyberCertPrinter.CertificateReserved.selector);
+        vm.expectRevert(ICyberCertPrinter.CertificateReserved.selector);
         im.assignCert(address(certPrinter), seller, sellerTokenId, newOwner, _sellerCertDetails(UNITS));
 
         // Below verifies DealManager does double-check the legal ownership at every step, but we will never reach there if

--- a/test/IssuanceManagerConversionTest.t.sol
+++ b/test/IssuanceManagerConversionTest.t.sol
@@ -1055,6 +1055,24 @@ contract IssuanceManagerConversionTest is Test {
         assertEq(newCert.unitsRepresented, 100 * 1e18); // 150 * 2 / 3
     }
 
+    function test_setCertLookThroughBadge_AdminWiresBadgeOnPrinter() public {
+        ICyberCertPrinter certPrinter = _deployPrinter("Badge Wire", "BW");
+        assertEq(certPrinter.lookThroughBadge(), address(0));
+
+        address badge = makeAddr("lookThroughBadge");
+        issuanceManager.setCertLookThroughBadge(address(certPrinter), badge);
+        assertEq(certPrinter.lookThroughBadge(), badge);
+    }
+
+    function test_setCertLookThroughBadge_NonAdminReverts() public {
+        ICyberCertPrinter certPrinter = _deployPrinter("Badge Wire 2", "BW2");
+        address badge = makeAddr("lookThroughBadge");
+
+        vm.prank(investor);
+        vm.expectRevert();
+        issuanceManager.setCertLookThroughBadge(address(certPrinter), badge);
+    }
+
     function test_convertScripToCert_ignoresVoidedCertAndMintsNewCertificate()
         public
     {

--- a/test/IssuanceManagerSecondaryTransferTest.t.sol
+++ b/test/IssuanceManagerSecondaryTransferTest.t.sol
@@ -196,9 +196,9 @@ contract IssuanceManagerSecondaryTransferTest is Test {
         _assertMirrorEndorsement(cert, 1, "Bob");
     }
 
-    // A buyer's repeat purchase consolidates by default: a second secondary transfer folds its units into the
-    // buyer's existing active cert rather than minting a new one (mirrors the scrip-to-cert recert behavior).
-    function test_SecondaryTransfer_RepeatPurchase_AccumulatesIntoExistingCert() public {
+    // Fresh-mint-per-lot: a buyer's repeat purchase mints a NEW cert each time (its own acquisitionTimestamp
+    // clock) rather than folding into an existing one — the per-lot holding-period model (§7.5).
+    function test_SecondaryTransfer_RepeatPurchase_MintsDistinctLots() public {
         ICyberCertPrinter cert = _deployPrinterWithSellerCert(UNITS);
 
         // First purchase: 40 units mints the buyer a fresh cert (id 1).
@@ -206,19 +206,20 @@ contract IssuanceManagerSecondaryTransferTest is Test {
         assertEq(cert.balanceOf(buyer), 1, "buyer holds one cert after the first purchase");
         assertEq(cert.getCertificateDetails(1).unitsRepresented, 40, "first cert holds 40");
 
-        // Second purchase: another 40 units reuses cert 1 (the event reports the existing token, not a new mint).
+        // Second purchase: another 40 units mints a distinct new cert (id 2), reported as a fresh mint.
         vm.expectEmit(true, true, true, true, address(issuanceManager));
-        emit IIssuanceManager.SecondaryTransferExecuted(SETTLEMENT_ID, address(cert), buyer, 0, 1, seller, 40, 20, 80, false, false);
+        emit IIssuanceManager.SecondaryTransferExecuted(SETTLEMENT_ID, address(cert), buyer, 0, 2, seller, 40, 20, 40, false, true);
         issuanceManager.secondaryTransfer(_dealMetadata(address(cert), 0, 40, "Bob", HostingMode.DIRECT, address(0)));
 
-        assertEq(cert.totalSupply(), 2, "no new cert minted (seller 0 + buyer 1)");
-        assertEq(cert.balanceOf(buyer), 1, "buyer still holds a single consolidated cert");
-        assertEq(cert.getCertificateDetails(1).unitsRepresented, 80, "units accumulated into the existing cert");
+        assertEq(cert.totalSupply(), 3, "a new cert minted per lot (seller 0 + buyer 1 + buyer 2)");
+        assertEq(cert.balanceOf(buyer), 2, "buyer holds one cert per lot");
+        assertEq(cert.getCertificateDetails(1).unitsRepresented, 40, "first lot unchanged");
+        assertEq(cert.getCertificateDetails(2).unitsRepresented, 40, "second lot is its own cert");
     }
 
-    // Merging a secondary purchase into a cert the buyer already holds from PRIMARY issuance must leave that
-    // cert's cost-basis snapshot untouched — only units accumulate (spec: snapshot at primary issuance).
-    function test_SecondaryTransfer_MergeIntoPrimaryCert_PreservesBasisSnapshot() public {
+    // Fresh-mint-per-lot: a secondary purchase never folds into a cert the buyer already holds from PRIMARY
+    // issuance — a distinct lot is minted, and the primary cert (units and cost-basis snapshot) is untouched.
+    function test_SecondaryTransfer_DoesNotMergeIntoPrimaryCert() public {
         ICyberCertPrinter cert = _deployPrinterWithSellerCert(UNITS);
 
         // The buyer already holds a primary-issued cert (id 1) with its own cost basis.
@@ -233,21 +234,26 @@ contract IssuanceManagerSecondaryTransferTest is Test {
         });
         issuanceManager.createCertAndAssign(address(cert), buyer, primaryDetails);
 
-        // A secondary purchase of 30 units folds into the buyer's existing primary cert (id 1).
+        // A secondary purchase of 30 units mints a fresh lot (id 2), leaving the primary cert untouched.
         issuanceManager.secondaryTransfer(_dealMetadata(address(cert), 0, 30, "Bob", HostingMode.DIRECT, address(0)));
 
-        CertificateDetails memory merged = cert.getCertificateDetails(1);
-        assertEq(merged.unitsRepresented, 80, "secondary units folded into the primary cert");
-        assertEq(merged.investmentAmountUSD, 2000, "primary cost-basis snapshot unchanged");
-        assertEq(merged.issuerUSDValuationAtTimeOfInvestment, 20000, "primary valuation snapshot unchanged");
+        CertificateDetails memory primary = cert.getCertificateDetails(1);
+        assertEq(primary.unitsRepresented, 50, "primary cert units untouched");
+        assertEq(primary.investmentAmountUSD, 2000, "primary cost-basis snapshot unchanged");
+        assertEq(primary.issuerUSDValuationAtTimeOfInvestment, 20000, "primary valuation snapshot unchanged");
+
+        CertificateDetails memory secondaryLot = cert.getCertificateDetails(2);
+        assertEq(secondaryLot.unitsRepresented, 30, "secondary purchase is its own lot");
+        assertEq(secondaryLot.investmentAmountUSD, 0, "secondary lot carries no primary-issuance basis");
+        assertEq(cert.balanceOf(buyer), 2, "buyer holds the primary cert and the new secondary lot");
     }
 
     // TODO should test administered hosted as well
 
-    // Administered hosting where ONE multisig custodies certs for two different legal owners. Consolidation must
-    // target the buyer's OWN cert by legal owner of record — never another holder's cert that happens to share
-    // the custodian. This is the case a custody (balanceOf) scan could not get right.
-    function test_SecondaryTransfer_AdministeredHosting_AccumulatesByLegalOwnerNotCustodian() public {
+    // Administered hosting where ONE multisig custodies certs for two different legal owners. Fresh-mint-per-lot
+    // means each fill mints its own cert to the multisig, owned of record by the respective buyer — the legal
+    // owner of record (not the shared custodian) is what distinguishes lots.
+    function test_SecondaryTransfer_AdministeredHosting_MintsLotPerFillByLegalOwner() public {
         ICyberCertPrinter cert = _deployPrinterWithSellerCert(UNITS);
         address adminMultisig = makeAddr("adminMultisig");
         (address buyer2,) = makeAddrAndKey("buyer2");
@@ -256,14 +262,38 @@ contract IssuanceManagerSecondaryTransferTest is Test {
         issuanceManager.secondaryTransfer(_dealMetadataFor(buyer, address(cert), 0, 30, "Bob", HostingMode.ADMINISTERED, adminMultisig));
         issuanceManager.secondaryTransfer(_dealMetadataFor(buyer2, address(cert), 0, 40, "Carol", HostingMode.ADMINISTERED, adminMultisig));
 
-        // Bob buys again: must accumulate into Bob's cert (id 1), not Carol's (id 2).
+        // Bob buys again: a distinct new lot (id 3) is minted to the multisig, owned of record by Bob.
         issuanceManager.secondaryTransfer(_dealMetadataFor(buyer, address(cert), 0, 30, "Bob", HostingMode.ADMINISTERED, adminMultisig));
 
-        assertEq(cert.balanceOf(adminMultisig), 2, "multisig custodies one cert per legal owner");
-        assertEq(cert.legalOwnerOf(1), buyer, "cert 1 owned of record by Bob");
-        assertEq(cert.legalOwnerOf(2), buyer2, "cert 2 owned of record by Carol");
-        assertEq(cert.getCertificateDetails(1).unitsRepresented, 60, "Bob's cert accumulated both his fills");
-        assertEq(cert.getCertificateDetails(2).unitsRepresented, 40, "Carol's cert untouched");
+        assertEq(cert.balanceOf(adminMultisig), 3, "multisig custodies one cert per lot");
+        assertEq(cert.balanceOfLegalOwner(buyer), 2, "Bob owns of record two lots");
+        assertEq(cert.balanceOfLegalOwner(buyer2), 1, "Carol owns of record one lot");
+        assertEq(cert.legalOwnerOf(1), buyer, "lot 1 owned of record by Bob");
+        assertEq(cert.legalOwnerOf(2), buyer2, "lot 2 owned of record by Carol");
+        assertEq(cert.legalOwnerOf(3), buyer, "Bob's second lot owned of record by Bob");
+        assertEq(cert.getCertificateDetails(1).unitsRepresented, 30, "Bob's first lot");
+        assertEq(cert.getCertificateDetails(3).unitsRepresented, 30, "Bob's second lot is distinct");
+        assertEq(cert.getCertificateDetails(2).unitsRepresented, 40, "Carol's lot untouched");
+    }
+
+    // The admin can correct a cert's issue timestamp for a position issued off-chain before being recorded
+    // on-chain (overrides the mint-stamped value); non-admins cannot.
+    function test_SetIssueTimestamp_AdminOverridesMintStamp() public {
+        vm.warp(200 days);
+        ICyberCertPrinter cert = _deployPrinterWithSellerCert(UNITS);
+        assertEq(cert.issueTimestamp(0), uint64(block.timestamp), "mint stamps the on-chain issue time");
+
+        uint64 historical = uint64(110 days); // truly issued off-chain, earlier than the on-chain record
+        vm.expectEmit(true, false, false, true, address(cert));
+        emit ICyberCertPrinter.IssueTimestampSet(0, historical);
+        issuanceManager.setIssueTimestamp(address(cert), 0, historical);
+        assertEq(cert.issueTimestamp(0), historical, "admin override applied");
+
+        address notAdmin = makeAddr("notAdmin");
+        uint256 adminRole = auth.ADMIN_ROLE();
+        vm.prank(notAdmin);
+        vm.expectRevert(abi.encodeWithSignature("BorgAuth_NotAuthorized(uint256,address)", adminRole, notAdmin));
+        issuanceManager.setIssueTimestamp(address(cert), 0, historical);
     }
 
     // ─────────────────────────────────────────────────────────────────────────

--- a/test/IssuanceManagerSecondaryTransferTest.t.sol
+++ b/test/IssuanceManagerSecondaryTransferTest.t.sol
@@ -296,6 +296,26 @@ contract IssuanceManagerSecondaryTransferTest is Test {
         issuanceManager.setIssueTimestamp(address(cert), 0, historical);
     }
 
+    // The admin can override a cert's acquisition timestamp (e.g. to seed a seasoned migrated position);
+    // non-admins cannot.
+    function test_SetAcquisitionTimestamp_AdminOverridesMintStamp() public {
+        vm.warp(200 days);
+        ICyberCertPrinter cert = _deployPrinterWithSellerCert(UNITS);
+        assertEq(cert.acquisitionTimestamp(0), uint64(block.timestamp), "mint stamps the acquisition time");
+
+        uint64 seasoned = uint64(110 days); // acquired off-chain earlier than the on-chain record
+        vm.expectEmit(true, false, false, true, address(cert));
+        emit ICyberCertPrinter.AcquisitionTimestampSet(0, seasoned);
+        issuanceManager.setAcquisitionTimestamp(address(cert), 0, seasoned);
+        assertEq(cert.acquisitionTimestamp(0), seasoned, "admin override applied");
+
+        address notAdmin = makeAddr("notAdmin");
+        uint256 adminRole = auth.ADMIN_ROLE();
+        vm.prank(notAdmin);
+        vm.expectRevert(abi.encodeWithSignature("BorgAuth_NotAuthorized(uint256,address)", adminRole, notAdmin));
+        issuanceManager.setAcquisitionTimestamp(address(cert), 0, seasoned);
+    }
+
     // ─────────────────────────────────────────────────────────────────────────
     // Helpers
     // ─────────────────────────────────────────────────────────────────────────

--- a/test/IssuanceManagerSecondaryTransferTest.t.sol
+++ b/test/IssuanceManagerSecondaryTransferTest.t.sol
@@ -10,6 +10,7 @@ import {IIssuanceManager} from "../src/interfaces/IIssuanceManager.sol";
 import {ITransferRestrictionHook} from "../src/interfaces/ITransferRestrictionHook.sol";
 import {ICondition} from "../src/interfaces/ICondition.sol";
 import {ExemptionPathway, HostingMode} from "../src/interfaces/ISecondaryTradeStorage.sol";
+import {FundInterestData, FundInterestExtension} from "../src/storage/extensions/FundInterestExtension.sol";
 import "../src/libs/auth.sol";
 import "forge-std/Test.sol";
 import {ERC1967Proxy} from "openzeppelin-contracts/proxy/ERC1967/ERC1967Proxy.sol";
@@ -316,9 +317,63 @@ contract IssuanceManagerSecondaryTransferTest is Test {
         issuanceManager.setAcquisitionTimestamp(address(cert), 0, seasoned);
     }
 
+    // The admin can override a cert's Rule 144(d)(3) tacking anchor (tackedFromAcquisitionDate) inside the
+    // FundInterestData blob, leaving acquisitionDate and the other fields intact; non-admins cannot.
+    function test_UpdateCertificateTackedFromAcquisitionDate_AdminOverrides() public {
+        vm.warp(200 days);
+        ICyberCertPrinter cert = _deployPrinterWithFundInterestCert(UNITS, uint64(111 days), 0, "keep");
+
+        uint64 tacked = uint64(90 days);
+        issuanceManager.updateCertificateTackedFromAcquisitionDate(address(cert), 0, tacked);
+
+        FundInterestData memory fid = abi.decode(cert.getCertificateDetails(0).extensionData, (FundInterestData));
+        assertEq(fid.tackedFromAcquisitionDate, tacked, "tacking anchor updated");
+        assertEq(fid.acquisitionDate, uint64(111 days), "acquisitionDate preserved");
+        assertEq(fid.customProvisions, "keep", "other FundInterestData fields preserved");
+
+        address notAdmin = makeAddr("notAdmin");
+        uint256 adminRole = auth.ADMIN_ROLE();
+        vm.prank(notAdmin);
+        vm.expectRevert(abi.encodeWithSignature("BorgAuth_NotAuthorized(uint256,address)", adminRole, notAdmin));
+        issuanceManager.updateCertificateTackedFromAcquisitionDate(address(cert), 0, tacked);
+    }
+
+    // Guarding a non-FUND_INTEREST cert: the setter reverts before touching extensionData, so it can never
+    // misread or clobber another extension's blob (mirrors backfillAcquisitionTimestamp's extension-type gate).
+    function test_UpdateCertificateTackedFromAcquisitionDate_RevertsOnNonFundInterestCert() public {
+        ICyberCertPrinter cert = _deployPrinterWithSellerCert(UNITS); // printer has no extension (address(0))
+        vm.expectRevert(ICyberCertPrinter.ExtensionTypeNotSupported.selector);
+        issuanceManager.updateCertificateTackedFromAcquisitionDate(address(cert), 0, uint64(90 days));
+    }
+
     // ─────────────────────────────────────────────────────────────────────────
     // Helpers
     // ─────────────────────────────────────────────────────────────────────────
+
+    /// @dev Deploys a printer and mints the seller's Ledger Entry Token (id 0) carrying a FundInterestData blob.
+    function _deployPrinterWithFundInterestCert(
+        uint256 units,
+        uint64 acquisitionDate,
+        uint64 tackedFromAcquisitionDate,
+        string memory customProvisions
+    ) internal returns (ICyberCertPrinter cert) {
+        cert = ICyberCertPrinter(
+            issuanceManager.createCertPrinter(
+                new string[](0), "Cert", "CERT", "uri://cert",
+                SecurityClass.CommonStock, SecuritySeries.SeriesA, address(new FundInterestExtension())
+            )
+        );
+        CertificateDetails memory details = CertificateDetails({
+            signingOfficerName: "Officer",
+            signingOfficerTitle: "Title",
+            investmentAmountUSD: 1000,
+            issuerUSDValuationAtTimeOfInvestment: 10000,
+            unitsRepresented: units,
+            legalDetails: "",
+            extensionData: abi.encode(FundInterestData(acquisitionDate, tackedFromAcquisitionDate, customProvisions))
+        });
+        issuanceManager.createCertAndAssign(address(cert), seller, details);
+    }
 
     /// @dev Deploys a printer and mints the seller's Ledger Entry Token (id 0, `units` units)
     function _deployPrinterWithSellerCert(uint256 units) internal returns (ICyberCertPrinter cert) {

--- a/test/LegalOwnerBugFix.t.sol
+++ b/test/LegalOwnerBugFix.t.sol
@@ -241,6 +241,15 @@ contract LegalOwnerBugPOCTest is Test {
         );
     }
 
+    // The bare-mint path (createCert) sets the legal owner but historically emitted no ownership event;
+    // _setLegalOwner now emits LegalOwnerChanged from the chokepoint, so this path is observable too.
+    function test_CreateCert_EmitsLegalOwnerChanged() public {
+        uint256 nextId = certPrinter.totalSupply();
+        vm.expectEmit(true, true, true, true, address(certPrinter));
+        emit ICyberCertPrinter.LegalOwnerChanged(nextId, address(0), investor, "", uint64(block.timestamp));
+        issuanceManager.createCert(address(certPrinter), investor, _details(10));
+    }
+
     function _details(uint256 units) internal pure returns (CertificateDetails memory) {
         return CertificateDetails({
             signingOfficerName: "Officer",

--- a/test/conditions/secondary/AgreementSignedCondition.t.sol
+++ b/test/conditions/secondary/AgreementSignedCondition.t.sol
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.28;
+
+import {IDealManager} from "../../../src/interfaces/IDealManager.sol";
+import {AgreementSignedCondition} from "../../../src/libs/conditions/secondary/AgreementSignedCondition.sol";
+import {SecondaryConditionTestBase} from "./SecondaryConditionMocks.sol";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AgreementSignedCondition — every party's signature recorded on the trade agreement.
+//
+// Legal/economic intent: a defensive invariant that the settlement agreement is fully executed before
+// it clears. Trivially true at acceptance (acceptOffer creates it fully signed) but guards any flow
+// that composes conditions independently. Silent at posting — no settlement agreement exists yet.
+//
+// Scenario × outcome
+// | # | context   | all parties signed | expect | rationale                     |
+// |---|-----------|:------------------:|:------:|-------------------------------|
+// | 1 | posting   |        n/a          |  pass  | no agreement yet              |
+// | 2 | accepted  |        yes          |  pass  | fully executed                |
+// | 3 | accepted  |        no           |  fail  | a signature is missing        |
+//
+// Config/authorization
+// | # | case                        | expect                 |
+// |---|-----------------------------|------------------------|
+// | 4 | initialize zero registry    | revert InvalidRegistry |
+// | 5 | updateRegistry zero         | revert InvalidRegistry |
+// | 6 | updateRegistry by stranger  | revert (not admin)     |
+// ─────────────────────────────────────────────────────────────────────────────
+
+contract AgreementSignedConditionTest is SecondaryConditionTestBase {
+    AgreementSignedCondition internal signed;
+
+    function setUp() public {
+        _setUpBase();
+        signed = AgreementSignedCondition(
+            _proxy(
+                address(new AgreementSignedCondition()),
+                abi.encodeCall(AgreementSignedCondition.initialize, (address(auth), address(registry)))
+            )
+        );
+    }
+
+    function _check(bytes32 agreementId) internal view returns (bool) {
+        return signed.checkCondition(IDealManager(address(dm)), bytes4(0), OFFER_ID, agreementId);
+    }
+
+    // 1
+    function test_Posting_Silent_Passes() public view {
+        assertTrue(_check(bytes32(0)));
+    }
+
+    // 2
+    function test_Accepted_AllSigned_Passes() public {
+        registry.setAllPartiesSigned(AGREEMENT_ID, true);
+        assertTrue(_check(AGREEMENT_ID));
+    }
+
+    // 3
+    function test_Accepted_NotAllSigned_Fails() public view {
+        assertFalse(_check(AGREEMENT_ID));
+    }
+
+    // 4
+    function test_Initialize_ZeroRegistry_Reverts() public {
+        AgreementSignedCondition impl = new AgreementSignedCondition();
+        vm.expectRevert(AgreementSignedCondition.InvalidRegistry.selector);
+        _proxy(address(impl), abi.encodeCall(AgreementSignedCondition.initialize, (address(auth), address(0))));
+    }
+
+    // 5
+    function test_UpdateRegistry_Zero_Reverts() public {
+        vm.expectRevert(AgreementSignedCondition.InvalidRegistry.selector);
+        signed.updateRegistry(address(0));
+    }
+
+    // 6
+    function test_UpdateRegistry_ByStranger_Reverts() public {
+        vm.prank(stranger);
+        vm.expectRevert();
+        signed.updateRegistry(address(registry));
+    }
+}

--- a/test/conditions/secondary/CFIUSCondition.t.sol
+++ b/test/conditions/secondary/CFIUSCondition.t.sol
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.28;
+
+import {CategoryKind} from "../../../src/creds/storage/lexchexBadgeStorage.sol";
+import {IDealManager} from "../../../src/interfaces/IDealManager.sol";
+import {Offer, SecondaryEscrow} from "../../../src/interfaces/ISecondaryTradeStorage.sol";
+import {CFIUSCondition} from "../../../src/libs/conditions/secondary/CFIUSCondition.sol";
+import {SecondaryConditionTestBase} from "./SecondaryConditionMocks.sol";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CFIUSCondition — FIRRMA gating for CFIUS-sensitive SPVs.
+//
+// Legal/economic intent: for SPVs holding a TID U.S. business (and not qualifying for the FIRRMA
+// investment-fund exception), block transfers to non-U.S. persons — or U.S. persons from a blocked-
+// affiliation jurisdiction — until the GP records a manual CFIUS clearance. Dormant (always passes)
+// when the SPV is not TID-sensitive.
+//
+// Scenario × outcome (deployed tidUsBusiness = true)
+// | # | scenario                                        | expect | rationale                        |
+// |---|-------------------------------------------------|:------:|----------------------------------|
+// | 1 | tidUsBusiness = false (dormant)                 |  pass  | condition not engaged            |
+// | 2 | posting (no buyer)                              |  pass  | nothing to gate                  |
+// | 3 | U.S. buyer, unblocked jurisdiction              |  pass  | no CFIUS concern                 |
+// | 4 | non-U.S.-person badge, no clearance             |  fail  | foreign acquirer, unreviewed     |
+// | 5 | non-U.S. jurisdiction, no clearance             |  fail  | foreign acquirer, unreviewed     |
+// | 6 | non-U.S. person WITH recorded clearance         |  pass  | GP review cleared it             |
+// | 7 | U.S. buyer whose jurisdiction is blocked-listed |  fail  | blocked-affiliation, needs review|
+//
+// Config/authorization
+// | # | case                          | expect              |
+// |---|-------------------------------|---------------------|
+// | 8 | setCfiusClearance zero buyer  | revert InvalidBuyer |
+// | 9 | setCfiusClearance by stranger | revert (not admin)  |
+// |10 | initialize zero badge         | revert InvalidBadge |
+// ─────────────────────────────────────────────────────────────────────────────
+
+contract CFIUSConditionTest is SecondaryConditionTestBase {
+    CFIUSCondition internal cfius;
+
+    function setUp() public {
+        _setUpBase();
+        cfius = _deploy(true, new string[](0));
+        badge.setInvestorJurisdiction(buyer, "US");
+        _postSellAndAccept(_sellOffer(), _sellEscrow());
+    }
+
+    function _deploy(bool tid, string[] memory blocked) internal returns (CFIUSCondition c) {
+        c = CFIUSCondition(
+            _proxy(
+                address(new CFIUSCondition()),
+                abi.encodeCall(CFIUSCondition.initialize, (address(auth), address(badge), tid, blocked))
+            )
+        );
+    }
+
+    function _check() internal view returns (bool) {
+        return cfius.checkCondition(IDealManager(address(dm)), bytes4(0), OFFER_ID, AGREEMENT_ID);
+    }
+
+    // 1
+    function test_Dormant_Passes() public {
+        cfius.setTidUsBusiness(false);
+        badge.setInvestorJurisdiction(buyer, "KY");
+        assertTrue(_check());
+    }
+
+    // 2
+    function test_Posting_NoBuyer_Passes() public view {
+        assertTrue(cfius.checkCondition(IDealManager(address(dm)), bytes4(0), OFFER_ID, bytes32(0)));
+    }
+
+    // 3
+    function test_UsBuyer_Unblocked_Passes() public view {
+        assertTrue(_check());
+    }
+
+    // 4
+    function test_NonUsPersonBadge_Fails() public {
+        badge.setValidKind(buyer, CategoryKind.NON_US_PERSON, "", true);
+        assertFalse(_check());
+    }
+
+    // 5
+    function test_NonUsJurisdiction_Fails() public {
+        badge.setInvestorJurisdiction(buyer, "KY");
+        assertFalse(_check());
+    }
+
+    // 6
+    function test_NonUsPerson_WithClearance_Passes() public {
+        badge.setValidKind(buyer, CategoryKind.NON_US_PERSON, "", true);
+        cfius.setCfiusClearance(buyer, true);
+        assertTrue(_check());
+    }
+
+    // 7
+    function test_UsBuyer_BlockedJurisdiction_Fails() public {
+        string[] memory blocked = new string[](1);
+        blocked[0] = "United States";
+        cfius = _deploy(true, blocked);
+        badge.setInvestorJurisdiction(buyer, "United States");
+        assertFalse(_check());
+    }
+
+    // 8
+    function test_SetClearance_ZeroBuyer_Reverts() public {
+        vm.expectRevert(CFIUSCondition.InvalidBuyer.selector);
+        cfius.setCfiusClearance(address(0), true);
+    }
+
+    // 9
+    function test_SetClearance_ByStranger_Reverts() public {
+        vm.prank(stranger);
+        vm.expectRevert();
+        cfius.setCfiusClearance(buyer, true);
+    }
+
+    // 10
+    function test_Initialize_ZeroBadge_Reverts() public {
+        CFIUSCondition impl = new CFIUSCondition();
+        vm.expectRevert(CFIUSCondition.InvalidBadge.selector);
+        _proxy(
+            address(impl), abi.encodeCall(CFIUSCondition.initialize, (address(auth), address(0), true, new string[](0)))
+        );
+    }
+}

--- a/test/conditions/secondary/ERISACondition.t.sol
+++ b/test/conditions/secondary/ERISACondition.t.sol
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.28;
+
+import {IDealManager} from "../../../src/interfaces/IDealManager.sol";
+import {ExemptionPathway, Offer, SecondaryEscrow} from "../../../src/interfaces/ISecondaryTradeStorage.sol";
+import {ERISACondition} from "../../../src/libs/conditions/secondary/ERISACondition.sol";
+import {SecondaryConditionTestBase} from "./SecondaryConditionMocks.sol";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ERISACondition — buyer's ERISA negative attestation (no plan assets).
+//
+// Legal/economic intent: keep "benefit plan investor" money out unless the buyer affirmatively
+// attests it holds no plan assets. The attestation is a party value recorded on the settlement
+// agreement at acceptance. Reg S trades are exempt (that pathway already requires a non-U.S. buyer),
+// so the condition is silent there; and it is silent at posting (no settlement agreement yet).
+//
+// Scenario × outcome
+// | # | context                         | attestation recorded | expect | rationale                       |
+// |---|---------------------------------|----------------------|:------:|---------------------------------|
+// | 1 | Reg S pathway                   |         no           |  pass  | silent for Reg S                |
+// | 2 | posting (no agreement)          |         n/a          |  pass  | no attestation surface yet      |
+// | 3 | accepted, exact attestation     |         yes          |  pass  | negative attestation on file    |
+// | 4 | accepted, no party values       |         no           |  fail  | attestation missing             |
+// | 5 | accepted, wrong value           |     wrong string     |  fail  | attestation does not match      |
+// | 6 | accepted, attestation among many|         yes          |  pass  | scan finds the marker           |
+//
+// Config/authorization
+// | # | case                               | expect                   |
+// |---|------------------------------------|--------------------------|
+// | 7 | initialize zero registry           | revert InvalidRegistry   |
+// | 8 | initialize empty attestation       | revert InvalidAttestation|
+// | 9 | updateAttestationValue empty       | revert InvalidAttestation|
+// |10 | updateRegistry by stranger         | revert (not admin)       |
+// ─────────────────────────────────────────────────────────────────────────────
+
+contract ERISAConditionTest is SecondaryConditionTestBase {
+    ERISACondition internal erisa;
+    string internal constant ATTEST = "ERISA:no-plan-assets";
+
+    function setUp() public {
+        _setUpBase();
+        erisa = ERISACondition(
+            _proxy(
+                address(new ERISACondition()),
+                abi.encodeCall(ERISACondition.initialize, (address(auth), address(registry), ATTEST))
+            )
+        );
+    }
+
+    function _check(bytes32 agreementId) internal view returns (bool) {
+        return erisa.checkCondition(IDealManager(address(dm)), bytes4(0), OFFER_ID, agreementId);
+    }
+
+    // 1
+    function test_RegS_Silent_Passes() public {
+        Offer memory o = _sellOffer();
+        o.exemptionPathway = ExemptionPathway.REGULATION_S;
+        _postSellAndAccept(o, _sellEscrow());
+        assertTrue(_check(AGREEMENT_ID));
+    }
+
+    // 2
+    function test_Posting_Silent_Passes() public {
+        dm.setOffer(OFFER_ID, _sellOffer());
+        assertTrue(_check(bytes32(0)));
+    }
+
+    // 3
+    function test_Accepted_ExactAttestation_Passes() public {
+        registry.setSignerValues(AGREEMENT_ID, buyer, _one(ATTEST));
+        _postSellAndAccept(_sellOffer(), _sellEscrow());
+        assertTrue(_check(AGREEMENT_ID));
+    }
+
+    // 4
+    function test_Accepted_NoValues_Fails() public {
+        _postSellAndAccept(_sellOffer(), _sellEscrow());
+        assertFalse(_check(AGREEMENT_ID));
+    }
+
+    // 5
+    function test_Accepted_WrongValue_Fails() public {
+        registry.setSignerValues(AGREEMENT_ID, buyer, _one("ERISA:is-a-plan"));
+        _postSellAndAccept(_sellOffer(), _sellEscrow());
+        assertFalse(_check(AGREEMENT_ID));
+    }
+
+    // 6
+    function test_Accepted_AttestationAmongMany_Passes() public {
+        string[] memory values = new string[](3);
+        values[0] = "some-other-field";
+        values[1] = ATTEST;
+        values[2] = "4a7:ack";
+        registry.setSignerValues(AGREEMENT_ID, buyer, values);
+        _postSellAndAccept(_sellOffer(), _sellEscrow());
+        assertTrue(_check(AGREEMENT_ID));
+    }
+
+    // 7
+    function test_Initialize_ZeroRegistry_Reverts() public {
+        ERISACondition impl = new ERISACondition();
+        vm.expectRevert(ERISACondition.InvalidRegistry.selector);
+        _proxy(address(impl), abi.encodeCall(ERISACondition.initialize, (address(auth), address(0), ATTEST)));
+    }
+
+    // 8
+    function test_Initialize_EmptyAttestation_Reverts() public {
+        ERISACondition impl = new ERISACondition();
+        vm.expectRevert(ERISACondition.InvalidAttestation.selector);
+        _proxy(address(impl), abi.encodeCall(ERISACondition.initialize, (address(auth), address(registry), "")));
+    }
+
+    // 9
+    function test_UpdateAttestationValue_Empty_Reverts() public {
+        vm.expectRevert(ERISACondition.InvalidAttestation.selector);
+        erisa.updateAttestationValue("");
+    }
+
+    // 10
+    function test_UpdateRegistry_ByStranger_Reverts() public {
+        vm.prank(stranger);
+        vm.expectRevert();
+        erisa.updateRegistry(address(registry));
+    }
+}

--- a/test/conditions/secondary/GPLPApprovalCondition.t.sol
+++ b/test/conditions/secondary/GPLPApprovalCondition.t.sol
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.28;
+
+import {IDealManager} from "../../../src/interfaces/IDealManager.sol";
+import {GPLPApprovalCondition} from "../../../src/libs/conditions/secondary/GPLPApprovalCondition.sol";
+import {SecondaryConditionTestBase} from "./SecondaryConditionMocks.sol";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GPLPApprovalCondition — per-deal GP/LP manual approval gate.
+//
+// Legal/economic intent: where governing documents require manual approval or LP-level consents
+// (spousal, co-investor), the deal cannot clear until the DealManager's designated approver signs off
+// on the specific deal — the offerId (pre-approving every settlement) or a specific
+// settlementAgreementId. Silent at posting; withdrawal bites at finalize (conditions re-run there).
+//
+// Scenario × outcome
+// | # | context   | approval present            | expect | rationale                     |
+// |---|-----------|-----------------------------|:------:|-------------------------------|
+// | 1 | posting   | n/a                         |  pass  | no settlement yet             |
+// | 2 | accepted  | none                        |  fail  | approval outstanding          |
+// | 3 | accepted  | approved on offerId         |  pass  | offer-level pre-approval      |
+// | 4 | accepted  | approved on settlementId    |  pass  | settlement-level approval     |
+// | 5 | accepted  | approved then withdrawn     |  fail  | withdrawal bites              |
+//
+// Config/authorization
+// | # | case                             | expect                    |
+// |---|----------------------------------|---------------------------|
+// | 6 | setApprover by non-owner         | revert (not owner)        |
+// | 7 | setApprover zero dealManager     | revert InvalidDealManager |
+// | 8 | setDealApproval by non-approver  | revert NotApprover        |
+// | 9 | setDealApproval zero dealId      | revert InvalidDealId      |
+// ─────────────────────────────────────────────────────────────────────────────
+
+contract GPLPApprovalConditionTest is SecondaryConditionTestBase {
+    GPLPApprovalCondition internal gplp;
+    address internal approver = makeAddr("approver");
+
+    function setUp() public {
+        _setUpBase();
+        gplp = GPLPApprovalCondition(
+            _proxy(
+                address(new GPLPApprovalCondition()), abi.encodeCall(GPLPApprovalCondition.initialize, (address(auth)))
+            )
+        );
+        gplp.setApprover(address(dm), approver);
+    }
+
+    function _check(bytes32 agreementId) internal view returns (bool) {
+        return gplp.checkCondition(IDealManager(address(dm)), bytes4(0), OFFER_ID, agreementId);
+    }
+
+    function _approve(bytes32 dealId, bool approved) internal {
+        vm.prank(approver);
+        gplp.setDealApproval(address(dm), dealId, approved);
+    }
+
+    // 1
+    function test_Posting_Silent_Passes() public view {
+        assertTrue(_check(bytes32(0)));
+    }
+
+    // 2
+    function test_Accepted_NoApproval_Fails() public view {
+        assertFalse(_check(AGREEMENT_ID));
+    }
+
+    // 3
+    function test_Accepted_ApprovedOnOffer_Passes() public {
+        _approve(OFFER_ID, true);
+        assertTrue(_check(AGREEMENT_ID));
+    }
+
+    // 4
+    function test_Accepted_ApprovedOnSettlement_Passes() public {
+        _approve(AGREEMENT_ID, true);
+        assertTrue(_check(AGREEMENT_ID));
+    }
+
+    // 5
+    function test_Accepted_ApprovalWithdrawn_Fails() public {
+        _approve(OFFER_ID, true);
+        assertTrue(_check(AGREEMENT_ID));
+        _approve(OFFER_ID, false);
+        assertFalse(_check(AGREEMENT_ID));
+    }
+
+    // 6
+    function test_SetApprover_ByNonOwner_Reverts() public {
+        vm.prank(stranger);
+        vm.expectRevert();
+        gplp.setApprover(address(dm), approver);
+    }
+
+    // 7
+    function test_SetApprover_ZeroDealManager_Reverts() public {
+        vm.expectRevert(GPLPApprovalCondition.InvalidDealManager.selector);
+        gplp.setApprover(address(0), approver);
+    }
+
+    // 8
+    function test_SetDealApproval_ByNonApprover_Reverts() public {
+        vm.prank(stranger);
+        vm.expectRevert(GPLPApprovalCondition.NotApprover.selector);
+        gplp.setDealApproval(address(dm), OFFER_ID, true);
+    }
+
+    // 9
+    function test_SetDealApproval_ZeroDealId_Reverts() public {
+        vm.prank(approver);
+        vm.expectRevert(GPLPApprovalCondition.InvalidDealId.selector);
+        gplp.setDealApproval(address(dm), bytes32(0), true);
+    }
+}

--- a/test/conditions/secondary/GlobalKillCondition.t.sol
+++ b/test/conditions/secondary/GlobalKillCondition.t.sol
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.28;
+
+import {IDealManager} from "../../../src/interfaces/IDealManager.sol";
+import {GlobalKillCondition} from "../../../src/libs/conditions/secondary/GlobalKillCondition.sol";
+import {SecondaryConditionTestBase} from "./SecondaryConditionMocks.sol";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GlobalKillCondition — platform-wide finalization kill switch (closing condition).
+//
+// Legal/economic intent: an emergency brake on settlement. Two admin slots (MetaLeX, Legion); either
+// can raise the flag unilaterally (fast response), but lowering takes both (one proposes, the other
+// confirms) so no single key can silently re-enable the platform. While raised, finalization is
+// blocked platform-wide. Each admin can rotate its own key.
+//
+// Scenario × outcome
+// |  # | scenario                                        | expect                       |
+// |----|-------------------------------------------------|------------------------------|
+// |  1 | fresh deployment                                | checkCondition true          |
+// |  2 | raised by MetaLeX admin                         | checkCondition false         |
+// |  3 | raised by Legion admin                          | checkCondition false         |
+// |  4 | raise by non-admin                              | revert NotKillAdmin          |
+// |  5 | raise while already killed                      | revert AlreadyKilled         |
+// |  6 | proposer tries to self-confirm the lower        | revert ProposerCannotConfirm |
+// |  7 | other admin confirms the lower                  | flag drops, checkCondition true |
+// |  8 | confirm with no pending proposal                | revert NoLowerProposal       |
+// |  9 | propose lower while not killed                  | revert NotKilled             |
+// | 10 | rotate own slot: new key works, old key barred  | rotation effective           |
+// | 11 | rotate to an existing admin address             | revert InvalidAdmin          |
+// | 12 | rotate by non-admin                             | revert NotKillAdmin          |
+// | 13 | construct with a zero admin                      | revert InvalidAdmin          |
+// | 14 | construct with identical admins                  | revert InvalidAdmin          |
+// ─────────────────────────────────────────────────────────────────────────────
+
+contract GlobalKillConditionTest is SecondaryConditionTestBase {
+    GlobalKillCondition internal kill;
+    address internal metalex = makeAddr("metalexAdmin");
+    address internal legion = makeAddr("legionAdmin");
+
+    function setUp() public {
+        _setUpBase();
+        kill = new GlobalKillCondition(metalex, legion);
+    }
+
+    function _check() internal view returns (bool) {
+        return kill.checkCondition(IDealManager(address(dm)), bytes4(0), OFFER_ID, AGREEMENT_ID);
+    }
+
+    // 1
+    function test_Fresh_NotKilled() public view {
+        assertTrue(_check());
+    }
+
+    // 2
+    function test_RaisedByMetalex_Blocks() public {
+        vm.prank(metalex);
+        kill.raiseKill();
+        assertFalse(_check());
+    }
+
+    // 3
+    function test_RaisedByLegion_Blocks() public {
+        vm.prank(legion);
+        kill.raiseKill();
+        assertFalse(_check());
+    }
+
+    // 4
+    function test_RaiseByNonAdmin_Reverts() public {
+        vm.prank(stranger);
+        vm.expectRevert(GlobalKillCondition.NotKillAdmin.selector);
+        kill.raiseKill();
+    }
+
+    // 5
+    function test_RaiseWhenAlreadyKilled_Reverts() public {
+        vm.prank(metalex);
+        kill.raiseKill();
+        vm.prank(legion);
+        vm.expectRevert(GlobalKillCondition.AlreadyKilled.selector);
+        kill.raiseKill();
+    }
+
+    // 6 & 7
+    function test_TwoCallLower() public {
+        vm.prank(metalex);
+        kill.raiseKill();
+
+        vm.prank(metalex);
+        kill.proposeLower();
+
+        // 6 — proposer cannot also confirm
+        vm.prank(metalex);
+        vm.expectRevert(GlobalKillCondition.ProposerCannotConfirm.selector);
+        kill.confirmLower();
+
+        // 7 — the other admin confirms and the flag drops
+        vm.prank(legion);
+        kill.confirmLower();
+        assertTrue(_check());
+    }
+
+    // 8
+    function test_ConfirmWithoutProposal_Reverts() public {
+        vm.prank(metalex);
+        kill.raiseKill();
+        vm.prank(legion);
+        vm.expectRevert(GlobalKillCondition.NoLowerProposal.selector);
+        kill.confirmLower();
+    }
+
+    // 9
+    function test_ProposeWhenNotKilled_Reverts() public {
+        vm.prank(metalex);
+        vm.expectRevert(GlobalKillCondition.NotKilled.selector);
+        kill.proposeLower();
+    }
+
+    // 10
+    function test_RotateOwnSlot() public {
+        address newMetalex = makeAddr("newMetalex");
+        vm.prank(metalex);
+        kill.rotateAdmin(newMetalex);
+
+        // Old key is no longer an admin.
+        vm.prank(metalex);
+        vm.expectRevert(GlobalKillCondition.NotKillAdmin.selector);
+        kill.raiseKill();
+
+        // New key works.
+        vm.prank(newMetalex);
+        kill.raiseKill();
+        assertFalse(_check());
+    }
+
+    // 11
+    function test_RotateToExistingAdmin_Reverts() public {
+        vm.prank(metalex);
+        vm.expectRevert(GlobalKillCondition.InvalidAdmin.selector);
+        kill.rotateAdmin(legion);
+    }
+
+    // 12
+    function test_RotateByNonAdmin_Reverts() public {
+        vm.prank(stranger);
+        vm.expectRevert(GlobalKillCondition.NotKillAdmin.selector);
+        kill.rotateAdmin(makeAddr("whoever"));
+    }
+
+    // 13
+    function test_Construct_ZeroAdmin_Reverts() public {
+        vm.expectRevert(GlobalKillCondition.InvalidAdmin.selector);
+        new GlobalKillCondition(address(0), legion);
+    }
+
+    // 14
+    function test_Construct_IdenticalAdmins_Reverts() public {
+        vm.expectRevert(GlobalKillCondition.InvalidAdmin.selector);
+        new GlobalKillCondition(metalex, metalex);
+    }
+}

--- a/test/conditions/secondary/HolderCapCondition.t.sol
+++ b/test/conditions/secondary/HolderCapCondition.t.sol
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.28;
+
+import {IDealManager} from "../../../src/interfaces/IDealManager.sol";
+import {Offer, SecondaryEscrow} from "../../../src/interfaces/ISecondaryTradeStorage.sol";
+import {HolderCapCondition} from "../../../src/libs/conditions/secondary/HolderCapCondition.sol";
+import {SecondaryConditionTestBase} from "./SecondaryConditionMocks.sol";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// HolderCapCondition — ICA §3(c)(1)/§3(c)(1)(C)/§3(c)(7) holder limits at transfer time.
+//
+// Legal/economic intent: keep the SPV within its Investment Company Act exception. A fresh holder
+// counts against the numeric cap (100 / 250); an existing holder increasing a position does not; a
+// look-through entity contributes its credentialed beneficial-owner count instead of 1; §3(c)(7)
+// funds have no numeric cap. Offshore variants: count only U.S. residents (Touche Remnant), or block
+// U.S. buyers outright. The count is read at acceptance/finalization, never at posting.
+//
+// Scenario × outcome (default deployment: §3(c)(1), cap = 100)
+// |  # | scenario                                        | expect | rationale                             |
+// |----|-------------------------------------------------|:------:|---------------------------------------|
+// |  1 | posting (no acquirer)                           |  pass  | cap evaluated later                   |
+// |  2 | fresh U.S. buyer, count 99 (+1 = 100)           |  pass  | lands exactly on the cap              |
+// |  3 | fresh U.S. buyer, count 100 (+1 = 101)          |  fail  | would breach the cap                  |
+// |  4 | existing holder (balance > 0), count 100        |  pass  | position increase, not a new holder   |
+// |  5 | entity look-through boCount 5, count 95 (=100)  |  pass  | 5 BOs flow through, lands on cap      |
+// |  6 | entity look-through boCount 5, count 96 (=101)  |  fail  | look-through breaches the cap         |
+// |  7 | §3(c)(7) (cap 0), fresh buyer, count 500        |  pass  | no numeric cap                        |
+// |  8 | blockUsInvestors, U.S. buyer                    |  fail  | offshore no-U.S.-investor floor       |
+// |  9 | blockUsInvestors, non-U.S. buyer                |  pass  | floor only bites U.S. buyers          |
+// | 10 | usResidentOnlyCount, non-U.S. buyer             |  pass  | non-U.S. acquirer not counted         |
+// | 11 | usResidentOnlyCount, fresh U.S. buyer at cap    |  fail  | only U.S. residents counted, breaches |
+//
+// Config/authorization
+// | # | case                              | expect              |
+// |---|-----------------------------------|---------------------|
+// |12 | initialize zero badge             | revert InvalidBadge |
+// |13 | updateConfig by stranger          | revert (not admin)  |
+// |14 | updateBadge by stranger           | revert (not admin)  |
+// ─────────────────────────────────────────────────────────────────────────────
+
+contract HolderCapConditionTest is SecondaryConditionTestBase {
+    HolderCapCondition internal holderCap;
+
+    function setUp() public {
+        _setUpBase();
+        holderCap = HolderCapCondition(
+            _proxy(
+                address(new HolderCapCondition()),
+                abi.encodeCall(
+                    HolderCapCondition.initialize,
+                    (address(auth), address(badge), HolderCapCondition.IcaException.SECTION_3C1, 100, false, false)
+                )
+            )
+        );
+        badge.setInvestorJurisdiction(buyer, "US");
+    }
+
+    function _check() internal returns (bool) {
+        _postSellAndAccept(_sellOffer(), _sellEscrow());
+        return holderCap.checkCondition(IDealManager(address(dm)), bytes4(0), OFFER_ID, AGREEMENT_ID);
+    }
+
+    // 1
+    function test_Posting_NoAcquirer_Passes() public {
+        dm.setOffer(OFFER_ID, _sellOffer());
+        assertTrue(holderCap.checkCondition(IDealManager(address(dm)), bytes4(0), OFFER_ID, bytes32(0)));
+    }
+
+    // 2
+    function test_FreshUsBuyer_LandsOnCap_Passes() public {
+        cert.setHolderCount(99);
+        assertTrue(_check());
+    }
+
+    // 3
+    function test_FreshUsBuyer_BreachesCap_Fails() public {
+        cert.setHolderCount(100);
+        assertFalse(_check());
+    }
+
+    // 4
+    function test_ExistingHolder_PositionIncrease_Passes() public {
+        cert.setHolderCount(100);
+        cert.setBalanceOfLegalOwner(buyer, 5);
+        assertTrue(_check());
+    }
+
+    // 5
+    function test_EntityLookThrough_LandsOnCap_Passes() public {
+        cert.setHolderCount(95);
+        badge.setBeneficialOwnerCount(buyer, 5);
+        assertTrue(_check());
+    }
+
+    // 6
+    function test_EntityLookThrough_BreachesCap_Fails() public {
+        cert.setHolderCount(96);
+        badge.setBeneficialOwnerCount(buyer, 5);
+        assertFalse(_check());
+    }
+
+    // 7
+    function test_Section3c7_NoNumericCap_Passes() public {
+        holderCap.updateConfig(HolderCapCondition.IcaException.SECTION_3C7, 0, false, false);
+        cert.setHolderCount(500);
+        assertTrue(_check());
+    }
+
+    // 8
+    function test_BlockUsInvestors_UsBuyer_Fails() public {
+        holderCap.updateConfig(HolderCapCondition.IcaException.SECTION_3C1, 100, false, true);
+        cert.setHolderCount(0);
+        assertFalse(_check());
+    }
+
+    // 9
+    function test_BlockUsInvestors_NonUsBuyer_Passes() public {
+        holderCap.updateConfig(HolderCapCondition.IcaException.SECTION_3C1, 100, false, true);
+        badge.setInvestorJurisdiction(buyer, "KY");
+        cert.setHolderCount(0);
+        assertTrue(_check());
+    }
+
+    // 10
+    function test_UsResidentOnlyCount_NonUsBuyer_NotCounted_Passes() public {
+        holderCap.updateConfig(HolderCapCondition.IcaException.SECTION_3C1, 1, true, false);
+        badge.setInvestorJurisdiction(buyer, "KY");
+        // Even with a "full" ledger, a non-U.S. acquirer does not add to the U.S.-resident count.
+        cert.setHolderCount(1);
+        assertTrue(_check());
+    }
+
+    // 11
+    function test_UsResidentOnlyCount_UsBuyerBreaches_Fails() public {
+        holderCap.updateConfig(HolderCapCondition.IcaException.SECTION_3C1, 1, true, false);
+        // Ledger: one U.S. resident and one non-U.S. holder; only the U.S. one counts (= 1). A fresh
+        // U.S. buyer would make 2 > cap 1.
+        address usHolder = makeAddr("usHolder");
+        address nonUsHolder = makeAddr("nonUsHolder");
+        badge.setInvestorJurisdiction(usHolder, "US");
+        badge.setInvestorJurisdiction(nonUsHolder, "KY");
+        cert.setTotalSupply(2);
+        cert.setTokenAt(0, 10, usHolder);
+        cert.setTokenAt(1, 11, nonUsHolder);
+        assertFalse(_check());
+    }
+
+    // 12
+    function test_Initialize_ZeroBadge_Reverts() public {
+        HolderCapCondition impl = new HolderCapCondition();
+        vm.expectRevert(HolderCapCondition.InvalidBadge.selector);
+        _proxy(
+            address(impl),
+            abi.encodeCall(
+                HolderCapCondition.initialize,
+                (address(auth), address(0), HolderCapCondition.IcaException.SECTION_3C1, 100, false, false)
+            )
+        );
+    }
+
+    // 13
+    function test_UpdateConfig_ByStranger_Reverts() public {
+        vm.prank(stranger);
+        vm.expectRevert();
+        holderCap.updateConfig(HolderCapCondition.IcaException.SECTION_3C7, 0, false, false);
+    }
+
+    // 14
+    function test_UpdateBadge_ByStranger_Reverts() public {
+        vm.prank(stranger);
+        vm.expectRevert();
+        holderCap.updateBadge(address(badge));
+    }
+}

--- a/test/conditions/secondary/HolderCapCondition.t.sol
+++ b/test/conditions/secondary/HolderCapCondition.t.sol
@@ -21,7 +21,7 @@ import {SecondaryConditionTestBase} from "./SecondaryConditionMocks.sol";
 // |  1 | posting (no acquirer)                           |  pass  | cap evaluated later                   |
 // |  2 | fresh U.S. buyer, count 99 (+1 = 100)           |  pass  | lands exactly on the cap              |
 // |  3 | fresh U.S. buyer, count 100 (+1 = 101)          |  fail  | would breach the cap                  |
-// |  4 | existing holder (balance > 0), count 100        |  pass  | position increase, not a new holder   |
+// |  4 | existing holder (isLegalHolder), count 100      |  pass  | position increase, not a new holder   |
 // |  5 | entity look-through boCount 5, count 95 (=100)  |  pass  | 5 BOs flow through, lands on cap      |
 // |  6 | entity look-through boCount 5, count 96 (=101)  |  fail  | look-through breaches the cap         |
 // |  7 | §3(c)(7) (cap 0), fresh buyer, count 500        |  pass  | no numeric cap                        |
@@ -68,33 +68,33 @@ contract HolderCapConditionTest is SecondaryConditionTestBase {
 
     // 2
     function test_FreshUsBuyer_LandsOnCap_Passes() public {
-        cert.setHolderCount(99);
+        cert.setLookThroughHolderCount(99);
         assertTrue(_check());
     }
 
     // 3
     function test_FreshUsBuyer_BreachesCap_Fails() public {
-        cert.setHolderCount(100);
+        cert.setLookThroughHolderCount(100);
         assertFalse(_check());
     }
 
     // 4
     function test_ExistingHolder_PositionIncrease_Passes() public {
-        cert.setHolderCount(100);
-        cert.setBalanceOfLegalOwner(buyer, 5);
+        cert.setLookThroughHolderCount(100);
+        cert.setIsLegalHolder(buyer, true);
         assertTrue(_check());
     }
 
     // 5
     function test_EntityLookThrough_LandsOnCap_Passes() public {
-        cert.setHolderCount(95);
+        cert.setLookThroughHolderCount(95);
         badge.setBeneficialOwnerCount(buyer, 5);
         assertTrue(_check());
     }
 
     // 6
     function test_EntityLookThrough_BreachesCap_Fails() public {
-        cert.setHolderCount(96);
+        cert.setLookThroughHolderCount(96);
         badge.setBeneficialOwnerCount(buyer, 5);
         assertFalse(_check());
     }
@@ -102,14 +102,14 @@ contract HolderCapConditionTest is SecondaryConditionTestBase {
     // 7
     function test_Section3c7_NoNumericCap_Passes() public {
         holderCap.updateConfig(HolderCapCondition.IcaException.SECTION_3C7, 0, false, false);
-        cert.setHolderCount(500);
+        cert.setLookThroughHolderCount(500);
         assertTrue(_check());
     }
 
     // 8
     function test_BlockUsInvestors_UsBuyer_Fails() public {
         holderCap.updateConfig(HolderCapCondition.IcaException.SECTION_3C1, 100, false, true);
-        cert.setHolderCount(0);
+        cert.setLookThroughHolderCount(0);
         assertFalse(_check());
     }
 
@@ -117,7 +117,7 @@ contract HolderCapConditionTest is SecondaryConditionTestBase {
     function test_BlockUsInvestors_NonUsBuyer_Passes() public {
         holderCap.updateConfig(HolderCapCondition.IcaException.SECTION_3C1, 100, false, true);
         badge.setInvestorJurisdiction(buyer, "KY");
-        cert.setHolderCount(0);
+        cert.setLookThroughHolderCount(0);
         assertTrue(_check());
     }
 
@@ -125,23 +125,18 @@ contract HolderCapConditionTest is SecondaryConditionTestBase {
     function test_UsResidentOnlyCount_NonUsBuyer_NotCounted_Passes() public {
         holderCap.updateConfig(HolderCapCondition.IcaException.SECTION_3C1, 1, true, false);
         badge.setInvestorJurisdiction(buyer, "KY");
-        // Even with a "full" ledger, a non-U.S. acquirer does not add to the U.S.-resident count.
-        cert.setHolderCount(1);
+        // Even with a "full" U.S. tally, a non-U.S. acquirer does not add to the U.S.-resident count.
+        cert.setUsLookThroughHolderCount(1);
         assertTrue(_check());
     }
 
     // 11
     function test_UsResidentOnlyCount_UsBuyerBreaches_Fails() public {
         holderCap.updateConfig(HolderCapCondition.IcaException.SECTION_3C1, 1, true, false);
-        // Ledger: one U.S. resident and one non-U.S. holder; only the U.S. one counts (= 1). A fresh
-        // U.S. buyer would make 2 > cap 1.
-        address usHolder = makeAddr("usHolder");
-        address nonUsHolder = makeAddr("nonUsHolder");
-        badge.setInvestorJurisdiction(usHolder, "US");
-        badge.setInvestorJurisdiction(nonUsHolder, "KY");
-        cert.setTotalSupply(2);
-        cert.setTokenAt(0, 10, usHolder);
-        cert.setTokenAt(1, 11, nonUsHolder);
+        // The printer's U.S.-resident look-through tally already stands at the cap (= 1). A fresh U.S.
+        // buyer would make 2 > cap 1. (The base is the printer's maintained count; the base-side
+        // look-through math itself is covered in CyberCertPrinterTest.)
+        cert.setUsLookThroughHolderCount(1);
         assertFalse(_check());
     }
 

--- a/test/conditions/secondary/HoldingPeriodCondition.t.sol
+++ b/test/conditions/secondary/HoldingPeriodCondition.t.sol
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.28;
+
+import {IDealManager} from "../../../src/interfaces/IDealManager.sol";
+import {Offer, OfferSide, SecondaryEscrow} from "../../../src/interfaces/ISecondaryTradeStorage.sol";
+import {HoldingPeriodCondition} from "../../../src/libs/conditions/secondary/HoldingPeriodCondition.sol";
+import {FundInterestData} from "../../../src/storage/extensions/FundInterestExtension.sol";
+import {SecondaryConditionTestBase} from "./SecondaryConditionMocks.sol";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// HoldingPeriodCondition — Rule 144 holding-period verification.
+//
+// Legal/economic intent: a Rule 144 resale requires the seller's lot to have seasoned for the
+// required hold (one year for non-reporting issuers). The anchor is the lot's base acquisition
+// timestamp; where Rule 144(d)(3) tacking is asserted (non-zero tackedFrom), the EARLIER date
+// governs. A missing anchor fails closed. A bid at posting has no seller yet, so it is verified later.
+//
+// Scenario × outcome (hold = 365 days)
+// | # | scenario                                          | expect | rationale                          |
+// |---|---------------------------------------------------|:------:|------------------------------------|
+// | 1 | no acquisition record (anchor 0)                  |  fail  | fail closed                        |
+// | 2 | acquired exactly 365 d ago                        |  pass  | hold satisfied (>=)                |
+// | 3 | acquired 364 d ago                                |  fail  | one day short                      |
+// | 4 | acquired 10 d ago, tacked from 400 d ago          |  pass  | tacking anchor governs (earlier)   |
+// | 5 | acquired 10 d ago, tacked from 5 d ago            |  fail  | tacking ignored (not earlier)      |
+// | 6 | acquired 10 d ago, no tacking asserted (0)        |  fail  | base anchor governs                |
+// | 7 | BUY offer at posting                              |  pass  | seller/hold verified at acceptance |
+//
+// Config/authorization
+// | # | case                          | expect                      |
+// |---|-------------------------------|-----------------------------|
+// | 8 | initialize zero holding       | revert InvalidHoldingPeriod |
+// | 9 | updateHoldingPeriod zero      | revert InvalidHoldingPeriod |
+// |10 | updateHoldingPeriod stranger  | revert (not admin)          |
+// ─────────────────────────────────────────────────────────────────────────────
+
+contract HoldingPeriodConditionTest is SecondaryConditionTestBase {
+    HoldingPeriodCondition internal hold;
+    uint64 internal constant HOLD = 365 days;
+    uint256 internal constant NOW = 500 days;
+
+    function setUp() public {
+        _setUpBase();
+        vm.warp(NOW);
+        hold = HoldingPeriodCondition(
+            _proxy(
+                address(new HoldingPeriodCondition()),
+                abi.encodeCall(HoldingPeriodCondition.initialize, (address(auth), HOLD))
+            )
+        );
+    }
+
+    function _sellPosting(uint64 anchor, uint64 tackedFrom) internal returns (bool) {
+        cert.setAcquisitionTimestamp(1, anchor);
+        cert.setExtensionData(
+            1,
+            abi.encode(
+                FundInterestData({acquisitionDate: 0, tackedFromAcquisitionDate: tackedFrom, customProvisions: ""})
+            )
+        );
+        dm.setOffer(OFFER_ID, _sellOffer());
+        return hold.checkCondition(IDealManager(address(dm)), bytes4(0), OFFER_ID, bytes32(0));
+    }
+
+    // 1
+    function test_NoRecord_FailsClosed() public {
+        dm.setOffer(OFFER_ID, _sellOffer());
+        assertFalse(hold.checkCondition(IDealManager(address(dm)), bytes4(0), OFFER_ID, bytes32(0)));
+    }
+
+    // 2
+    function test_ExactlyHold_Passes() public {
+        assertTrue(_sellPosting(uint64(NOW) - HOLD, 0));
+    }
+
+    // 3
+    function test_OneDayShort_Fails() public {
+        assertFalse(_sellPosting(uint64(NOW) - (HOLD - 1 days), 0));
+    }
+
+    // 4
+    function test_TackingEarlier_Passes() public {
+        assertTrue(_sellPosting(uint64(NOW) - 10 days, uint64(NOW) - 400 days));
+    }
+
+    // 5
+    function test_TackingNotEarlier_Ignored_Fails() public {
+        assertFalse(_sellPosting(uint64(NOW) - 10 days, uint64(NOW) - 5 days));
+    }
+
+    // 6
+    function test_NoTacking_BaseAnchorGoverns_Fails() public {
+        assertFalse(_sellPosting(uint64(NOW) - 10 days, 0));
+    }
+
+    // 7
+    function test_BuyPosting_Passes() public {
+        Offer memory o = _sellOffer();
+        o.side = OfferSide.BUY;
+        o.tokenId = 0;
+        dm.setOffer(OFFER_ID, o);
+        assertTrue(hold.checkCondition(IDealManager(address(dm)), bytes4(0), OFFER_ID, bytes32(0)));
+    }
+
+    // 8
+    function test_Initialize_ZeroHolding_Reverts() public {
+        HoldingPeriodCondition impl = new HoldingPeriodCondition();
+        vm.expectRevert(HoldingPeriodCondition.InvalidHoldingPeriod.selector);
+        _proxy(address(impl), abi.encodeCall(HoldingPeriodCondition.initialize, (address(auth), 0)));
+    }
+
+    // 9
+    function test_UpdateHoldingPeriod_Zero_Reverts() public {
+        vm.expectRevert(HoldingPeriodCondition.InvalidHoldingPeriod.selector);
+        hold.updateHoldingPeriod(0);
+    }
+
+    // 10
+    function test_UpdateHoldingPeriod_ByStranger_Reverts() public {
+        vm.prank(stranger);
+        vm.expectRevert();
+        hold.updateHoldingPeriod(30 days);
+    }
+}

--- a/test/conditions/secondary/KYCAMLCondition.t.sol
+++ b/test/conditions/secondary/KYCAMLCondition.t.sol
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.28;
+
+import {CategoryKind} from "../../../src/creds/storage/lexchexBadgeStorage.sol";
+import {IDealManager} from "../../../src/interfaces/IDealManager.sol";
+import {Offer, OfferSide, SecondaryEscrow} from "../../../src/interfaces/ISecondaryTradeStorage.sol";
+import {BorgAuth} from "../../../src/libs/auth.sol";
+import {KYCAMLCondition} from "../../../src/libs/conditions/secondary/KYCAMLCondition.sol";
+import {SecondaryConditionTestBase} from "./SecondaryConditionMocks.sol";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// KYCAMLCondition — both parties must hold a valid, unexpired KYC/AML badge.
+//
+// Legal/economic intent: a KYC/AML gate on every counterparty; an unvetted, revoked, or
+// never-onboarded party cannot clear a secondary trade. Buyer is unknown at posting, so
+// buyer-facing checks short-circuit until a settlement exists.
+//
+// Scenario × outcome
+// | # | context            | seller KYC | buyer KYC | expect | rationale                              |
+// |---|--------------------|:----------:|:---------:|:------:|----------------------------------------|
+// | 1 | SELL posting       |    yes     |    n/a    |  pass  | buyer unknown, seller vetted           |
+// | 2 | SELL posting       |     no     |    n/a    |  fail  | seller not onboarded                   |
+// | 3 | SELL accepted      |    yes     |    yes    |  pass  | both vetted                            |
+// | 4 | SELL accepted      |    yes     |     no    |  fail  | buyer not onboarded                    |
+// | 5 | SELL accepted      |     no     |    yes    |  fail  | seller credential lapsed post-listing  |
+// | 6 | BUY posting        |    n/a     |    yes    |  pass  | offeror is the buyer, vetted           |
+// | 7 | BUY posting        |    n/a     |     no    |  fail  | bidder not onboarded                   |
+//
+// Config/authorization
+// | # | case                                    | expect                 |
+// |---|-----------------------------------------|------------------------|
+// | 8 | initialize with zero badge              | revert InvalidBadge    |
+// | 9 | updateBadge by owner                     | badge updated          |
+// |10 | updateBadge by stranger                  | revert (not admin)     |
+// |11 | updateBadge to zero                      | revert InvalidBadge    |
+// ─────────────────────────────────────────────────────────────────────────────
+
+contract KYCAMLConditionTest is SecondaryConditionTestBase {
+    KYCAMLCondition internal kyc;
+
+    function setUp() public {
+        _setUpBase();
+        kyc = KYCAMLCondition(
+            _proxy(
+                address(new KYCAMLCondition()),
+                abi.encodeCall(KYCAMLCondition.initialize, (address(auth), address(badge)))
+            )
+        );
+    }
+
+    function _kyc(address who, bool v) internal {
+        badge.setValidKind(who, CategoryKind.KYC_AML, "", v);
+    }
+
+    function _check(bytes32 agreementId) internal view returns (bool) {
+        return kyc.checkCondition(IDealManager(address(dm)), bytes4(0), OFFER_ID, agreementId);
+    }
+
+    // 1
+    function test_SellPosting_SellerVetted_Passes() public {
+        _kyc(seller, true);
+        dm.setOffer(OFFER_ID, _sellOffer());
+        assertTrue(_check(bytes32(0)));
+    }
+
+    // 2
+    function test_SellPosting_SellerUnvetted_Fails() public {
+        dm.setOffer(OFFER_ID, _sellOffer());
+        assertFalse(_check(bytes32(0)));
+    }
+
+    // 3
+    function test_SellAccepted_BothVetted_Passes() public {
+        _kyc(seller, true);
+        _kyc(buyer, true);
+        _postSellAndAccept(_sellOffer(), _sellEscrow());
+        assertTrue(_check(AGREEMENT_ID));
+    }
+
+    // 4
+    function test_SellAccepted_BuyerUnvetted_Fails() public {
+        _kyc(seller, true);
+        _postSellAndAccept(_sellOffer(), _sellEscrow());
+        assertFalse(_check(AGREEMENT_ID));
+    }
+
+    // 5
+    function test_SellAccepted_SellerCredentialLapsed_Fails() public {
+        _kyc(buyer, true);
+        _postSellAndAccept(_sellOffer(), _sellEscrow());
+        assertFalse(_check(AGREEMENT_ID));
+    }
+
+    // 6 & 7
+    function test_BuyPosting_BidderVettedGate() public {
+        Offer memory o = _sellOffer();
+        o.side = OfferSide.BUY;
+        o.offeror = buyer;
+        o.tokenId = 0;
+        dm.setOffer(OFFER_ID, o);
+
+        assertFalse(_check(bytes32(0)));
+        _kyc(buyer, true);
+        assertTrue(_check(bytes32(0)));
+    }
+
+    // 8
+    function test_Initialize_ZeroBadge_Reverts() public {
+        KYCAMLCondition impl = new KYCAMLCondition();
+        vm.expectRevert(KYCAMLCondition.InvalidBadge.selector);
+        _proxy(address(impl), abi.encodeCall(KYCAMLCondition.initialize, (address(auth), address(0))));
+    }
+
+    // 9
+    function test_UpdateBadge_ByOwner_Succeeds() public {
+        MockBadgeLike b = new MockBadgeLike();
+        kyc.updateBadge(address(b));
+        assertEq(address(kyc.badge()), address(b));
+    }
+
+    // 10
+    function test_UpdateBadge_ByStranger_Reverts() public {
+        vm.prank(stranger);
+        vm.expectRevert();
+        kyc.updateBadge(address(badge));
+    }
+
+    // 11
+    function test_UpdateBadge_Zero_Reverts() public {
+        vm.expectRevert(KYCAMLCondition.InvalidBadge.selector);
+        kyc.updateBadge(address(0));
+    }
+}
+
+// Minimal non-zero address that can stand in as a badge for the updateBadge success path.
+contract MockBadgeLike {}

--- a/test/conditions/secondary/LegalOpinionCondition.t.sol
+++ b/test/conditions/secondary/LegalOpinionCondition.t.sol
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.28;
+
+import {IDealManager} from "../../../src/interfaces/IDealManager.sol";
+import {Offer, SecondaryEscrow} from "../../../src/interfaces/ISecondaryTradeStorage.sol";
+import {LegalOpinionCondition} from "../../../src/libs/conditions/secondary/LegalOpinionCondition.sol";
+import {SecondaryConditionTestBase} from "./SecondaryConditionMocks.sol";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// LegalOpinionCondition — §4(a)(1½) GP/issuer-counsel assurance gate.
+//
+// Legal/economic intent: a §4(a)(1½) resale needs the GP's compliance sign-off or a formal legal
+// opinion. Each SPV chooses the mechanism (EITHER by default, or only GP sign-off, or only a formal
+// opinion). Assurance is per-deal — keyed by the offerId (pre-approving every settlement) or a
+// specific settlementAgreementId — and is silent at posting. Revoking sign-off bites at finalize
+// because threshold conditions re-run there.
+//
+// Scenario × outcome
+// | # | mechanism | context  | assurance present            | expect | rationale                     |
+// |---|-----------|----------|------------------------------|:------:|-------------------------------|
+// | 1 | EITHER    | posting  | none                         |  pass  | silent, no settlement yet     |
+// | 2 | EITHER    | accepted | none                         |  fail  | no assurance recorded         |
+// | 3 | EITHER    | accepted | GP sign-off on offerId       |  pass  | offer-level pre-approval      |
+// | 4 | EITHER    | accepted | GP sign-off on settlementId  |  pass  | settlement-level approval     |
+// | 5 | EITHER    | accepted | formal opinion on offerId    |  pass  | opinion satisfies             |
+// | 6 | GP_SIGNOFF| accepted | formal opinion only          |  fail  | mechanism requires sign-off   |
+// | 7 | GP_SIGNOFF| accepted | GP sign-off                  |  pass  | mechanism satisfied           |
+// | 8 | FORMAL    | accepted | GP sign-off only             |  fail  | mechanism requires opinion    |
+// | 9 | EITHER    | accepted | sign-off recorded then revoked|  fail | revocation bites at finalize  |
+//
+// Config/authorization
+// | # | case                              | expect                 |
+// |---|-----------------------------------|------------------------|
+// |10 | recordGPSignOff zero dealManager  | revert InvalidDealManager |
+// |11 | recordGPSignOff zero dealId       | revert InvalidDealId   |
+// |12 | recordGPSignOff by non-admin      | revert (not admin)     |
+// |13 | submitOpinion zero hash           | revert InvalidOpinionHash |
+// |14 | setMechanism by non-SPV-admin     | revert (not admin)     |
+// ─────────────────────────────────────────────────────────────────────────────
+
+contract LegalOpinionConditionTest is SecondaryConditionTestBase {
+    LegalOpinionCondition internal legal;
+
+    function setUp() public {
+        _setUpBase();
+        legal = LegalOpinionCondition(
+            _proxy(
+                address(new LegalOpinionCondition()), abi.encodeCall(LegalOpinionCondition.initialize, (address(auth)))
+            )
+        );
+        _postSellAndAccept(_sellOffer(), _sellEscrow());
+    }
+
+    function _check(bytes32 agreementId) internal view returns (bool) {
+        return legal.checkCondition(IDealManager(address(dm)), bytes4(0), OFFER_ID, agreementId);
+    }
+
+    // 1
+    function test_Posting_Silent_Passes() public view {
+        assertTrue(_check(bytes32(0)));
+    }
+
+    // 2
+    function test_Accepted_NoAssurance_Fails() public view {
+        assertFalse(_check(AGREEMENT_ID));
+    }
+
+    // 3
+    function test_Either_SignOffOnOffer_Passes() public {
+        legal.recordGPSignOff(address(dm), OFFER_ID);
+        assertTrue(_check(AGREEMENT_ID));
+    }
+
+    // 4
+    function test_Either_SignOffOnSettlement_Passes() public {
+        legal.recordGPSignOff(address(dm), AGREEMENT_ID);
+        assertTrue(_check(AGREEMENT_ID));
+    }
+
+    // 5
+    function test_Either_FormalOpinion_Passes() public {
+        legal.submitOpinion(address(dm), OFFER_ID, keccak256("opinion"), "ipfs://opinion");
+        assertTrue(_check(AGREEMENT_ID));
+    }
+
+    // 6
+    function test_GpSignoffMechanism_OpinionOnly_Fails() public {
+        legal.setMechanism(address(dm), LegalOpinionCondition.OpinionMechanism.GP_SIGNOFF);
+        legal.submitOpinion(address(dm), OFFER_ID, keccak256("opinion"), "ipfs://opinion");
+        assertFalse(_check(AGREEMENT_ID));
+    }
+
+    // 7
+    function test_GpSignoffMechanism_SignOff_Passes() public {
+        legal.setMechanism(address(dm), LegalOpinionCondition.OpinionMechanism.GP_SIGNOFF);
+        legal.recordGPSignOff(address(dm), OFFER_ID);
+        assertTrue(_check(AGREEMENT_ID));
+    }
+
+    // 8
+    function test_FormalMechanism_SignOffOnly_Fails() public {
+        legal.setMechanism(address(dm), LegalOpinionCondition.OpinionMechanism.FORMAL_OPINION);
+        legal.recordGPSignOff(address(dm), OFFER_ID);
+        assertFalse(_check(AGREEMENT_ID));
+    }
+
+    // 9
+    function test_SignOffRevoked_Fails() public {
+        legal.recordGPSignOff(address(dm), OFFER_ID);
+        assertTrue(_check(AGREEMENT_ID));
+        legal.revokeGPSignOff(address(dm), OFFER_ID);
+        assertFalse(_check(AGREEMENT_ID));
+    }
+
+    // 10
+    function test_RecordSignOff_ZeroDealManager_Reverts() public {
+        vm.expectRevert(LegalOpinionCondition.InvalidDealManager.selector);
+        legal.recordGPSignOff(address(0), OFFER_ID);
+    }
+
+    // 11
+    function test_RecordSignOff_ZeroDealId_Reverts() public {
+        vm.expectRevert(LegalOpinionCondition.InvalidDealId.selector);
+        legal.recordGPSignOff(address(dm), bytes32(0));
+    }
+
+    // 12
+    function test_RecordSignOff_ByNonAdmin_Reverts() public {
+        vm.prank(stranger);
+        vm.expectRevert();
+        legal.recordGPSignOff(address(dm), OFFER_ID);
+    }
+
+    // 13
+    function test_SubmitOpinion_ZeroHash_Reverts() public {
+        vm.expectRevert(LegalOpinionCondition.InvalidOpinionHash.selector);
+        legal.submitOpinion(address(dm), OFFER_ID, bytes32(0), "ipfs://opinion");
+    }
+
+    // 14
+    function test_SetMechanism_ByNonSpvAdmin_Reverts() public {
+        vm.prank(stranger);
+        vm.expectRevert();
+        legal.setMechanism(address(dm), LegalOpinionCondition.OpinionMechanism.GP_SIGNOFF);
+    }
+}

--- a/test/conditions/secondary/LegionSoulboundCondition.t.sol
+++ b/test/conditions/secondary/LegionSoulboundCondition.t.sol
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.28;
+
+import {IDealManager} from "../../../src/interfaces/IDealManager.sol";
+import {Offer, OfferSide, SecondaryEscrow} from "../../../src/interfaces/ISecondaryTradeStorage.sol";
+import {LegionSoulboundCondition} from "../../../src/libs/conditions/secondary/LegionSoulboundCondition.sol";
+import {SecondaryConditionTestBase} from "./SecondaryConditionMocks.sol";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// LegionSoulboundCondition — issuer-specific credential category/tier gate.
+//
+// Legal/economic intent: enforce issuer-specific gating not captured by generic credentials —
+// syndicate-circle restrictions, non-accredited-tier requirements. Configured with a required
+// category and whether it applies to the buyer only, or buyer and seller.
+//
+// Scenario × outcome
+// | # | applyToSeller | context       | buyer cred | seller cred | expect | rationale                     |
+// |---|:-------------:|---------------|:----------:|:-----------:|:------:|-------------------------------|
+// | 1 |      no       | SELL posting  |    n/a     |     no      |  pass  | buyer unknown, seller ungated |
+// | 2 |      no       | accepted      |    yes     |     no      |  pass  | buyer in the circle           |
+// | 3 |      no       | accepted      |     no     |     yes     |  fail  | buyer not in the circle       |
+// | 4 |     yes       | accepted      |    yes     |     no      |  fail  | seller also gated             |
+// | 5 |     yes       | accepted      |    yes     |     yes     |  pass  | both in the circle            |
+// | 6 |     yes       | SELL posting  |    n/a     |     no      |  fail  | seller gated even at posting  |
+//
+// Config/authorization
+// | # | case                            | expect                |
+// |---|---------------------------------|-----------------------|
+// | 7 | initialize zero badge           | revert InvalidBadge   |
+// | 8 | initialize zero category        | revert InvalidCategory|
+// | 9 | updateConfig by stranger        | revert (not admin)    |
+// ─────────────────────────────────────────────────────────────────────────────
+
+contract LegionSoulboundConditionTest is SecondaryConditionTestBase {
+    LegionSoulboundCondition internal legion;
+    bytes32 internal constant CAT = keccak256("cat.legion");
+
+    function setUp() public {
+        _setUpBase();
+        legion = _deploy(false);
+    }
+
+    function _deploy(bool applyToSeller) internal returns (LegionSoulboundCondition c) {
+        c = LegionSoulboundCondition(
+            _proxy(
+                address(new LegionSoulboundCondition()),
+                abi.encodeCall(LegionSoulboundCondition.initialize, (address(auth), address(badge), CAT, applyToSeller))
+            )
+        );
+    }
+
+    function _check(LegionSoulboundCondition c, bytes32 agreementId) internal view returns (bool) {
+        return c.checkCondition(IDealManager(address(dm)), bytes4(0), OFFER_ID, agreementId);
+    }
+
+    // 1
+    function test_BuyerOnly_Posting_SellerUngated_Passes() public {
+        dm.setOffer(OFFER_ID, _sellOffer());
+        assertTrue(_check(legion, bytes32(0)));
+    }
+
+    // 2
+    function test_BuyerOnly_Accepted_BuyerInCircle_Passes() public {
+        badge.setValidCredential(buyer, CAT, true);
+        _postSellAndAccept(_sellOffer(), _sellEscrow());
+        assertTrue(_check(legion, AGREEMENT_ID));
+    }
+
+    // 3
+    function test_BuyerOnly_Accepted_BuyerNotInCircle_Fails() public {
+        badge.setValidCredential(seller, CAT, true);
+        _postSellAndAccept(_sellOffer(), _sellEscrow());
+        assertFalse(_check(legion, AGREEMENT_ID));
+    }
+
+    // 4
+    function test_ApplyToSeller_SellerMissing_Fails() public {
+        LegionSoulboundCondition c = _deploy(true);
+        badge.setValidCredential(buyer, CAT, true);
+        _postSellAndAccept(_sellOffer(), _sellEscrow());
+        assertFalse(_check(c, AGREEMENT_ID));
+    }
+
+    // 5
+    function test_ApplyToSeller_BothInCircle_Passes() public {
+        LegionSoulboundCondition c = _deploy(true);
+        badge.setValidCredential(buyer, CAT, true);
+        badge.setValidCredential(seller, CAT, true);
+        _postSellAndAccept(_sellOffer(), _sellEscrow());
+        assertTrue(_check(c, AGREEMENT_ID));
+    }
+
+    // 6
+    function test_ApplyToSeller_Posting_SellerMissing_Fails() public {
+        LegionSoulboundCondition c = _deploy(true);
+        dm.setOffer(OFFER_ID, _sellOffer());
+        assertFalse(_check(c, bytes32(0)));
+    }
+
+    // 7
+    function test_Initialize_ZeroBadge_Reverts() public {
+        LegionSoulboundCondition impl = new LegionSoulboundCondition();
+        vm.expectRevert(LegionSoulboundCondition.InvalidBadge.selector);
+        _proxy(
+            address(impl), abi.encodeCall(LegionSoulboundCondition.initialize, (address(auth), address(0), CAT, false))
+        );
+    }
+
+    // 8
+    function test_Initialize_ZeroCategory_Reverts() public {
+        LegionSoulboundCondition impl = new LegionSoulboundCondition();
+        vm.expectRevert(LegionSoulboundCondition.InvalidCategory.selector);
+        _proxy(
+            address(impl),
+            abi.encodeCall(LegionSoulboundCondition.initialize, (address(auth), address(badge), bytes32(0), false))
+        );
+    }
+
+    // 9
+    function test_UpdateConfig_ByStranger_Reverts() public {
+        vm.prank(stranger);
+        vm.expectRevert();
+        legion.updateConfig(address(badge), CAT, true);
+    }
+}

--- a/test/conditions/secondary/LexChexBadgeKindCondition.t.sol
+++ b/test/conditions/secondary/LexChexBadgeKindCondition.t.sol
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.28;
+
+import {CategoryKind} from "../../../src/creds/storage/lexchexBadgeStorage.sol";
+import {IDealManager} from "../../../src/interfaces/IDealManager.sol";
+import {Offer, SecondaryEscrow} from "../../../src/interfaces/ISecondaryTradeStorage.sol";
+import {LexChexBadgeKindCondition} from "../../../src/libs/conditions/secondary/LexChexBadgeKindCondition.sol";
+import {SecondaryConditionTestBase} from "./SecondaryConditionMocks.sol";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// LexChexBadgeKindCondition — parameterizable investor-status gate on the LeXcheXBadge layer.
+//
+// Legal/economic intent: one primitive deployed per investor-status parameterization —
+// AccreditedInvestor (buyer only, §4(a)(7)), QIB (buyer only, Rule 144A), QualifiedPurchaser
+// (buyer + seller, §3(c)(7)). An optional investorType filter narrows within the kind.
+//
+// Scenario × outcome
+// | # | config                 | context      | buyer status | seller status | expect | rationale             |
+// |---|------------------------|--------------|:------------:|:-------------:|:------:|-----------------------|
+// | 1 | ACCREDITED, buyer-only | SELL posting |     n/a      |      no       |  pass  | seller ungated        |
+// | 2 | ACCREDITED, buyer-only | accepted     |     yes      |      no       |  pass  | buyer accredited      |
+// | 3 | ACCREDITED, buyer-only | accepted     |      no      |      yes      |  fail  | buyer not accredited  |
+// | 4 | ACCREDITED + filter    | accepted     | wrong filter |      no       |  fail  | subtype mismatch      |
+// | 5 | ACCREDITED + filter    | accepted     | right filter |      no       |  pass  | subtype match         |
+// | 6 | QP, buyer+seller       | accepted     |     yes      |      no       |  fail  | seller also gated     |
+// | 7 | QP, buyer+seller       | accepted     |     yes      |      yes      |  pass  | both qualified        |
+//
+// Config/authorization
+// | # | case                        | expect              |
+// |---|-----------------------------|---------------------|
+// | 8 | initialize zero badge       | revert InvalidBadge |
+// | 9 | updateParameters by stranger| revert (not admin)  |
+// ─────────────────────────────────────────────────────────────────────────────
+
+contract LexChexBadgeKindConditionTest is SecondaryConditionTestBase {
+    LexChexBadgeKindCondition internal cond;
+
+    function setUp() public {
+        _setUpBase();
+        cond = _deploy(CategoryKind.ACCREDITED_INVESTOR, "", false);
+    }
+
+    function _deploy(CategoryKind kind, string memory filter, bool checkSeller)
+        internal
+        returns (LexChexBadgeKindCondition c)
+    {
+        c = LexChexBadgeKindCondition(
+            _proxy(
+                address(new LexChexBadgeKindCondition()),
+                abi.encodeCall(
+                    LexChexBadgeKindCondition.initialize, (address(auth), address(badge), kind, filter, checkSeller)
+                )
+            )
+        );
+    }
+
+    function _check(LexChexBadgeKindCondition c, bytes32 agreementId) internal view returns (bool) {
+        return c.checkCondition(IDealManager(address(dm)), bytes4(0), OFFER_ID, agreementId);
+    }
+
+    // 1
+    function test_BuyerOnly_Posting_Passes() public {
+        dm.setOffer(OFFER_ID, _sellOffer());
+        assertTrue(_check(cond, bytes32(0)));
+    }
+
+    // 2
+    function test_BuyerOnly_Accredited_Passes() public {
+        badge.setValidKind(buyer, CategoryKind.ACCREDITED_INVESTOR, "", true);
+        _postSellAndAccept(_sellOffer(), _sellEscrow());
+        assertTrue(_check(cond, AGREEMENT_ID));
+    }
+
+    // 3
+    function test_BuyerOnly_NotAccredited_Fails() public {
+        badge.setValidKind(seller, CategoryKind.ACCREDITED_INVESTOR, "", true);
+        _postSellAndAccept(_sellOffer(), _sellEscrow());
+        assertFalse(_check(cond, AGREEMENT_ID));
+    }
+
+    // 4
+    function test_Filter_Mismatch_Fails() public {
+        LexChexBadgeKindCondition c = _deploy(CategoryKind.ACCREDITED_INVESTOR, "Reg D 501(a)(5)", false);
+        badge.setValidKind(buyer, CategoryKind.ACCREDITED_INVESTOR, "", true);
+        _postSellAndAccept(_sellOffer(), _sellEscrow());
+        assertFalse(_check(c, AGREEMENT_ID));
+    }
+
+    // 5
+    function test_Filter_Match_Passes() public {
+        LexChexBadgeKindCondition c = _deploy(CategoryKind.ACCREDITED_INVESTOR, "Reg D 501(a)(5)", false);
+        badge.setValidKind(buyer, CategoryKind.ACCREDITED_INVESTOR, "Reg D 501(a)(5)", true);
+        _postSellAndAccept(_sellOffer(), _sellEscrow());
+        assertTrue(_check(c, AGREEMENT_ID));
+    }
+
+    // 6
+    function test_CheckSeller_SellerMissing_Fails() public {
+        LexChexBadgeKindCondition c = _deploy(CategoryKind.QUALIFIED_PURCHASER, "", true);
+        badge.setValidKind(buyer, CategoryKind.QUALIFIED_PURCHASER, "", true);
+        _postSellAndAccept(_sellOffer(), _sellEscrow());
+        assertFalse(_check(c, AGREEMENT_ID));
+    }
+
+    // 7
+    function test_CheckSeller_BothQualified_Passes() public {
+        LexChexBadgeKindCondition c = _deploy(CategoryKind.QUALIFIED_PURCHASER, "", true);
+        badge.setValidKind(buyer, CategoryKind.QUALIFIED_PURCHASER, "", true);
+        badge.setValidKind(seller, CategoryKind.QUALIFIED_PURCHASER, "", true);
+        _postSellAndAccept(_sellOffer(), _sellEscrow());
+        assertTrue(_check(c, AGREEMENT_ID));
+    }
+
+    // 8
+    function test_Initialize_ZeroBadge_Reverts() public {
+        LexChexBadgeKindCondition impl = new LexChexBadgeKindCondition();
+        vm.expectRevert(LexChexBadgeKindCondition.InvalidBadge.selector);
+        _proxy(
+            address(impl),
+            abi.encodeCall(
+                LexChexBadgeKindCondition.initialize, (address(auth), address(0), CategoryKind.QIB, "", false)
+            )
+        );
+    }
+
+    // 9
+    function test_UpdateParameters_ByStranger_Reverts() public {
+        vm.prank(stranger);
+        vm.expectRevert();
+        cond.updateParameters(CategoryKind.QIB, "", true);
+    }
+}

--- a/test/conditions/secondary/RegSDistributionComplianceCondition.t.sol
+++ b/test/conditions/secondary/RegSDistributionComplianceCondition.t.sol
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.28;
+
+import {IDealManager} from "../../../src/interfaces/IDealManager.sol";
+import {Offer, OfferSide, SecondaryEscrow} from "../../../src/interfaces/ISecondaryTradeStorage.sol";
+import {
+    RegSDistributionComplianceCondition
+} from "../../../src/libs/conditions/secondary/RegSDistributionComplianceCondition.sol";
+import {SecondaryConditionTestBase} from "./SecondaryConditionMocks.sol";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// RegSDistributionComplianceCondition — Regulation S distribution compliance period.
+//
+// Legal/economic intent: a Reg S resale requires the applicable distribution compliance period to
+// have elapsed since the interest was acquired. The period is a per-SPV parameter encoded by counsel
+// (issuer category 1/2/3). An unconfigured SPV fails closed; a missing acquisition anchor fails
+// closed; a bid at posting has no seller yet and is verified at acceptance.
+//
+// Scenario × outcome (compliance period = 365 days)
+// | # | scenario                                         | expect | rationale                       |
+// |---|--------------------------------------------------|:------:|---------------------------------|
+// | 1 | SPV not configured (even if seasoned)            |  fail  | fail closed, no counsel config  |
+// | 2 | configured, no acquisition record                |  fail  | fail closed                     |
+// | 3 | configured, seasoned exactly the period          |  pass  | period elapsed (>=)             |
+// | 4 | configured, not yet seasoned                     |  fail  | period not elapsed              |
+// | 5 | configured, BUY offer at posting                 |  pass  | verified at acceptance          |
+//
+// Config/authorization
+// | # | case                              | expect                |
+// |---|-----------------------------------|-----------------------|
+// | 6 | setRegSConfig zero spv            | revert InvalidSpv     |
+// | 7 | setRegSConfig category 0          | revert InvalidCategory|
+// | 8 | setRegSConfig category 4          | revert InvalidCategory|
+// | 9 | setRegSConfig by non-SPV-admin    | revert (not admin)    |
+// ─────────────────────────────────────────────────────────────────────────────
+
+contract RegSDistributionComplianceConditionTest is SecondaryConditionTestBase {
+    RegSDistributionComplianceCondition internal regS;
+    uint64 internal constant PERIOD = 365 days;
+    uint256 internal constant NOW = 500 days;
+
+    function setUp() public {
+        _setUpBase();
+        vm.warp(NOW);
+        regS = RegSDistributionComplianceCondition(
+            _proxy(
+                address(new RegSDistributionComplianceCondition()),
+                abi.encodeCall(RegSDistributionComplianceCondition.initialize, (address(auth)))
+            )
+        );
+    }
+
+    function _configure() internal {
+        regS.setRegSConfig(address(dm), 3, PERIOD);
+    }
+
+    function _sellPosting(uint64 anchor) internal returns (bool) {
+        cert.setAcquisitionTimestamp(1, anchor);
+        dm.setOffer(OFFER_ID, _sellOffer());
+        return regS.checkCondition(IDealManager(address(dm)), bytes4(0), OFFER_ID, bytes32(0));
+    }
+
+    // 1
+    function test_Unconfigured_FailsClosed() public {
+        assertFalse(_sellPosting(uint64(NOW) - PERIOD));
+    }
+
+    // 2
+    function test_Configured_NoRecord_FailsClosed() public {
+        _configure();
+        dm.setOffer(OFFER_ID, _sellOffer());
+        assertFalse(regS.checkCondition(IDealManager(address(dm)), bytes4(0), OFFER_ID, bytes32(0)));
+    }
+
+    // 3
+    function test_Configured_Seasoned_Passes() public {
+        _configure();
+        assertTrue(_sellPosting(uint64(NOW) - PERIOD));
+    }
+
+    // 4
+    function test_Configured_NotSeasoned_Fails() public {
+        _configure();
+        assertFalse(_sellPosting(uint64(NOW) - (PERIOD - 1 days)));
+    }
+
+    // 5
+    function test_Configured_BuyPosting_Passes() public {
+        _configure();
+        Offer memory o = _sellOffer();
+        o.side = OfferSide.BUY;
+        o.tokenId = 0;
+        dm.setOffer(OFFER_ID, o);
+        assertTrue(regS.checkCondition(IDealManager(address(dm)), bytes4(0), OFFER_ID, bytes32(0)));
+    }
+
+    // 6
+    function test_SetRegSConfig_ZeroSpv_Reverts() public {
+        vm.expectRevert(RegSDistributionComplianceCondition.InvalidSpv.selector);
+        regS.setRegSConfig(address(0), 3, PERIOD);
+    }
+
+    // 7
+    function test_SetRegSConfig_CategoryZero_Reverts() public {
+        vm.expectRevert(RegSDistributionComplianceCondition.InvalidCategory.selector);
+        regS.setRegSConfig(address(dm), 0, PERIOD);
+    }
+
+    // 8
+    function test_SetRegSConfig_CategoryFour_Reverts() public {
+        vm.expectRevert(RegSDistributionComplianceCondition.InvalidCategory.selector);
+        regS.setRegSConfig(address(dm), 4, PERIOD);
+    }
+
+    // 9
+    function test_SetRegSConfig_ByNonSpvAdmin_Reverts() public {
+        vm.prank(stranger);
+        vm.expectRevert();
+        regS.setRegSConfig(address(dm), 3, PERIOD);
+    }
+}

--- a/test/conditions/secondary/Rule144DisclosureCondition.t.sol
+++ b/test/conditions/secondary/Rule144DisclosureCondition.t.sol
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.28;
+
+import {IDealManager} from "../../../src/interfaces/IDealManager.sol";
+import {Offer, SecondaryEscrow} from "../../../src/interfaces/ISecondaryTradeStorage.sol";
+import {Rule144DisclosureCondition} from "../../../src/libs/conditions/secondary/Rule144DisclosureCondition.sol";
+import {SecondaryConditionTestBase} from "./SecondaryConditionMocks.sol";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Rule144DisclosureCondition — current public information gate for Rule 144 trades.
+//
+// Legal/economic intent: Rule 144(c)(2) / 15c2-11(b)(5) require current public information about the
+// issuer. The SPV records a disclosure package (URI + as-of date); the gate fails when the record is
+// missing or older than the freshness policy (e.g. balance sheet > 16 months). SPV-wide: no party
+// lookup, enforced at posting, acceptance, and finalize alike.
+//
+// Scenario × outcome (freshness policy = 480 days)
+// | # | scenario                                     | expect | rationale                        |
+// |---|----------------------------------------------|:------:|----------------------------------|
+// | 1 | no disclosure record                         |  fail  | no current public information    |
+// | 2 | fresh record                                 |  pass  | within freshness policy          |
+// | 3 | exactly at the freshness boundary            |  pass  | boundary inclusive (<=)          |
+// | 4 | stale by one second                          |  fail  | outside freshness policy         |
+// | 5 | fresh record, evaluated at acceptance context|  pass  | SPV-wide, context-independent    |
+//
+// Config/authorization
+// | # | case                              | expect                 |
+// |---|-----------------------------------|------------------------|
+// | 6 | setDisclosurePackage zero spv     | revert InvalidSpv      |
+// | 7 | setDisclosurePackage asOf 0       | revert InvalidTimestamp|
+// | 8 | setDisclosurePackage future asOf  | revert InvalidTimestamp|
+// | 9 | setDisclosurePackage non-SPV-admin| revert (not admin)     |
+// |10 | initialize zero maxAge            | revert InvalidMaxAge   |
+// ─────────────────────────────────────────────────────────────────────────────
+
+contract Rule144DisclosureConditionTest is SecondaryConditionTestBase {
+    Rule144DisclosureCondition internal disc;
+    uint256 internal constant MAX_AGE = 480 days;
+    uint256 internal constant NOW = 500 days;
+    string internal constant URI = "ipfs://144-package";
+
+    function setUp() public {
+        _setUpBase();
+        vm.warp(NOW);
+        disc = Rule144DisclosureCondition(
+            _proxy(
+                address(new Rule144DisclosureCondition()),
+                abi.encodeCall(Rule144DisclosureCondition.initialize, (address(auth), MAX_AGE))
+            )
+        );
+        dm.setOffer(OFFER_ID, _sellOffer());
+    }
+
+    function _check(bytes32 agreementId) internal view returns (bool) {
+        return disc.checkCondition(IDealManager(address(dm)), bytes4(0), OFFER_ID, agreementId);
+    }
+
+    // 1
+    function test_NoRecord_Fails() public view {
+        assertFalse(_check(bytes32(0)));
+    }
+
+    // 2
+    function test_FreshRecord_Passes() public {
+        disc.setDisclosurePackage(address(dm), URI, uint64(NOW));
+        assertTrue(_check(bytes32(0)));
+    }
+
+    // 3
+    function test_AtFreshnessBoundary_Passes() public {
+        disc.setDisclosurePackage(address(dm), URI, uint64(NOW - MAX_AGE));
+        assertTrue(_check(bytes32(0)));
+    }
+
+    // 4
+    function test_StaleByOneSecond_Fails() public {
+        disc.setDisclosurePackage(address(dm), URI, uint64(NOW - MAX_AGE - 1));
+        assertFalse(_check(bytes32(0)));
+    }
+
+    // 5
+    function test_FreshRecord_AcceptanceContext_Passes() public {
+        disc.setDisclosurePackage(address(dm), URI, uint64(NOW));
+        dm.setEscrow(AGREEMENT_ID, _sellEscrow());
+        assertTrue(_check(AGREEMENT_ID));
+    }
+
+    // 6
+    function test_SetDisclosure_ZeroSpv_Reverts() public {
+        vm.expectRevert(Rule144DisclosureCondition.InvalidSpv.selector);
+        disc.setDisclosurePackage(address(0), URI, uint64(NOW));
+    }
+
+    // 7
+    function test_SetDisclosure_ZeroAsOf_Reverts() public {
+        vm.expectRevert(Rule144DisclosureCondition.InvalidTimestamp.selector);
+        disc.setDisclosurePackage(address(dm), URI, 0);
+    }
+
+    // 8
+    function test_SetDisclosure_FutureAsOf_Reverts() public {
+        vm.expectRevert(Rule144DisclosureCondition.InvalidTimestamp.selector);
+        disc.setDisclosurePackage(address(dm), URI, uint64(NOW + 1));
+    }
+
+    // 9
+    function test_SetDisclosure_ByNonSpvAdmin_Reverts() public {
+        vm.prank(stranger);
+        vm.expectRevert();
+        disc.setDisclosurePackage(address(dm), URI, uint64(NOW));
+    }
+
+    // 10
+    function test_Initialize_ZeroMaxAge_Reverts() public {
+        Rule144DisclosureCondition impl = new Rule144DisclosureCondition();
+        vm.expectRevert(Rule144DisclosureCondition.InvalidMaxAge.selector);
+        _proxy(address(impl), abi.encodeCall(Rule144DisclosureCondition.initialize, (address(auth), 0)));
+    }
+}

--- a/test/conditions/secondary/SecondaryConditionMocks.sol
+++ b/test/conditions/secondary/SecondaryConditionMocks.sol
@@ -1,0 +1,262 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.28;
+
+import {ERC1967Proxy} from "../../../dependencies/openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {CategoryKind} from "../../../src/creds/storage/lexchexBadgeStorage.sol";
+import {CertificateDetails} from "../../../src/interfaces/ICyberCertPrinter.sol";
+import {ExemptionPathway, Offer, OfferSide, SecondaryEscrow} from "../../../src/interfaces/ISecondaryTradeStorage.sol";
+import {BorgAuth} from "../../../src/libs/auth.sol";
+import {Test} from "forge-std/Test.sol";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Lightweight mocks — just the surface each secondary-trading condition reads.
+// These keep the condition unit tests fast and let a single test set up dozens of
+// distinct legal/economic scenarios (expired badge, wrong jurisdiction, stale
+// disclosure, unmet hold, …) that would be impractical against the full stack.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// @notice Answers the three IDealManager getters the conditions call, and exposes AUTH() so setters
+/// gated on the DealManager's own BorgAuth (LegalOpinion, GPLPApproval, TimeSettlement) resolve here.
+contract MockDealManager {
+    address public AUTH;
+    uint256 internal settlementWindow;
+    mapping(bytes32 => Offer) internal offers;
+    mapping(bytes32 => SecondaryEscrow) internal escrows;
+
+    constructor(address auth_) {
+        AUTH = auth_;
+    }
+
+    function setSettlementWindow(uint256 w) external {
+        settlementWindow = w;
+    }
+
+    function getSettlementWindow() external view returns (uint256) {
+        return settlementWindow;
+    }
+
+    function setOffer(bytes32 id, Offer memory o) external {
+        offers[id] = o;
+    }
+
+    function getOffer(bytes32 id) external view returns (Offer memory) {
+        return offers[id];
+    }
+
+    function setEscrow(bytes32 id, SecondaryEscrow memory e) external {
+        escrows[id] = e;
+    }
+
+    function getSecondaryEscrow(bytes32 id) external view returns (SecondaryEscrow memory) {
+        return escrows[id];
+    }
+}
+
+/// @notice An SPV/target address that only needs to advertise its BorgAuth for the per-SPV setters.
+contract MockAuthTarget {
+    address public AUTH;
+
+    constructor(address auth_) {
+        AUTH = auth_;
+    }
+}
+
+/// @notice Configurable LeXcheXBadge credential layer.
+contract MockBadge {
+    mapping(address => mapping(bytes32 => bool)) internal categoryCred;
+    mapping(bytes32 => bool) internal kindCred;
+    mapping(address => bytes2) internal usState;
+    mapping(address => uint32) internal boCount;
+    mapping(address => string) internal jurisdiction;
+
+    function _kindKey(address owner, CategoryKind kind, string memory filter) internal pure returns (bytes32) {
+        return keccak256(abi.encode(owner, kind, filter));
+    }
+
+    function setValidCredential(address owner, bytes32 categoryId, bool v) external {
+        categoryCred[owner][categoryId] = v;
+    }
+
+    function setValidKind(address owner, CategoryKind kind, string memory filter, bool v) external {
+        kindCred[_kindKey(owner, kind, filter)] = v;
+    }
+
+    function setUsState(address owner, bytes2 s) external {
+        usState[owner] = s;
+    }
+
+    function setBeneficialOwnerCount(address owner, uint32 c) external {
+        boCount[owner] = c;
+    }
+
+    function setInvestorJurisdiction(address owner, string memory j) external {
+        jurisdiction[owner] = j;
+    }
+
+    function hasValidCredential(address owner, bytes32 categoryId) external view returns (bool) {
+        return categoryCred[owner][categoryId];
+    }
+
+    function hasValidCredentialOfKind(address owner, CategoryKind kind, string memory filter)
+        external
+        view
+        returns (bool)
+    {
+        return kindCred[_kindKey(owner, kind, filter)];
+    }
+
+    function getUsState(address owner) external view returns (bytes2) {
+        return usState[owner];
+    }
+
+    function getBeneficialOwnerCount(address owner) external view returns (uint32) {
+        return boCount[owner];
+    }
+
+    function getInvestorJurisdiction(address owner) external view returns (string memory) {
+        return jurisdiction[owner];
+    }
+}
+
+/// @notice Configurable CyberAgreementRegistry surface (signatures + per-signer party values).
+contract MockRegistry {
+    mapping(bytes32 => bool) internal signed;
+    mapping(bytes32 => mapping(address => string[])) internal signerValues;
+
+    function setAllPartiesSigned(bytes32 id, bool v) external {
+        signed[id] = v;
+    }
+
+    function setSignerValues(bytes32 id, address signer, string[] memory values) external {
+        signerValues[id][signer] = values;
+    }
+
+    function allPartiesSigned(bytes32 id) external view returns (bool) {
+        return signed[id];
+    }
+
+    function getSignerValues(bytes32 id, address signer) external view returns (string[] memory) {
+        return signerValues[id][signer];
+    }
+}
+
+/// @notice Configurable CyberCertPrinter surface (per-lot acquisition anchor, tacking extension, holders).
+contract MockCertPrinter {
+    mapping(uint256 => uint64) internal acqTs;
+    mapping(uint256 => bytes) internal ext;
+    mapping(address => uint256) internal legalBalance;
+    mapping(uint256 => address) internal legalOwner;
+    mapping(uint256 => uint256) internal tokenAtIndex;
+    uint256 internal holders;
+    uint256 internal supply;
+
+    function setAcquisitionTimestamp(uint256 tokenId, uint64 ts) external {
+        acqTs[tokenId] = ts;
+    }
+
+    function setExtensionData(uint256 tokenId, bytes memory data) external {
+        ext[tokenId] = data;
+    }
+
+    function setBalanceOfLegalOwner(address owner, uint256 bal) external {
+        legalBalance[owner] = bal;
+    }
+
+    function setHolderCount(uint256 c) external {
+        holders = c;
+    }
+
+    function setTotalSupply(uint256 s) external {
+        supply = s;
+    }
+
+    function setTokenAt(uint256 index, uint256 tokenId, address owner) external {
+        tokenAtIndex[index] = tokenId;
+        legalOwner[tokenId] = owner;
+    }
+
+    function acquisitionTimestamp(uint256 tokenId) external view returns (uint64) {
+        return acqTs[tokenId];
+    }
+
+    function getCertificateDetails(uint256 tokenId) external view returns (CertificateDetails memory d) {
+        d.extensionData = ext[tokenId];
+    }
+
+    function balanceOfLegalOwner(address owner) external view returns (uint256) {
+        return legalBalance[owner];
+    }
+
+    function holderCount() external view returns (uint256) {
+        return holders;
+    }
+
+    function totalSupply() external view returns (uint256) {
+        return supply;
+    }
+
+    function tokenByIndex(uint256 index) external view returns (uint256) {
+        return tokenAtIndex[index];
+    }
+
+    function legalOwnerOf(uint256 tokenId) external view returns (address) {
+        return legalOwner[tokenId];
+    }
+}
+
+/// @notice Shared setup for the secondary-trading condition unit tests. The test contract itself holds
+/// OWNER_ROLE on `auth`, so it can call the conditions' admin/owner setters without pranking; `stranger`
+/// stands in for an unauthorized caller in negative-authorization cases.
+abstract contract SecondaryConditionTestBase is Test {
+    BorgAuth internal auth;
+    MockBadge internal badge;
+    MockRegistry internal registry;
+    MockCertPrinter internal cert;
+    MockDealManager internal dm;
+
+    address internal stranger = makeAddr("stranger");
+    address internal seller = makeAddr("seller");
+    address internal buyer = makeAddr("buyer");
+
+    bytes32 internal constant OFFER_ID = keccak256("offer");
+    bytes32 internal constant AGREEMENT_ID = keccak256("settlement");
+
+    function _setUpBase() internal {
+        auth = new BorgAuth(address(this));
+        badge = new MockBadge();
+        registry = new MockRegistry();
+        cert = new MockCertPrinter();
+        dm = new MockDealManager(address(auth));
+    }
+
+    function _proxy(address impl, bytes memory initData) internal returns (address) {
+        return address(new ERC1967Proxy(impl, initData));
+    }
+
+    /// @dev A SELL offer with the mock cert printer and dm-as-SPV wired in. Callers tweak per scenario.
+    function _sellOffer() internal view returns (Offer memory o) {
+        o.spvAddress = address(dm);
+        o.offeror = seller;
+        o.side = OfferSide.SELL;
+        o.certPrinter = address(cert);
+        o.tokenId = 1;
+        o.exemptionPathway = ExemptionPathway.RULE_144;
+    }
+
+    /// @dev An escrow whose counterparty is the buyer (as materialized at acceptOffer for a SELL offer).
+    function _sellEscrow() internal view returns (SecondaryEscrow memory e) {
+        e.counterparty = buyer;
+        e.tokenId = 1;
+    }
+
+    /// @dev Posts a SELL offer and its accepted escrow into the mock DealManager.
+    function _postSellAndAccept(Offer memory o, SecondaryEscrow memory e) internal {
+        dm.setOffer(OFFER_ID, o);
+        dm.setEscrow(AGREEMENT_ID, e);
+    }
+
+    function _one(string memory v) internal pure returns (string[] memory a) {
+        a = new string[](1);
+        a[0] = v;
+    }
+}

--- a/test/conditions/secondary/SecondaryConditionMocks.sol
+++ b/test/conditions/secondary/SecondaryConditionMocks.sol
@@ -116,6 +116,11 @@ contract MockBadge {
     function getInvestorJurisdiction(address owner) external view returns (string memory) {
         return jurisdiction[owner];
     }
+
+    function isUSInvestor(address owner) external view returns (bool) {
+        bytes32 h = keccak256(bytes(jurisdiction[owner]));
+        return h == keccak256("US") || h == keccak256("USA") || h == keccak256("United States");
+    }
 }
 
 /// @notice Configurable CyberAgreementRegistry surface (signatures + per-signer party values).
@@ -149,6 +154,9 @@ contract MockCertPrinter {
     mapping(uint256 => uint256) internal tokenAtIndex;
     uint256 internal holders;
     uint256 internal supply;
+    uint256 internal lookThroughHolders;
+    uint256 internal usLookThroughHolders;
+    mapping(address => bool) internal legalHolder;
 
     function setAcquisitionTimestamp(uint256 tokenId, uint64 ts) external {
         acqTs[tokenId] = ts;
@@ -164,6 +172,18 @@ contract MockCertPrinter {
 
     function setHolderCount(uint256 c) external {
         holders = c;
+    }
+
+    function setLookThroughHolderCount(uint256 c) external {
+        lookThroughHolders = c;
+    }
+
+    function setUsLookThroughHolderCount(uint256 c) external {
+        usLookThroughHolders = c;
+    }
+
+    function setIsLegalHolder(address owner, bool v) external {
+        legalHolder[owner] = v;
     }
 
     function setTotalSupply(uint256 s) external {
@@ -189,6 +209,18 @@ contract MockCertPrinter {
 
     function holderCount() external view returns (uint256) {
         return holders;
+    }
+
+    function lookThroughHolderCount() external view returns (uint256) {
+        return lookThroughHolders;
+    }
+
+    function usLookThroughHolderCount() external view returns (uint256) {
+        return usLookThroughHolders;
+    }
+
+    function isLegalHolder(address owner) external view returns (bool) {
+        return legalHolder[owner];
     }
 
     function totalSupply() external view returns (uint256) {

--- a/test/conditions/secondary/Section4a7DisclosureCondition.t.sol
+++ b/test/conditions/secondary/Section4a7DisclosureCondition.t.sol
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.28;
+
+import {IDealManager} from "../../../src/interfaces/IDealManager.sol";
+import {Offer, SecondaryEscrow} from "../../../src/interfaces/ISecondaryTradeStorage.sol";
+import {Section4a7DisclosureCondition} from "../../../src/libs/conditions/secondary/Section4a7DisclosureCondition.sol";
+import {SecondaryConditionTestBase} from "./SecondaryConditionMocks.sol";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Section4a7DisclosureCondition — §4(a)(7) information-delivery gate (two-part test).
+//
+// Legal/economic intent: §4(a)(7)(d)(3) requires (1) the SPV to have a fresh information package on
+// record (incl. two years of GAAP financials), enforced from posting onward, and (2) the buyer to
+// acknowledge receipt of it, recorded as a party value at acceptance. Both must hold to clear.
+//
+// Scenario × outcome (freshness policy = 480 days)
+// | # | context   | package        | buyer ack | expect | rationale                        |
+// |---|-----------|----------------|:---------:|:------:|----------------------------------|
+// | 1 | posting   | none           |    n/a    |  fail  | package missing (part 1)         |
+// | 2 | posting   | fresh          |    n/a    |  pass  | ack deferred to acceptance       |
+// | 3 | accepted  | fresh          |    yes    |  pass  | both parts satisfied             |
+// | 4 | accepted  | fresh          |     no    |  fail  | receipt not acknowledged         |
+// | 5 | accepted  | stale          |    yes    |  fail  | package stale (part 1 fails)     |
+//
+// Config/authorization
+// | # | case                              | expect                    |
+// |---|-----------------------------------|---------------------------|
+// | 6 | initialize zero registry          | revert InvalidRegistry    |
+// | 7 | initialize empty acknowledgment   | revert InvalidAcknowledgment |
+// | 8 | initialize zero maxAge            | revert InvalidMaxAge      |
+// | 9 | setDisclosurePackage non-SPV-admin| revert (not admin)        |
+// ─────────────────────────────────────────────────────────────────────────────
+
+contract Section4a7DisclosureConditionTest is SecondaryConditionTestBase {
+    Section4a7DisclosureCondition internal disc;
+    uint256 internal constant MAX_AGE = 480 days;
+    uint256 internal constant NOW = 500 days;
+    string internal constant URI = "ipfs://4a7-package";
+    string internal constant ACK = "4a7:information-package-received";
+
+    function setUp() public {
+        _setUpBase();
+        vm.warp(NOW);
+        disc = Section4a7DisclosureCondition(
+            _proxy(
+                address(new Section4a7DisclosureCondition()),
+                abi.encodeCall(
+                    Section4a7DisclosureCondition.initialize, (address(auth), address(registry), ACK, MAX_AGE)
+                )
+            )
+        );
+        dm.setOffer(OFFER_ID, _sellOffer());
+    }
+
+    function _check(bytes32 agreementId) internal view returns (bool) {
+        return disc.checkCondition(IDealManager(address(dm)), bytes4(0), OFFER_ID, agreementId);
+    }
+
+    // 1
+    function test_Posting_NoPackage_Fails() public view {
+        assertFalse(_check(bytes32(0)));
+    }
+
+    // 2
+    function test_Posting_FreshPackage_Passes() public {
+        disc.setDisclosurePackage(address(dm), URI, uint64(NOW));
+        assertTrue(_check(bytes32(0)));
+    }
+
+    // 3
+    function test_Accepted_FreshAndAcked_Passes() public {
+        disc.setDisclosurePackage(address(dm), URI, uint64(NOW));
+        registry.setSignerValues(AGREEMENT_ID, buyer, _one(ACK));
+        dm.setEscrow(AGREEMENT_ID, _sellEscrow());
+        assertTrue(_check(AGREEMENT_ID));
+    }
+
+    // 4
+    function test_Accepted_FreshNoAck_Fails() public {
+        disc.setDisclosurePackage(address(dm), URI, uint64(NOW));
+        dm.setEscrow(AGREEMENT_ID, _sellEscrow());
+        assertFalse(_check(AGREEMENT_ID));
+    }
+
+    // 5
+    function test_Accepted_StalePackage_Fails() public {
+        disc.setDisclosurePackage(address(dm), URI, uint64(NOW - MAX_AGE - 1));
+        registry.setSignerValues(AGREEMENT_ID, buyer, _one(ACK));
+        dm.setEscrow(AGREEMENT_ID, _sellEscrow());
+        assertFalse(_check(AGREEMENT_ID));
+    }
+
+    // 6
+    function test_Initialize_ZeroRegistry_Reverts() public {
+        Section4a7DisclosureCondition impl = new Section4a7DisclosureCondition();
+        vm.expectRevert(Section4a7DisclosureCondition.InvalidRegistry.selector);
+        _proxy(
+            address(impl),
+            abi.encodeCall(Section4a7DisclosureCondition.initialize, (address(auth), address(0), ACK, MAX_AGE))
+        );
+    }
+
+    // 7
+    function test_Initialize_EmptyAck_Reverts() public {
+        Section4a7DisclosureCondition impl = new Section4a7DisclosureCondition();
+        vm.expectRevert(Section4a7DisclosureCondition.InvalidAcknowledgment.selector);
+        _proxy(
+            address(impl),
+            abi.encodeCall(Section4a7DisclosureCondition.initialize, (address(auth), address(registry), "", MAX_AGE))
+        );
+    }
+
+    // 8
+    function test_Initialize_ZeroMaxAge_Reverts() public {
+        Section4a7DisclosureCondition impl = new Section4a7DisclosureCondition();
+        vm.expectRevert(Section4a7DisclosureCondition.InvalidMaxAge.selector);
+        _proxy(
+            address(impl),
+            abi.encodeCall(Section4a7DisclosureCondition.initialize, (address(auth), address(registry), ACK, 0))
+        );
+    }
+
+    // 9
+    function test_SetDisclosure_ByNonSpvAdmin_Reverts() public {
+        vm.prank(stranger);
+        vm.expectRevert();
+        disc.setDisclosurePackage(address(dm), URI, uint64(NOW));
+    }
+}

--- a/test/conditions/secondary/TaxInfoCondition.t.sol
+++ b/test/conditions/secondary/TaxInfoCondition.t.sol
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.28;
+
+import {IDealManager} from "../../../src/interfaces/IDealManager.sol";
+import {Offer, SecondaryEscrow} from "../../../src/interfaces/ISecondaryTradeStorage.sol";
+import {TaxInfoCondition} from "../../../src/libs/conditions/secondary/TaxInfoCondition.sol";
+import {SecondaryConditionTestBase} from "./SecondaryConditionMocks.sol";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TaxInfoCondition — blocks acceptance until the buyer's tax form is on file.
+//
+// Legal/economic intent: K-1 readiness and §1446(f) withholding posture require the acquirer's
+// W-9 / W-8BEN(-E) on record before they can take the interest. The seller's record is readable
+// but does NOT gate (it should already exist from primary issuance). Nothing to gate at posting.
+//
+// Scenario × outcome
+// | # | context       | buyer form   | seller form | expect | rationale                          |
+// |---|---------------|--------------|-------------|:------:|------------------------------------|
+// | 1 | SELL posting  |    n/a       |    n/a      |  pass  | no acquirer yet                    |
+// | 2 | SELL accepted | W-9          |    none     |  pass  | U.S. buyer form on file            |
+// | 3 | SELL accepted | W-8BEN       |    none     |  pass  | non-U.S. buyer form on file        |
+// | 4 | SELL accepted | none         |    W-9      |  fail  | seller's form does not cover buyer |
+// | 5 | SELL accepted | NONE (empty) |    none     |  fail  | explicit NONE is not "on file"     |
+// | 6 | SELL accepted | cleared      |    none     |  fail  | form withdrawn before settlement   |
+//
+// Config/authorization
+// | # | case                                | expect                 |
+// |---|-------------------------------------|------------------------|
+// | 7 | setTaxForm zero account             | revert InvalidAccount  |
+// | 8 | setTaxForm by stranger              | revert (not admin)     |
+// | 9 | clearTaxForm by stranger            | revert (not admin)     |
+// ─────────────────────────────────────────────────────────────────────────────
+
+contract TaxInfoConditionTest is SecondaryConditionTestBase {
+    TaxInfoCondition internal tax;
+
+    function setUp() public {
+        _setUpBase();
+        tax = TaxInfoCondition(
+            _proxy(address(new TaxInfoCondition()), abi.encodeCall(TaxInfoCondition.initialize, (address(auth))))
+        );
+    }
+
+    function _check(bytes32 agreementId) internal view returns (bool) {
+        return tax.checkCondition(IDealManager(address(dm)), bytes4(0), OFFER_ID, agreementId);
+    }
+
+    // 1
+    function test_Posting_NoBuyer_Passes() public {
+        dm.setOffer(OFFER_ID, _sellOffer());
+        assertTrue(_check(bytes32(0)));
+    }
+
+    // 2
+    function test_Accepted_BuyerW9_Passes() public {
+        tax.setTaxForm(buyer, TaxInfoCondition.TaxFormType.W9, keccak256("w9"));
+        _postSellAndAccept(_sellOffer(), _sellEscrow());
+        assertTrue(_check(AGREEMENT_ID));
+    }
+
+    // 3
+    function test_Accepted_BuyerW8BEN_Passes() public {
+        tax.setTaxForm(buyer, TaxInfoCondition.TaxFormType.W8BEN, keccak256("w8"));
+        _postSellAndAccept(_sellOffer(), _sellEscrow());
+        assertTrue(_check(AGREEMENT_ID));
+    }
+
+    // 4
+    function test_Accepted_OnlySellerHasForm_Fails() public {
+        tax.setTaxForm(seller, TaxInfoCondition.TaxFormType.W9, keccak256("w9"));
+        _postSellAndAccept(_sellOffer(), _sellEscrow());
+        assertFalse(_check(AGREEMENT_ID));
+    }
+
+    // 5
+    function test_Accepted_ExplicitNone_Fails() public {
+        tax.setTaxForm(buyer, TaxInfoCondition.TaxFormType.NONE, keccak256("none"));
+        _postSellAndAccept(_sellOffer(), _sellEscrow());
+        assertFalse(_check(AGREEMENT_ID));
+    }
+
+    // 6
+    function test_Accepted_FormCleared_Fails() public {
+        tax.setTaxForm(buyer, TaxInfoCondition.TaxFormType.W9, keccak256("w9"));
+        tax.clearTaxForm(buyer);
+        _postSellAndAccept(_sellOffer(), _sellEscrow());
+        assertFalse(_check(AGREEMENT_ID));
+    }
+
+    // 7
+    function test_SetTaxForm_ZeroAccount_Reverts() public {
+        vm.expectRevert(TaxInfoCondition.InvalidAccount.selector);
+        tax.setTaxForm(address(0), TaxInfoCondition.TaxFormType.W9, keccak256("w9"));
+    }
+
+    // 8
+    function test_SetTaxForm_ByStranger_Reverts() public {
+        vm.prank(stranger);
+        vm.expectRevert();
+        tax.setTaxForm(buyer, TaxInfoCondition.TaxFormType.W9, keccak256("w9"));
+    }
+
+    // 9
+    function test_ClearTaxForm_ByStranger_Reverts() public {
+        vm.prank(stranger);
+        vm.expectRevert();
+        tax.clearTaxForm(buyer);
+    }
+}

--- a/test/conditions/secondary/TimeSettlementPeriodCondition.t.sol
+++ b/test/conditions/secondary/TimeSettlementPeriodCondition.t.sol
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.28;
+
+import {IDealManager} from "../../../src/interfaces/IDealManager.sol";
+import {SecondaryEscrow} from "../../../src/interfaces/ISecondaryTradeStorage.sol";
+import {TimeSettlementPeriodCondition} from "../../../src/libs/conditions/secondary/TimeSettlementPeriodCondition.sol";
+import {SecondaryConditionTestBase} from "./SecondaryConditionMocks.sol";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TimeSettlementPeriodCondition — minimum delay between acceptance and finalization (closing).
+//
+// Legal/economic intent: a structural cooling-off window between acceptance and finalization — the
+// intervention window for the Compromised Credential voidness provision and the Global Kill, and the
+// timer the keeper waits on. Default 24h from acceptance; per-DealManager overrides. Acceptance time
+// is reconstructed as escrow.expiry - settlementWindow.
+//
+// Scenario × outcome (default delay 24h; acceptance at A, window 7d, expiry = A + 7d)
+// | # | scenario                                     | expect | rationale                          |
+// |---|----------------------------------------------|:------:|------------------------------------|
+// | 1 | posting (no settlement id)                   |  pass  | silent, evaluated at finalize      |
+// | 2 | at acceptance (no time elapsed)              |  fail  | window not yet elapsed             |
+// | 3 | exactly A + 24h                              |  pass  | window elapsed (>=)                |
+// | 4 | finalizableAt == A + DEFAULT_DELAY           |  true  | getter matches                     |
+// | 5 | delay override 2d: at A + 24h                 |  fail  | longer window not yet elapsed      |
+// | 6 | delay override 2d: at A + 2d                  |  pass  | overridden window elapsed          |
+// | 7 | override back to 0 restores default          |  pass  | 0 == DEFAULT_DELAY                  |
+//
+// Config/authorization
+// | # | case                              | expect                  |
+// |---|-----------------------------------|-------------------------|
+// | 8 | setDelayOverride zero dealManager | revert InvalidDealManager |
+// | 9 | setDelayOverride by non-owner     | revert (not owner)      |
+// ─────────────────────────────────────────────────────────────────────────────
+
+contract TimeSettlementPeriodConditionTest is SecondaryConditionTestBase {
+    TimeSettlementPeriodCondition internal timing;
+    uint256 internal constant A = 100 days; // acceptance timestamp
+    uint256 internal constant WINDOW = 7 days;
+
+    function setUp() public {
+        _setUpBase();
+        timing = new TimeSettlementPeriodCondition();
+        dm.setSettlementWindow(WINDOW);
+        SecondaryEscrow memory e = _sellEscrow();
+        e.expiry = A + WINDOW; // acceptOffer stamps expiry = acceptance + window
+        dm.setEscrow(AGREEMENT_ID, e);
+    }
+
+    function _check() internal view returns (bool) {
+        return timing.checkCondition(IDealManager(address(dm)), bytes4(0), OFFER_ID, AGREEMENT_ID);
+    }
+
+    // 1
+    function test_Posting_Silent_Passes() public view {
+        assertTrue(timing.checkCondition(IDealManager(address(dm)), bytes4(0), OFFER_ID, bytes32(0)));
+    }
+
+    // 2
+    function test_AtAcceptance_Fails() public {
+        vm.warp(A);
+        assertFalse(_check());
+    }
+
+    // 3
+    function test_AtWindowEnd_Passes() public {
+        vm.warp(A + timing.DEFAULT_DELAY());
+        assertTrue(_check());
+    }
+
+    // 4
+    function test_FinalizableAt_MatchesDefault() public view {
+        assertEq(timing.finalizableAt(IDealManager(address(dm)), AGREEMENT_ID), A + timing.DEFAULT_DELAY());
+    }
+
+    // 5
+    function test_Override2d_BeforeElapsed_Fails() public {
+        timing.setDelayOverride(address(dm), 2 days);
+        vm.warp(A + 1 days);
+        assertFalse(_check());
+    }
+
+    // 6
+    function test_Override2d_AfterElapsed_Passes() public {
+        timing.setDelayOverride(address(dm), 2 days);
+        vm.warp(A + 2 days);
+        assertTrue(_check());
+    }
+
+    // 7
+    function test_OverrideZero_RestoresDefault() public {
+        timing.setDelayOverride(address(dm), 2 days);
+        timing.setDelayOverride(address(dm), 0);
+        assertEq(timing.delayFor(address(dm)), timing.DEFAULT_DELAY());
+        vm.warp(A + timing.DEFAULT_DELAY());
+        assertTrue(_check());
+    }
+
+    // 8
+    function test_SetDelayOverride_ZeroDealManager_Reverts() public {
+        vm.expectRevert(TimeSettlementPeriodCondition.InvalidDealManager.selector);
+        timing.setDelayOverride(address(0), 1 days);
+    }
+
+    // 9
+    function test_SetDelayOverride_ByNonOwner_Reverts() public {
+        vm.prank(stranger);
+        vm.expectRevert();
+        timing.setDelayOverride(address(dm), 1 days);
+    }
+}

--- a/test/conditions/secondary/USStateOfResidenceCondition.t.sol
+++ b/test/conditions/secondary/USStateOfResidenceCondition.t.sol
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.28;
+
+import {IDealManager} from "../../../src/interfaces/IDealManager.sol";
+import {Offer, SecondaryEscrow} from "../../../src/interfaces/ISecondaryTradeStorage.sol";
+import {USStateOfResidenceCondition} from "../../../src/libs/conditions/secondary/USStateOfResidenceCondition.sol";
+import {SecondaryConditionTestBase} from "./SecondaryConditionMocks.sol";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// USStateOfResidenceCondition — blue-sky state gating for U.S. acceptors (§6.9, Addendum D).
+//
+// Legal/economic intent: honor state securities (blue-sky) restrictions. Each SPV keeps a blocked-
+// states list; New York is blocked by default until the SPV registers under the Martin Act. Non-U.S.
+// acceptors carry no usState and are silent; U.S. acceptors in an unlisted state pass. Setters are
+// gated on the SPV's own BorgAuth admin (the GP), not the condition's global admin.
+//
+// Scenario × outcome
+// | # | scenario                                        | expect | rationale                          |
+// |---|-------------------------------------------------|:------:|------------------------------------|
+// | 1 | posting (no acquirer)                           |  pass  | nothing to gate                    |
+// | 2 | non-U.S. acceptor (no usState)                  |  pass  | no state attribute                 |
+// | 3 | U.S. acceptor, unlisted state (CA)              |  pass  | state not blocked                  |
+// | 4 | U.S. acceptor, NY, no Martin Act registration   |  fail  | NY default-blocked                 |
+// | 5 | U.S. acceptor, NY, Martin Act registered        |  pass  | NY default cleared                 |
+// | 6 | U.S. acceptor, GP-blocked state (AL)            |  fail  | explicitly blocked by SPV          |
+// | 7 | GP blocks then unblocks a state                 |  pass  | block is reversible                |
+//
+// Config/authorization
+// | # | case                                | expect             |
+// |---|-------------------------------------|--------------------|
+// | 8 | setStateBlocked zero spv            | revert InvalidSpv  |
+// | 9 | setStateBlocked by non-SPV-admin    | revert (not admin) |
+// |10 | setMartinActRegistered by non-admin | revert (not admin) |
+// |11 | initialize zero badge               | revert InvalidBadge|
+// ─────────────────────────────────────────────────────────────────────────────
+
+contract USStateOfResidenceConditionTest is SecondaryConditionTestBase {
+    USStateOfResidenceCondition internal usState;
+
+    function setUp() public {
+        _setUpBase();
+        usState = USStateOfResidenceCondition(
+            _proxy(
+                address(new USStateOfResidenceCondition()),
+                abi.encodeCall(USStateOfResidenceCondition.initialize, (address(auth), address(badge)))
+            )
+        );
+    }
+
+    function _accepted(bytes2 state) internal returns (bool) {
+        badge.setUsState(buyer, state);
+        _postSellAndAccept(_sellOffer(), _sellEscrow());
+        return usState.checkCondition(IDealManager(address(dm)), bytes4(0), OFFER_ID, AGREEMENT_ID);
+    }
+
+    // 1
+    function test_Posting_NoAcquirer_Passes() public {
+        dm.setOffer(OFFER_ID, _sellOffer());
+        assertTrue(usState.checkCondition(IDealManager(address(dm)), bytes4(0), OFFER_ID, bytes32(0)));
+    }
+
+    // 2
+    function test_NonUsAcceptor_Passes() public {
+        assertTrue(_accepted(bytes2(0)));
+    }
+
+    // 3
+    function test_UnlistedState_Passes() public {
+        assertTrue(_accepted("CA"));
+    }
+
+    // 4
+    function test_NewYork_Default_Fails() public {
+        assertFalse(_accepted("NY"));
+    }
+
+    // 5
+    function test_NewYork_MartinActRegistered_Passes() public {
+        usState.setMartinActRegistered(address(dm), true);
+        assertTrue(_accepted("NY"));
+    }
+
+    // 6
+    function test_GpBlockedState_Fails() public {
+        usState.setStateBlocked(address(dm), "AL", true);
+        assertFalse(_accepted("AL"));
+    }
+
+    // 7
+    function test_BlockThenUnblock_Passes() public {
+        usState.setStateBlocked(address(dm), "AL", true);
+        usState.setStateBlocked(address(dm), "AL", false);
+        assertTrue(_accepted("AL"));
+    }
+
+    // 8
+    function test_SetStateBlocked_ZeroSpv_Reverts() public {
+        vm.expectRevert(USStateOfResidenceCondition.InvalidSpv.selector);
+        usState.setStateBlocked(address(0), "AL", true);
+    }
+
+    // 9
+    function test_SetStateBlocked_ByNonSpvAdmin_Reverts() public {
+        vm.prank(stranger);
+        vm.expectRevert();
+        usState.setStateBlocked(address(dm), "AL", true);
+    }
+
+    // 10
+    function test_SetMartinAct_ByNonSpvAdmin_Reverts() public {
+        vm.prank(stranger);
+        vm.expectRevert();
+        usState.setMartinActRegistered(address(dm), true);
+    }
+
+    // 11
+    function test_Initialize_ZeroBadge_Reverts() public {
+        USStateOfResidenceCondition impl = new USStateOfResidenceCondition();
+        vm.expectRevert(USStateOfResidenceCondition.InvalidBadge.selector);
+        _proxy(address(impl), abi.encodeCall(USStateOfResidenceCondition.initialize, (address(auth), address(0))));
+    }
+}


### PR DESCRIPTION
## Added

- `issueTimestamp` and `acquisitionTimestamp` as base properties
- `CyberCertPrinter` to track holder caps (look-through & US)
- supporting setter/getter

## Updated

- Updated `HoldingPeriodCondition` and `RegSDistributionComplianceCondition` per above property changes
- Reverted `IssuanceManager` secondary transfer behavior and removed auto-merge feature (to avoid conflicting cert properties such as `acquisitionTimestamp`)
- Moved all CyberCertPrinter events and errors to ICyberCertPrinter.sol so they can be shared between base contract and storages