### PR TITLE
feat: complete first-customer protocol readiness

### DIFF
--- a/notes/plans/README.md
+++ b/notes/plans/README.md
@@ -1,0 +1,17 @@
+# Protocol plans
+
+Status index audited against `develop` on 2026-07-19.
+
+| Document | Status | What remains |
+| --- | --- | --- |
+| [protocol-improvement-plan.md](protocol-improvement-plan.md) | Active roadmap | P1's forward-deployment Board/officer authority target, root action matrix, and matching boardRoom integration; external-controller P2 canonical terms/cap enforcement; and P3 registry hardening are implemented locally and unreleased. P2 replaced an undeployable in-printer prototype and now passes the production size gate. All 50 current non-fork Foundry test files pass individually, and P1 pinned fork acceptance passes (47 CyberCorp + 36 PumpCorp + 25 ParentCo tests); policy approval, target-block dry run, fresh-corp route acceptance, and authenticated hosted acceptance remain. P2/P3 need coordinated demo/pilot rollout. A stockholder-voting adapter is pilot-conditional. P4 CAL is proposed. |
+| [p1-board-authority-rollout-runbook.md](p1-board-authority-rollout-runbook.md) | Ready; execution open | Forward-only cutover through a separate v5 single factory, per-route atomic implementation/pointer pairing, selective real-corp disposition, contract/webapp acceptance, stop conditions, and rollback. The legacy single factory/reference and every existing corp remain unchanged. |
+| [issuer-award-templates-plan.md](issuer-award-templates-plan.md) | Target implemented locally; rollout open | The live proxy still has the interim permissionless caller-chosen path. Local contracts restore the owner-only curated path, add idempotent content-addressed `createTemplatePublic`, reject empty legal URIs, and pass the focused 18-test suite including proxy state preservation; the webapp call site and ABI are updated locally. Deploy/upgrade and runtime verification remain. |
+| [p2-p3-rollout-runbook.md](p2-p3-rollout-runbook.md) | Ready; execution open | Renderer/controller/registry deployment, IssuanceManager reference, atomic per-corp manager upgrade plus printer migration, webapp release, acceptance, and rollback. No CyberCertPrinter beacon upgrade; test-corp migration is not a release gate. |
+| [control-agreement-encumbrance-spec.md](control-agreement-encumbrance-spec.md) | Proposed / unbuilt (P4) | Implement lien storage/lifecycle, collateral guards, foreclosure, agreement/condition checks, upgrade/deploy path, indexer/web surface, and adversarial Foundry tests. |
+
+Cross-repo app status lives in
+`metalex-webapp/notes/plans/README.md`. In particular, webapp #815’s
+director/board-consent UI now consumes the local P1 target when enforcement is
+detected and retains the title-derived model only as a labeled legacy fallback.
+Neither the contracts nor that app branch are deployed yet.

--- a/notes/plans/control-agreement-encumbrance-spec.md
+++ b/notes/plans/control-agreement-encumbrance-spec.md
@@ -1,19 +1,19 @@
 # cyberCORPs Protocol — Control-Agreement Liens & Permissionless Foreclosure (CAL) — `PROPOSED`
 
-> **Status (2026-07-12): `PROPOSED` — nothing implemented on develop.** Spec added 2026-06-27
+> **Status (2026-07-19): `PROPOSED` — nothing implemented on develop.** Spec added 2026-06-27
 > (commit `93faa94`). Verified against develop: no lien/encumbrance/foreclosure code exists in
 > `src/` — none of the §18 files have been touched for this feature, and `src/libs/conditions/`
 > still contains only the pre-existing conditions (no `MaturityDefaultCondition` /
 > `ArbiterDefaultCondition` / `OracleNonPaymentCondition` / `RepaidCondition`). The §15 roadmap
-> deliverable — a stub in `notes/plans/protocol-improvement-plan.md` — was never added, and that
+> deliverable — a stub in `notes/plans/protocol-improvement-plan.md` — is now present as **P4**. The
 > plan's **P3** slot has since been taken by "Issuer-defined award templates" (commit `3923b4b`,
-> interim-shipped 2026-07-08 via `7edb89d`), so this spec needs a new item number when queued.
+> interim-shipped 2026-07-08 via `7edb89d`); this spec is therefore canonical protocol item **P4**.
 
 **Scope.** A full design spec for tying **UCC Article 8 / 9 / 12 control agreements** to cyberCORPs
 share-NFTs (`CyberCertPrinter` tokens) so the underlying registered shares become **encumbered by a
 lender's security interest** — perfected *by control* — and can be **permissionlessly foreclosed**
 on default. This is a protocol-side feature (`src/`); a companion webapp/indexer surface is sketched
-at the end. Promote to implementation as protocol item **P3**.
+at the end. Promote to implementation as protocol item **P4**.
 
 **Legal anchor.** Permanent Editorial Board for the UCC, *Report on the "Tokenization" of Securities
 Transfers Under the Uniform Commercial Code* (Draft for Public Comment, Apr 24 2026), **Case Study 2
@@ -654,10 +654,9 @@ listed here so the implementer sees the reasoning and the test that proves the f
   the standard `script/libs/` + `ERC1967Proxy`/deterministic-salt scripts (`deploy-*.s.sol`).
   Solidity 0.8.28, optimizer runs per repo config, MetaLeX proprietary header on all new files;
   condition files follow the existing `conditions/` SPDX style.
-- **Roadmap.** Add a **P3** stub to `notes/plans/protocol-improvement-plan.md` (house format:
-  problem → desired model → design direction → open questions) pointing at this spec.
-  *(Status 2026-07-12: not yet done — and the P3 slot in that plan is now "Issuer-defined award
-  templates" (`3923b4b`), so this spec will take the next free item number when the stub is added.)*
+- **Roadmap.** **P4 entry added** to `notes/plans/protocol-improvement-plan.md`
+  (house format: problem → desired model → design direction → open questions), pointing
+  at this spec. Implementation itself remains unstarted.
 
 ---
 
@@ -741,7 +740,7 @@ For `metalex-webapp` / `apps/cybercorps-web` and the shared cap-table features (
 | `src/libs/conditions/RepaidCondition.sol` | new (permissionless release predicate) |
 | `src/storage/extensions/ControlAgreementExtension.sol` | optional, read-only `tokenURI` surfacing |
 | `script/deploy-*.s.sol` | deploy conditions + extension; beacon/UUPS upgrade scripts |
-| `notes/plans/protocol-improvement-plan.md` | add **P3** stub pointing here *(not yet added; P3 since taken by issuer award templates — needs a new number, see Status)* |
+| `notes/plans/protocol-improvement-plan.md` | **P4 entry added** pointing here; implementation remains unstarted |
 
 ---
 

--- a/notes/plans/issuer-award-templates-plan.md
+++ b/notes/plans/issuer-award-templates-plan.md
@@ -1,8 +1,9 @@
 # Issuer-defined award templates — design evaluation & recommendation
 
-**Status:** `INTERIM SHIPPED` (2026-07-08) — a **temporary** variant is live on-chain; see §0.
-The recommendation in §6 (contract-side `createTemplatePublic`) remains the **unbuilt** target
-end-state. **Cross-repo update (2026-07-12):** the §0 app-layer mitigations are now fully
+**Status:** `TARGET IMPLEMENTED LOCALLY / UNRELEASED` (2026-07-19). The **temporary**
+variant remains live on-chain; see §0. The §6 recommendation is implemented in the current
+worktrees and awaits coordinated contract/webapp rollout. The §0 app-layer mitigations are
+already
 **SHIPPED** in `metalex-webapp` — PR **#801** (self-serve per-corp award templates,
 content-addressed registration + DB-backed provenance, merged 2026-07-08), PR **#803**
 (bespoke per-recipient agreements, zero protocol change, merged 2026-07-08), PR **#805**
@@ -13,6 +14,22 @@ This doc is referenced by **P3** in `protocol-improvement-plan.md`.
 ---
 
 ## 0. Status update (2026-07-08) — interim solution shipped
+
+**Local hardening update (2026-07-19).** The target end state is implemented but not
+deployed:
+
+- `createTemplate` is owner-only again, restoring the curated caller-chosen namespace;
+- `createTemplatePublic(title, uri, globalFields, partyFields)` is permissionless,
+  derives the content hash on-chain, returns the ID, and is idempotent;
+- empty legal-contract URIs are rejected, eliminating the registry's ambiguous
+  “nonexistent” sentinel state;
+- the deployment salt is bumped to `UpgradeV3.3.0`;
+- five focused security/upgrade tests were added and the 18-test registry suite passes via IR; and
+- the webapp ABI and issuer-template hook now call `createTemplatePublic` and still
+  re-derive stored content before use to protect against legacy pre-upgrade records.
+
+Deployment is intentionally not implied by this code status. Upgrade simulation, coordinated
+proxy/webapp rollout, live owner/public-path calls, and post-upgrade content read-back remain.
 
 **What shipped.** Commit `7edb89d` ("Opening up template creation") dropped the `onlyOwner`
 modifier from the **caller-chosen-id** `createTemplate` (`src/CyberAgreementRegistry.sol`),
@@ -402,9 +419,10 @@ self-serve one).
    make the grants template id per-corp. This unblocks issuer-defined award templates with a
    ~6-line registry change, **no** MetaVesT/controller change, and **no** new trust
    assumptions (content-addressing supplies the anti-squat property).
-   *(Status 2026-07-12: app half ✅ SHIPPED — webapp #801, merged 2026-07-08; contract half
-   — `createTemplatePublic` — still unbuilt, interim-superseded by the §0 permissionless
-   `createTemplate`.)*
+   *(Status 2026-07-19: app half ✅ SHIPPED in webapp #801; the contract half and
+   matching ABI/call-site cutover are implemented locally/unreleased. The live
+   proxies still run the §0 interim permissionless caller-chosen path until the
+   coordinated upgrade.)*
 2. **Keep Option B in reserve** as a complementary path for genuinely bespoke per-grant
    agreements: add a `proposeAndSignDealStandalone` variant on the controller when that need
    appears. *(Status 2026-07-12: bespoke need since served app-side with zero protocol

--- a/notes/plans/p1-board-authority-rollout-runbook.md
+++ b/notes/plans/p1-board-authority-rollout-runbook.md
@@ -1,0 +1,164 @@
+# P1 Board authority — forward rollout runbook
+
+**Status:** local target and webapp integration implemented; pinned fork
+acceptance passes; no deployment broadcast. Target-block dry run, fresh-corp
+route acceptance, policy approval, and authenticated hosted runtime remain.
+
+## Release posture
+
+Use a **forward cutover**. Almost all indexed corps are tests, and legacy
+`BorgAuth` instances are immutable: upgrading a legacy `CyberCorp` proxy cannot
+add the one-way `roleManager` lock to its already-deployed auth contract. Do not
+pretend that upgrading only the corp proxy creates Board enforcement.
+
+- Every newly deployed corp after cutover must use the dedicated v5
+  `CyberCorpSingleFactory` and an upgraded top-level factory that completes the
+  role-manager handoff and calls `activateBoardGovernance`.
+- Existing corps remain explicitly legacy unless they are individually
+  redeployed/migrated.
+- The legacy single factory and its v4 reference remain unchanged. This keeps
+  omitted/legacy top-level factories on the legacy path instead of letting them
+  deploy a v5 corp without the P1 handoff.
+- Reconcile only the named real-corp allowlist: the corps with off-chain
+  records/non-draft positions, assets, known external recipients/signers, or a
+  support/sales/legal designation. Test corps are not migration blockers.
+
+## Preconditions
+
+1. Record the chain, previous implementations, legacy
+   `CyberCorpSingleFactory` address/reference, and every top-level factory proxy
+   actually used by the product.
+2. Confirm the broadcaster has `OWNER_ROLE` on the auth attached to the single
+   factory and each supplied top-level factory.
+3. Run the P1 focused suite and the relevant factory/fork suites.
+4. Release the matching webapp ABI and boardRoom branch in the same window.
+5. Do not configure a Board adapter until a concrete stockholder-governance
+   contract, historical registered-owner voting checkpoints, canonical class
+   voting terms, and the legal voting policy have separately passed review.
+
+Current local evidence (2026-07-19):
+
+- `CyberCorpBoardAuthorityTest`: 7/7;
+- `CyberCorpForkTest`: 47/47;
+- `PumpCorpFactoryForkTest`: 36/36;
+- `DeployParentCoFactoryForkTest`: 25/25;
+- PumpCorp and ParentCo fork fixtures point their exercised deployment route at
+  v5 before exercising P1-aware factory code, proving the version-pairing
+  invariant; and
+- ParentCo bootstraps all configured officers before the one-way auth handoff,
+  then asserts the founder is Board-authorized and additional officers retain
+  the exact officer role.
+
+## Environment
+
+Required:
+
+```text
+PRIVATE_KEY_MAIN
+CYBERCORP_SINGLE_FACTORY  # legacy factory; auth source/read-only invariant
+```
+
+Supply every top-level factory proxy that can deploy a corp on the target chain:
+
+```text
+CYBERCORP_FACTORY
+PUMP_CORP_FACTORY
+PARENT_CO_FACTORY
+METADAO_FACTORY
+```
+
+An omitted optional factory is **not** upgraded and must be disabled in the app
+until handled.
+
+## Dry run
+
+Never add `--broadcast` to the first run:
+
+```sh
+forge script --via-ir script/upgrade-board-authority-forward-path.s.sol:UpgradeBoardAuthorityForwardPathScript \
+  --rpc-url "$RPC_URL" -vvvv
+```
+
+The script:
+
+- checks authority before broadcasting;
+- deploys a deterministic CyberCorp v5 reference;
+- deploys a separate deterministic v5 `CyberCorpSingleFactory`, using the
+  existing single-factory auth but leaving the legacy factory/reference
+  unchanged;
+- upgrades only the top-level factory proxies explicitly supplied and switches
+  each proxy to the v5 single factory inside that proxy's same
+  `upgradeToAndCall` transaction;
+- asserts the v5 reference/deploy version, the unchanged legacy reference, and
+  every supplied top-level factory pointer; and
+- does **not** upgrade or activate any existing corp.
+
+Review the simulation trace, target addresses, implementation bytecode, and gas
+before an owner-authorized broadcast. This split-factory design is deliberate:
+an upgraded route fails closed until its atomic pointer switch, while an omitted
+legacy route continues to deploy v4 rather than silently creating an
+unactivated v5 corp.
+
+## Broadcast order
+
+1. Pause/hide all corp-creation entry points.
+2. Broadcast the forward-path script with the reviewed environment.
+3. Read back the unchanged legacy reference, the new v5 single-factory
+   reference, and every supplied proxy implementation/pointer.
+4. Deploy one fresh internal test corp through each enabled factory route.
+5. Release the matching webapp, including the new single-factory address used
+   by deterministic-address and Pump signature helpers.
+6. Re-enable creation only after the acceptance checks pass.
+
+## Required acceptance checks
+
+For every enabled deployment route:
+
+- `CyberCorp.DEPLOY_VERSION()` is `"5"`;
+- `boardGovernanceEnforced()` is `true`;
+- `AUTH.roleManager()` equals the new corp;
+- the founder is both a director and an officer;
+- director and officer counts are both one;
+- an officer added by the founder cannot call `AUTH.updateRole`;
+- that officer cannot add/remove officers, change root corp configuration, or
+  authorize a corp upgrade;
+- the founder can add/remove officers and directors;
+- neither the last officer nor last director can be removed;
+- removing one capacity from a dual-role person preserves the other;
+- boardRoom shows `Board enforced` / `Protocol roster`;
+- officer controls appear only to a connected, authenticated director;
+- seat/unseat uses `addDirector`/`removeDirector`;
+- unanimous consent signers match the protocol Board roster; and
+- the legacy officer-based “Transfer cyberCORP” action is absent.
+
+Also open a known legacy corp and verify that it is labeled `Legacy authority` /
+`Title-derived`, uses the old signer fallback, and is never described as
+Board-enforced.
+
+## Real legacy corps
+
+For each allowlisted real corp, choose and document one disposition:
+
+1. **Preserve as labeled legacy** temporarily, with no claim of Board
+   enforcement.
+2. **Redeploy and reconcile** its legal identity, authorized classes, positions,
+   documents, and recipients into a fresh v5 corp after legal/operational
+   approval.
+3. **Custom migration** only if redeployment is unacceptable and the old auth
+   can be safely replaced through an explicitly reviewed architecture.
+
+Do not blanket-migrate the test inventory.
+
+## Stop and rollback conditions
+
+Stop before re-enabling creation if any fresh corp lacks the auth lock, Board
+activation, founder memberships, or UI mode detection; if an officer can mutate
+roles or root configuration; if a factory route still points at old code; or if
+consent signers diverge from the displayed roster.
+
+Because the rollout is forward-only, rollback consists of pausing creation,
+restoring each switched top-level factory implementation/pointer, and reverting
+the webapp release. The legacy single factory never changed. Keep the v5 single
+factory available as the `upgradeFactory` for any fresh internal v5 corps
+created during the window, even if those test corps are abandoned; no existing
+corp was mutated by this script.

--- a/notes/plans/p2-p3-rollout-runbook.md
+++ b/notes/plans/p2-p3-rollout-runbook.md
@@ -1,0 +1,183 @@
+# P2/P3 coordinated rollout runbook
+
+**Status:** deployable tooling is implemented locally; no live upgrade or
+migration has been performed from this worktree.
+
+This runbook coordinates:
+
+- **P2:** upgraded `ShareExtension` parsing, the externalized
+  `ShareClassTermsController`, IssuanceManager 4.2 lifecycle enforcement,
+  canonical class terms, and authorized-share caps. `CyberCertPrinter` remains
+  version 4; there is no printer storage or beacon upgrade.
+- **P3:** CyberAgreementRegistry 3.3 content-addressed public template creation
+  plus the matching webapp ABI/call site.
+
+Every `forge script` command must be simulated without `--broadcast` first.
+Production broadcasts require the relevant MetaLeX/global owner or individual
+corp owner; repository access is not upgrade authority.
+
+## 1. Scope the rollout
+
+Use the webapp launch-baseline shortlist, not all historical test corps. Start
+with one named demo corp, then the first supported real pilot. For each record:
+
+- chain, corp, IssuanceManager, share-printer, current extension, and renderer
+  addresses;
+- current implementation addresses and `DEPLOY_VERSION` values;
+- the reviewed source certificate/token id for each existing share printer;
+- charter/class-authority evidence supporting its `SeriesTerms`; and
+- independently reconciled active certificate plus scrip units.
+
+Stop if prior certificates on one printer disagree on class terms. Migration
+chooses one canonical record and must not guess through a legal/data conflict.
+Test-corp migration is not a release gate.
+
+## 2. Verify the artifacts
+
+Run:
+
+```text
+forge test --via-ir --match-contract CyberCertPrinterClassTermsTest
+forge test --via-ir --match-contract CyberAgreementRegistryTest
+forge build --via-ir --sizes --skip test --skip script
+```
+
+The audited local build has:
+
+| Contract | Runtime bytes | EIP-170 margin |
+| --- | ---: | ---: |
+| CyberCertPrinter v4 | 23,644 | 932 |
+| IssuanceManager 4.2 | 18,662 | 5,914 |
+| ShareClassTermsController | 7,531 | 17,045 |
+| ShareExtension renderer | 23,311 | 1,265 |
+
+Stop on any size regression. The rejected in-printer P2 prototype was 28,979
+bytes—4,403 bytes over EIP-170—which is why canonical state lives in the
+external controller.
+
+## 3. Global deployments and references
+
+1. Upgrade each in-scope ShareExtension proxy with
+   `script/upgrade-share-extension.s.sol` and `SHARE_EXTENSION_PROXY`. This adds
+   the exact `SeriesTerms` extractor while preserving rendering.
+2. Deploy one UUPS controller proxy with
+   `script/deploy-share-class-terms-controller.s.sol` and
+   `SHARE_EXTENSION_RENDERER`.
+3. Deploy and set the IssuanceManager 4.2 reference with
+   `script/upgrade-issuance-manager-ref.s.sol`.
+4. Upgrade CyberAgreementRegistry to 3.3 with
+   `script/upgrade-cyber-agreement-registry.s.sol` and
+   `CYBER_AGREEMENT_REGISTRY`.
+
+Read back and archive:
+
+- controller proxy, implementation, auth, renderer, and `SHARE` support;
+- factory reference and `IssuanceManager(ref).DEPLOY_VERSION() == "4.2"`;
+- renderer proxy state and terms-extractor behavior; and
+- registry implementation/version plus a known pre-existing template and
+  agreement before and after upgrade.
+
+Do not deploy or set a CyberCertPrinter v5 reference. P2 does not change the
+printer implementation or its beacon.
+
+## 4. Per-corp atomic upgrade and migration
+
+An upgraded IssuanceManager fails closed when a share printer still points to a
+legacy renderer: issuance, update, void, and restore cannot bypass cap
+accounting. Use
+`script/upgrade-and-migrate-share-class-terms.s.sol` with:
+
+- `ISSUANCE_MANAGER`;
+- `ISSUANCE_MANAGER_IMPLEMENTATION` (which must already be the factory reference);
+- `SHARE_CLASS_TERMS_CONTROLLER`;
+- comma-delimited `CERT_PRINTERS`; and
+- matching comma-delimited `SOURCE_TOKEN_IDS`.
+
+The script submits one owner transaction:
+
+```text
+upgradeToAndCall(
+  referenceImplementation,
+  abi.encodeCall(
+    migrateClassTermsControllers,
+    (printers, controller, sourceExtensionData)
+  )
+)
+```
+
+This upgrades the manager and migrates every supplied printer atomically. Any
+bad source, class conflict, counter violation, length mismatch, or later-printer
+failure rolls back the implementation upgrade and every earlier printer change.
+The focused suite proves both the successful two-printer path and second-printer
+rollback.
+
+The older `accept-upgrade-issuance-manager.s.sol` plus
+`configure-share-class-terms.s.sol` scripts remain useful for simulation and
+diagnosis, but separate broadcasts create a temporary fail-closed pause. Do not
+use them as the production cutover unless issuance is operationally disabled and
+the non-atomic exception is explicitly approved.
+
+Once a controller is installed, the migration function refuses to replace it.
+Future implementation changes use the controller's governed UUPS upgrade; legal
+term changes use `amendClassTerms`.
+
+New printers must use `createCertPrinterWithClassTerms`, with the controller as
+their share extension, so class creation and configuration are atomic.
+
+## 5. Migration read-back
+
+For every migrated printer, call
+`ShareClassTermsController.getClassTerms(printer)` and archive:
+
+- controller and printer addresses;
+- terms bytes, hash, and decoded terms;
+- authorized and issued units;
+- the independently reconciled unit total;
+- source certificate and authority evidence; and
+- transaction hash, block, and operator.
+
+Verify normal printer metadata, ownership, certificate details, legends, token
+URIs, and scrip balances are unchanged. Stop on any counter disagreement.
+
+## 6. Release the webapp as one protocol unit
+
+Deploy the webapp build containing:
+
+- P3 `createTemplatePublic`;
+- the controller and IssuanceManager ABIs;
+- the printer `getExtension(0)` resolver;
+- `useCertPrinterClassTerms` and the strict `SeriesTerms` decoder; and
+- locked canonical class fields in the issuance form.
+
+Do not release the P2 UI for a corp before its manager and printers are migrated.
+Legacy/unconfigured reads resolve to the labeled legacy form, but the upgraded
+manager intentionally prevents lifecycle writes until migration succeeds.
+
+## 7. Runtime acceptance
+
+On the named demo corp, then the deliberately supported real pilot:
+
+1. Open issue-existing-class and confirm terms come from
+   `controller.getClassTerms(printer)` and are read-only.
+2. Mint within remaining authorization and confirm `issuedUnits` increases.
+3. Simulate/reject an over-cap mint and a mismatched-terms mint.
+4. Scripify partially, then recertify; confirm the counter does not move.
+5. Void/unvoid a test certificate and confirm the counter releases/restores.
+6. Attempt to migrate the printer to a second controller and confirm it reverts.
+7. Register identical award-template content twice; confirm the same id and no
+   overwrite. Confirm curated caller-chosen creation remains owner-only.
+8. Verify indexer/cap-table totals, holder portal visibility, and OCF export
+   against the on-chain record.
+
+## 8. Rollback and stop conditions
+
+Pause issuance before any rollback. Once canonical state is configured,
+downgrading the manager would make older code ignore its cap; pointing a printer
+back to the renderer would strand controller accounting. Neither is a safe
+operating state. Prefer fixing forward. If rollback is unavoidable, disable
+issuance in the webapp and operationally block owner lifecycle transactions until
+the controller-enforced implementation is restored.
+
+Stop on any storage drift, class-term disagreement, counter mismatch, unexpected
+typed revert, controller replacement, indexer divergence, or inability to
+identify legal authority for the class record.

--- a/notes/plans/protocol-improvement-plan.md
+++ b/notes/plans/protocol-improvement-plan.md
@@ -9,26 +9,43 @@ up front. Companion to the webapp-side plan (`notes/plans/mainframe-changes-plan
 **Status.** Active log. Each item: **problem → desired model → design direction → open questions**.
 Items are `PROPOSED` until specced/scheduled.
 
-**Last audited:** 2026-07-12 against `develop`. P1 `PROPOSED` (no code shipped — officer fns still
-`onlyOwner`, no Board role). P2 `PROPOSED` (no code shipped — terms still per-cert; PR #107 reshaped
-the struct but not the storage model, see P2 status note). P3 `INTERIM SHIPPED` on-chain (commit
-`7edb89d`, live 2026-07-08); webapp self-serve shipped (`metalex-webapp` #801 + #803, merged
-2026-07-08); recommended end-state (Option A) not built.
+**Last audited:** 2026-07-20 against the current worktree. P1 is **implemented locally for new
+corps / unreleased**: Board and officer roles are distinct, direct ACL mutation is locked behind
+the `CyberCorp`, Board membership is stored on-chain, officer and Board last-member guards are
+enforced, and a Board-role adapter provides the stockholder-governance execution hook. P2 is
+**implemented locally / unreleased** through an externalized `ShareClassTermsController`: the
+controller stores and hashes canonical `SeriesTerms`, enforces the authorized-share cap, maintains
+issued-unit accounting across update/void/unvoid/burn and scrip representation changes, and
+exposes governed configuration/amendment paths. `IssuanceManager` supplies the enforcement hooks
+and an atomic, one-way legacy-printer migration; the webapp resolves the controller through the
+printer and locks its canonical terms. This replaced an earlier in-printer prototype that exceeded
+EIP-170. The focused P2 suite passes 10/10, including atomic `upgradeToAndCall`, batch rollback,
+length validation, and migration replacement prevention, and all
+production contracts fit the runtime-size limit. P3's interim implementation remains
+live on-chain (commit `7edb89d`, 2026-07-08), while the recommended Option A hardening is
+**implemented locally / unreleased**: arbitrary caller-chosen IDs are owner-only again,
+`createTemplatePublic` is content-addressed and idempotent, empty legal URIs are rejected,
+the focused registry suite passes 18/18 including proxy state preservation, and the webapp
+ABI/call site is updated locally.
+All 50 current non-fork Foundry test files pass individually on the final local tree. The monolithic
+whole-suite command was not used as release evidence because unrelated legacy external-fork
+tests can spend an unbounded period retrying remote RPCs; the release-critical pinned fork
+suites are recorded under P1 below.
+Coordinated proxy upgrade plus webapp rollout/runtime verification remain. P4
+control-agreement liens / permissionless foreclosure is `PROPOSED`; no lien code exists.
 
 ---
 
-## P1 — Board role: governance-correct appointment & removal of officers — `PROPOSED`
+## P1 — Board role: governance-correct appointment & removal of officers — `TARGET LOCAL / UNRELEASED`
 
-_Status check 2026-07-12: still accurate on `develop` — `addOfficer`/`removeOfficer`/`removeOfficerAt`
-remain `onlyOwner`-gated with no last-officer guard (`src/CyberCorp.sol:191/200/215`), and no Board
-role exists in `src/libs/auth.sol`. Nothing shipped._
+**Status update (2026-07-19).** The forward-deployment target is implemented locally and its
+available fork suites pass. It has not been deployed. The matching webapp v5
+roster/mutation/consent integration is implemented locally but has not received
+authenticated hosted-runtime acceptance.
 
-**Problem (current on-chain behavior).** Every company officer holds BorgAuth role **200**, and the
-officer-management functions on `CyberCorp` — `addOfficer` (`src/CyberCorp.sol:191`), `removeOfficer`
-(`:200`), `removeOfficerAt` (`:215`) — are gated only by **`onlyOwner()`**, which is a *threshold*
-check `userRoles[caller] >= OWNER_ROLE (99)` (`src/libs/auth.sol`; cf. `isCyberCORPOfficer` =
-`role >= OWNER_ROLE`, `CyberCorp.sol:185`). Because every officer sits at 200 (≥ 99),
-**any officer can appoint or remove any other officer — or themselves.** Consequences:
+The historical/live behavior was a flat ACL: every company officer held BorgAuth role **200**, and
+the officer-management functions were gated by the numeric `onlyOwner()` threshold. Any officer
+could therefore appoint or remove any other officer, including the last officer. That caused:
 
 - **Flat, mutual eviction.** Officers are a flat peer set with no hierarchy; any co-owner can
   unilaterally remove the others, and in a dispute whoever signs `removeOfficer` first wins.
@@ -38,69 +55,138 @@ check `userRoles[caller] >= OWNER_ROLE (99)` (`src/libs/auth.sol`; cf. `isCyberC
   zero (no address `>= 99` → `onlyOwner` can never pass again → the corp is permanently frozen).
   (The webapp `metalex-webapp` PR #745 adds a *UI-only* guard; nothing enforces it on-chain.)
 
-This mismatches real corporate governance, where **stockholders elect the board, and the board
-appoints/removes officers** — officers do not appoint or fire themselves or each other.
+This mismatched real corporate governance, where **stockholders elect the board, and the board
+appoints/removes officers**.
 
-**Desired model.** Introduce a distinct **Board** (director) authority above officers:
+**Implemented target.**
 
 - **Officers are appointed/removed by the Board**, not by other officers. Re-gate
   `addOfficer` / `removeOfficer` / `removeOfficerAt` to require **Board** authority rather than
   `onlyOwner`/officer-200.
-- **The Board can only be changed in two ways:** (a) **by the Board itself** (board members
-  appoint/remove board members), or (b) **by the tokenized stockholders** (the on-chain equity
-  holders can replace the board).
+- **The Board can be changed by the Board itself** through explicit director add/remove functions,
+  or by an executor authorized through the Board role's `IAuthAdapter` hook. The actual
+  class-aware stockholder voting adapter/Governor is still a separate implementation item.
 - This encodes the real hierarchy on-chain — **tokenized stockholders → Board → officers →
   managers** — consistent with the constitutive-register thesis (the stockholders, the board, and
   their votes are all on-chain rather than pointers to an off-chain cap table).
 
-**Design direction (high-level — details TBD).**
+Implementation details:
 
-- A new **Board role** in BorgAuth (a distinct level/role above officer-200, or a separate Board
-  module); officer-management functions check Board authority instead of `onlyOwner`.
-- **Board self-management:** board-gated add/remove of board members.
-- **Stockholder override:** the protocol already has the hook — BorgAuth's **`IAuthAdapter` /
-  `setRoleAdapter`** lets a role's authority be delegated to an external contract. The Board role
-  could use an adapter that defers to a **stockholder-governance contract** (a vote/snapshot of the
-  cert/scrip holders representing equity, or a Governor/timelock), so "stockholders can replace the
-  board" without hard-coding a voting mechanism into `auth.sol`.
-- **Migration / backward-compat:** existing corps have officers at flat-200 with self-referential
-  power. A migration seats an initial Board (e.g. the founder becomes the first board member +
-  officer) and re-points officer management at the Board — likely via the existing `*WithMigration`
-  pattern.
-- **On-chain last-member guards:** prevent the Board (and officers) from reaching zero and bricking
-  the corp — the guard the webapp currently only enforces in the UI.
+- `BorgAuth` defines `OFFICER_ROLE = 200` and `BOARD_ROLE = 300`, and supports an irreversible,
+  one-time `roleManager`. Once the factory hands role management to the new `CyberCorp`, officers
+  cannot bypass Board policy by calling `updateRole` or `setRoleAdapter` directly.
+- `CyberCorp` v5 stores separate director/officer rosters and membership mappings. It exposes
+  Board activation, director add/remove, membership/count reads, and Board adapter configuration.
+- New deployments seed the founder as both the first director and first officer. All four corp
+  factories complete the ACL handoff and activate Board governance only after their manager roles
+  are configured. ParentCo additionally completes its configured multi-officer bootstrap before
+  the one-way handoff, so it does not lose authority midway through initialization.
+- The forward rollout deploys a separate v5 `CyberCorpSingleFactory` and atomically pairs each
+  upgraded top-level factory implementation with that pointer via `upgradeToAndCall`. The legacy
+  single factory/reference stays unchanged, preventing an omitted legacy factory from silently
+  deploying an unactivated v5 corp.
+- Officer appointment/removal is Board-gated once governance is enforced. Removing the last
+  officer or director reverts, and removing one capacity preserves the other for dual-role people.
+- Legacy upgraded proxies remain explicitly in compatibility mode until governance activation;
+  the app/plans must not label that mode as Board-enforced.
 
-**Open questions.**
+**Verification.** `CyberCorpBoardAuthorityTest` passes 7/7, covering the one-way role-manager lock,
+officer bypass prevention, Board-controlled officers, Board self-management, last-member guards,
+dual-role preservation, and adapter-authorized Board replacement. `CyberCorpSingleFactoryTest`
+passes. The pinned fork suites now model the required rollout order by updating the shared
+`CyberCorpSingleFactory` reference to v5 before using a P1-aware top-level factory:
+`CyberCorpForkTest` passes 47/47, `PumpCorpFactoryForkTest` passes 36/36, and
+`DeployParentCoFactoryForkTest` passes 25/25. Pump and ParentCo include explicit assertions for
+the role-manager lock, Board activation, and exact founder/additional-officer roles. The rollout
+scripts compile, and `ParentCoFactory` remains 3,423 bytes below EIP-170. No transaction has been
+broadcast.
 
-1. **Role encoding:** a new numeric BorgAuth level (where, relative to 200 / 99?) vs a separate
-   Board contract/module? Threshold (`>=`) semantics mean a higher Board level would also satisfy
-   officer/owner gates — intended or not?
-2. **What counts as "tokenized stockholders"** for the governance path — cyberSHARES / cyberSCRIP
-   holders, registered cert holders, or a per-class voting weight? Quorum / threshold / timelock?
-3. **Mechanism for the stockholder → board path:** an `IAuthAdapter` deferring to a Governor
-   contract, a direct stockholder-vote function on a Board module, snapshot-based, …?
-4. **Interaction with `OWNER_ROLE = 99` (the manager contracts) and the upgrade co-approval model**
-   — does Board subsume "owner," or coexist alongside it?
-5. **Legal mapping:** confirm the board / officer / stockholder split maps cleanly across the entity
-   types the protocol supports (DE C-corp directors & officers; LLC managers & members; SPC; etc.).
+**What remains before the first real pilot.**
 
-**References.** `src/CyberCorp.sol:185-222` (officer fns + `isCyberCORPOfficer`); `src/libs/auth.sol`
-(BorgAuth roles, `onlyRole` threshold, `updateRole`, `setRoleAdapter` / `IAuthAdapter`);
-`src/CyberCorpFactory.sol:220` (founder granted 200 at deploy). Webapp side: `metalex-webapp` M34 /
-PR #745 (Mainframe ownership UI) and the auth findings in its `notes/plans/mainframe-changes-plan.md`.
+1. Runtime-test and release the locally implemented webapp branch that uses v5
+   director reads and `addDirector`/`removeDirector`, gates officer controls on
+   Board authority, routes consent signers from the protocol roster, labels
+   legacy mode, and suppresses the legacy transfer flow for v5.
+2. The root action matrix is now implemented locally: legal identity, manager
+   pointers, treasury payable address, and corp upgrades are Board-gated when
+   enforcement is active; reusable escrowed signatures remain an officer
+   operation. Confirm this policy in legal/product review and extend it to
+   manager-contract actions only where a concrete corporate-approval rule
+   requires Board consent.
+3. Because existing `BorgAuth` deployments are immutable, inventory the small set of corps with
+   real records and choose per-corp migration/redeployment. Given current usage, do not attempt a
+   blanket migration of hundreds of test corps.
+4. Fork acceptance is complete. Dry-run the rollout script against the intended target block,
+   deploy a fresh test corp through every enabled route, and complete the authenticated
+   boardroom/consent/issuance acceptance checklist before any production cutover.
+5. Limit the pilot to a corporation whose founder-seeded initial Board policy has been explicitly
+   accepted. Confirm the legal mapping for LLCs, partnerships, SPCs, and funds before presenting
+   director/officer vocabulary to those entity types.
+
+The concrete class-aware stockholder voting/Governor adapter is a later or
+pilot-conditional item, not a blocker for a deliberately scoped founder-Board
+pilot that makes no claim of on-chain stockholder elections. Do not build it over
+current spot certificate balances. It first needs historical voting checkpoints
+at a record-date block, aggregation by registered/legal owner (which can differ
+from NFT `ownerOf`), and canonical per-class voting terms; then class voting,
+quorum, thresholds, proposal execution, replay protection, and timelocks. Until
+those prerequisites exist, the adapter hook is only an execution boundary and the
+UI must describe the founder-seeded Board as bootstrap policy, not stockholder
+governance.
+
+The forward rollout and selective legacy disposition are specified in
+[p1-board-authority-rollout-runbook.md](p1-board-authority-rollout-runbook.md).
+
+**References.** `src/CyberCorp.sol`; `src/libs/auth.sol`; the four factory handoff sites;
+`test/CyberCorpBoardAuthorityTest.t.sol`. Webapp side:
+`metalex-webapp/notes/plans/cybercorps-boardroom-plan.md`.
 
 ---
 
-## P2 — Class-level security terms have no on-chain home (stored per-certificate) — `PROPOSED`
+## P2 — Canonical class terms and authorized-share enforcement — `TARGET LOCAL / UNRELEASED`
 
-_Status check 2026-07-12: still accurate on `develop`; nothing from the desired model has shipped.
-Note PR #107 (`feat/shares-extension-logic`, merged 2026-06-02 — predates this section) reshaped the
+_Historical baseline: PR #107 (`feat/shares-extension-logic`, merged 2026-06-02) reshaped the
 per-cert struct — the old flat `ShareData` became `ShareCertData` with a dedicated `SeriesTerms` terms
 struct (`ShareExtension.sol:142-183`, expanded with dividend/redemption/pro-rata/information-rights
-fields) — but the **storage model is unchanged**: `ShareExtension` is a stateless encoder,
-`SeriesTerms` is still ABI-encoded into each cert's `extensionData` (now
-`CyberCertPrinterStorage.sol:58`), `CyberCertPrinter.initialize` still stores identity only, and
-`authorizedShares` remains unenforced. #107 does not address this item._
+fields), but left the storage model per-certificate and `authorizedShares` unenforced._
+
+**Status update (2026-07-19).** The deployable target is implemented locally but not deployed:
+
+- `ShareClassTermsController`, a UUPS extension facade, stores each printer's canonical
+  `SeriesTerms` bytes/hash, authorized shares, issued units, and configured flag. It delegates
+  rendering/parsing to the existing `ShareExtension`, so `CyberCertPrinter` remains at deploy
+  version 4 with no storage or beacon upgrade.
+- `ShareExtension.getSeriesTermsData` extracts exactly `SeriesTerms`. The controller validates
+  every later share mint/update against the canonical hash; `CertificateData`, restrictions,
+  triggers, and split history remain certificate-specific.
+- `IssuanceManager` calls the controller on every share lifecycle path. Issuance rejects
+  `issuedUnits + newUnits > authorizedShares`; normal unit updates apply deltas; void/burn release
+  units; unvoid restores them. Scripification and recertification are representation-only, so
+  scripified units count exactly once.
+- New printers use `createCertPrinterWithClassTerms` to create and configure atomically. Existing
+  printers use owner-gated `migrateClassTermsControllers`. The complete batch is valid
+  `upgradeToAndCall` payload, so upgrading a corp's manager and migrating all of its supplied
+  printers occurs in one transaction. It derives outstanding active plus scrip units on-chain and
+  rolls back the implementation upgrade plus every prior printer change if any migration fails.
+  After any controller is installed, the migration entry point refuses to replace it; later changes
+  use the controller's governed UUPS/amendment paths.
+- The upgraded manager deliberately fails closed for an unmigrated legacy share renderer:
+  lifecycle operations cannot silently bypass cap enforcement. Upgrade and per-printer migration
+  therefore belong in one owner-controlled batch for every in-scope corp.
+- `amendClassTerms` supports authorized corporate amendments but refuses to reduce authorization
+  below issued units.
+- The first in-printer implementation was rejected after size verification: it made
+  `CyberCertPrinter` 28,979 bytes, 4,403 bytes over EIP-170. On the current `develop` baseline,
+  the external controller is 7,531 bytes; the final `CyberCertPrinter` is 23,644 bytes
+  (932-byte margin), and `IssuanceManager` is 18,662 bytes (5,914-byte margin). The disabled
+  legacy `IssuanceManagerWithMigration` prototype is not part of the deployable artifact set.
+- Focused verification: `CyberCertPrinterClassTermsTest` **10/10**, including atomic manager
+  upgrade plus multi-printer migration, full-batch rollback, length validation, and
+  controller-replacement rejection; `IssuanceManagerScripComplianceTest` **7/7**; and
+  `ScripPOCTest` **15/15**. The full production size build passes.
+- Remaining rollout: upgrade the renderer, deploy the controller, set the IssuanceManager 4.2
+  reference, batch-upgrade/migrate only the named demo and real-pilot printers, then release the
+  matching webapp ABI/read path and verify live read-back. Test-corp migration is not a release gate.
 
 **Problem.** A `CyberCertPrinter` is the per-security-class contract, but it stores only class
 **identity** — `initialize(... name, ticker, certificateUri, SecurityClass, SecuritySeries, extension)`
@@ -126,29 +212,24 @@ on-chain home for its **class-level terms**, set once at class creation, so issu
 against the class** (the source of truth) and `authorizedShares` can be enforced as a cap. Genuinely
 per-certificate fields (units represented, investment amount, holder, issuance date) stay per-cert.
 
-**Design direction (high-level — details TBD).**
+**Implemented design.**
 
-- Add a class-terms struct to `CyberCertPrinter` storage, populated at `initialize` / `createCertPrinter`
-  (`src/IssuanceManager.sol:229`); split the `ShareExtension` terms into **class-level** (seriesName, par
-  value, original issue price, effective date, authorized shares, liquidation preference) vs **per-cert**.
-- On issuance, default per-cert extension data from the class terms and **validate**: reject mismatched
-  class terms and enforce `Σ unitsRepresented ≤ authorizedShares` at the class.
-- **Migration / back-compat:** existing printers have no class terms; backfill from the most-recent prior
-  cert (the only current source) or via a one-shot migration (cf. the `*WithMigration` pattern). Until
-  then the webapp M1 pre-fill can only seed from a prior cert.
+- The complete `SeriesTerms` struct is class-level. `CertificateData` and the variable-length
+  per-certificate arrays remain per-certificate.
+- Canonical data is stored by the external controller as ABI-encoded terms plus a hash, avoiding
+  a duplicate giant Solidity struct and keeping the already-near-limit printer deployable.
+- The cap is on-chain and uses the protocol's 18-decimal unit representation.
+- Terms may be amended only through an explicit owner-gated operation with the issued-unit floor.
 
-**Open questions.**
+**Remaining decisions / follow-up.**
 
-1. Which terms are truly class-level vs allowed to vary per cert (e.g. can `originalIssuePrice` differ by
-   round / tranche, or is it fixed per class)?
-2. On-chain class storage vs a canonical off-chain class row — and how that interacts with the
-   constitutive-register thesis (the class terms are arguably part of the authoritative record).
-3. Enforce the `authorizedShares` cap **on-chain** at issuance, or track/report it off-chain only?
-4. Interaction with scrip / unit accounting (scripified units still count against authorized) and with
-   non-share instruments (SAFE/SAFT/etc., which have different "class terms").
-5. OCF / cap-table mapping for the class-level fields.
+1. Define the evidence and approval record required before a production `amendClassTerms`.
+2. Add indexer/OCF class-level fields if direct RPC reads prove insufficient for reporting scale.
+3. Decide whether non-share instruments need analogous canonical records; P2 intentionally applies
+   only to extensions that advertise `EXTENSION_TYPE == keccak256("SHARE")`.
 
-**References.** `src/CyberCertPrinter.sol:107` (initialize — identity only, no terms);
+**References.** `src/storage/extensions/ShareClassTermsController.sol`;
+`src/storage/IssuanceManagerStorage.sol`; `src/CyberCertPrinter.sol:107` (initialize — identity only, no terms);
 `src/storage/extensions/ShareExtension.sol:143-150` (the terms struct, encoded per-cert) + `:286-305`
 (rendered per-cert into tokenURI); `src/storage/CyberCertPrinterStorage.sol:51` (`CertificateDetails.extensionData`);
 `src/IssuanceManager.sol:229` (`createCertPrinter`). Webapp side: `metalex-webapp` **M1** (pre-fill blocked by
@@ -156,12 +237,25 @@ this) in its `notes/plans/mainframe-changes-plan.md`.
 
 ---
 
-## P3 — Issuer-defined award templates (grants) — `INTERIM SHIPPED` (2026-07-08)
+## P3 — Issuer-defined award templates (grants) — `TARGET LOCAL / UNRELEASED`
 
 **Full evaluation:** `notes/plans/issuer-award-templates-plan.md` (three options, recommendation,
 per-option contract + app changes). Summary below.
 
-**Status update.** An **interim** variant is live: commit `7edb89d` removed `onlyOwner` from
+**Status update (2026-07-19).** The recommended Option A target is now implemented
+locally. `createTemplate` is restored to `onlyOwner` for curated caller-chosen IDs;
+permissionless issuers use the new `createTemplatePublic`, which derives
+`keccak256(abi.encode(title, legalContractUri, globalFields, partyFields))` on-chain
+and treats identical content idempotently. `_createTemplate` now rejects an empty legal
+URI so existence cannot remain ambiguous. Five focused security/upgrade tests cover the
+owner gate, permissionless content addressing, idempotency, empty-URI rejection, and proxy
+state preservation; the focused registry suite passes 18/18 with `forge test --via-ir`. The deployment script
+uses the new `UpgradeV3.3.0` salt. The companion webapp ABI and issuer registration call
+now target `createTemplatePublic`, while retaining read-back hash verification for
+pre-upgrade registry state.
+
+This code is **not live yet**. The currently deployed **interim** variant remains:
+commit `7edb89d` removed `onlyOwner` from
 the caller-chosen-id `createTemplate` and the registry proxy was upgraded (verified live on
 Base + Ethereum mainnet, 2026-07-08). This is deliberately **temporary** — it is the
 squattable caller-chosen-id variant the full doc warns against, accepted for now to unblock
@@ -170,11 +264,14 @@ Drawbacks, required app-layer mitigations, and the recommended optimal end-state
 `createTemplate` + add content-addressed `createTemplatePublic`, i.e. Option A) are recorded
 in the full doc's §0.
 
-**Webapp side (update 2026-07-12):** the compensating app layer has shipped — self-serve
+**Webapp side:** the compensating app layer shipped in 2026-07, and the current local
+worktree additionally switches registration to `createTemplatePublic`. The shipped layer is
+self-serve
 per-corp award templates with content-addressed registration against the now-permissionless
 `createTemplate` (`metalex-webapp` PR #801, merged 2026-07-08) and bespoke per-recipient
-agreements (`metalex-webapp` PR #803, merged 2026-07-08). The recommended on-chain end-state
-(Option A: re-gate `createTemplate`, add `createTemplatePublic`) remains **unbuilt**.
+agreements (`metalex-webapp` PR #803, merged 2026-07-08). The target contract and app changes
+must be released together after proxy-upgrade simulation; until then the live webapp continues
+to use the interim entry point.
 
 **Problem.** cyberCORPs grants register the award agreement in the **global, MetaLeX-owned**
 `CyberAgreementRegistry`, and the MetaVesT controller's `proposeAndSignDeal(templateId, …)`
@@ -230,6 +327,22 @@ MetaVesT `feat/re-enable-options` `MetaVesTControllerStorage.sol:220/331`. Webap
 
 ---
 
+## P4 — Control-agreement liens & permissionless foreclosure — `PROPOSED`
+
+**Full spec:** `notes/plans/control-agreement-encumbrance-spec.md`.
+
+Model a UCC Article 8/9/12 control-agreement lien over a cyberCERT without moving
+custody to the lender: the borrower remains registered/ERC-721 owner until a
+condition-verified foreclosure re-registers and transfers the shares. The full spec
+pins the lien state machine, collateral escape guards, agreement-party verification,
+conditions, upgrade/storage constraints, web/indexer surface, and Foundry test plan.
+
+_Status check 2026-07-19:_ no `Lien`/encumbrance/foreclosure state, entry points,
+conditions, extension, or tests exist in `src/`/`test/`. This item was originally
+described as P3 before issuer templates took that slot; P4 is now canonical.
+
+---
+
 ## Backlog (unprioritized)
 
-_(none yet — add future protocol improvements here)_
+_(none beyond P1–P4 yet)_

--- a/script/accept-upgrade-issuance-manager.s.sol
+++ b/script/accept-upgrade-issuance-manager.s.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.28;
 
-import {Script, console2} from "forge-std/Script.sol";
-import {CyberCorpFactory} from "../src/CyberCorpFactory.sol";
 import {CyberCorp} from "../src/CyberCorp.sol";
+import {CyberCorpFactory} from "../src/CyberCorpFactory.sol";
 import {IssuanceManager} from "../src/IssuanceManager.sol";
 import {IssuanceManagerFactory} from "../src/IssuanceManagerFactory.sol";
-import {DeploymentConstants} from "./libs/DeploymentConstants.sol";
 import {ERC1967ProxyLib} from "../test/libs/ERC1967ProxyLib.sol";
+import {DeploymentConstants} from "./libs/DeploymentConstants.sol";
+import {Script, console2} from "forge-std/Script.sol";
 
 contract AcceptUpgradeIssuanceManagerScript is Script {
     using ERC1967ProxyLib for address;
@@ -16,9 +16,8 @@ contract AcceptUpgradeIssuanceManagerScript is Script {
         DeploymentConstants.CoreDeployment memory deployment = DeploymentConstants.coreV2(block.chainid);
 
         address cyberCorpFactoryAddr = vm.envOr("CYBERCORP_FACTORY", deployment.cyberCorpFactory);
-        IssuanceManagerFactory imFactory = IssuanceManagerFactory(
-            CyberCorpFactory(cyberCorpFactoryAddr).issuanceManagerFactory()
-        );
+        IssuanceManagerFactory imFactory =
+            IssuanceManagerFactory(CyberCorpFactory(cyberCorpFactoryAddr).issuanceManagerFactory());
 
         IssuanceManager im = IssuanceManager(CyberCorp(corpAddr).issuanceManager());
         address currentImplAddr = address(im).getErc1967Implementation();
@@ -26,19 +25,21 @@ contract AcceptUpgradeIssuanceManagerScript is Script {
 
         console2.log("==== Configs ====");
         console2.log("Current implementation: %s, DEPLOY_VERSION: %s", currentImplAddr, im.DEPLOY_VERSION());
-        console2.log("Reference implementation: %s, DEPLOY_VERSION: %s", refImplAddr, IssuanceManager(refImplAddr).DEPLOY_VERSION());
+        console2.log(
+            "Reference implementation: %s, DEPLOY_VERSION: %s",
+            refImplAddr,
+            IssuanceManager(refImplAddr).DEPLOY_VERSION()
+        );
         console2.log("");
 
-        vm.assertNotEq(
-            currentImplAddr,
-            refImplAddr,
-            "Already at reference implementation, no need to upgrade"
-        );
+        vm.assertNotEq(currentImplAddr, refImplAddr, "Already at reference implementation, no need to upgrade");
 
         vm.startBroadcast(vm.envUint("PRIVATE_KEY_MAIN"));
 
         im.upgradeToAndCall(refImplAddr, "");
         console2.log("CyberCorp: %s accepted IssuanceManager upgrade to: %s", corpAddr, refImplAddr);
+
+        vm.assertEq(im.DEPLOY_VERSION(), "4.2", "IssuanceManager version mismatch");
 
         vm.stopBroadcast();
     }

--- a/script/configure-share-class-terms.s.sol
+++ b/script/configure-share-class-terms.s.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.28;
+
+import {CyberCertPrinter} from "../src/CyberCertPrinter.sol";
+import {IssuanceManager} from "../src/IssuanceManager.sol";
+import {IShareClassTermsController} from "../src/interfaces/IShareClassTermsController.sol";
+import {BorgAuth} from "../src/libs/auth.sol";
+import {CertificateDetails} from "../src/storage/CyberCertPrinterStorage.sol";
+import {Script, console2} from "forge-std/Script.sol";
+
+/// @notice One-shot migration for an existing share printer.
+/// @dev The operator must review SOURCE_TOKEN_ID against the charter/class
+///      authority before broadcasting. Outstanding units, including scrip,
+///      are derived on-chain by the printer rather than supplied by the caller.
+contract ConfigureShareClassTermsScript is Script {
+    function run() external {
+        uint256 privateKey = vm.envUint("PRIVATE_KEY_MAIN");
+        address deployer = vm.addr(privateKey);
+        address printerAddress = vm.envAddress("CERT_PRINTER");
+        address controllerAddress = vm.envAddress("SHARE_CLASS_TERMS_CONTROLLER");
+        uint256 sourceTokenId = vm.envUint("SOURCE_TOKEN_ID");
+
+        CyberCertPrinter printer = CyberCertPrinter(printerAddress);
+        IssuanceManager issuanceManager = IssuanceManager(printer.issuanceManager());
+        IShareClassTermsController controller = IShareClassTermsController(controllerAddress);
+        BorgAuth auth = BorgAuth(address(issuanceManager.AUTH()));
+
+        if (auth.userRoles(deployer) < auth.OWNER_ROLE()) {
+            revert("Deployer is not issuance-manager AUTH owner");
+        }
+        if (printer.isVoided(sourceTokenId)) {
+            revert("Source certificate is voided");
+        }
+
+        (,,,, bool alreadyConfigured) = controller.getClassTerms(printerAddress);
+        if (alreadyConfigured) revert("Class terms already configured");
+
+        CertificateDetails memory source = printer.getActiveCertificateDetails(sourceTokenId);
+        if (source.extensionData.length == 0) {
+            revert("Source certificate has no extension data");
+        }
+
+        address[] memory printers = new address[](1);
+        printers[0] = printerAddress;
+        bytes[] memory extensionData = new bytes[](1);
+        extensionData[0] = source.extensionData;
+
+        vm.startBroadcast(privateKey);
+        issuanceManager.migrateClassTermsControllers(printers, controllerAddress, extensionData);
+        vm.stopBroadcast();
+
+        (, bytes32 termsHash, uint256 authorizedShares, uint256 issuedUnits, bool configured) =
+            controller.getClassTerms(printerAddress);
+        vm.assertTrue(configured, "Class terms migration did not persist");
+        vm.assertTrue(termsHash != bytes32(0), "Class terms hash is empty");
+        vm.assertGe(authorizedShares, issuedUnits, "Issued units exceed authorized shares");
+
+        console2.log("Configured cert printer:", printerAddress);
+        console2.logBytes32(termsHash);
+        console2.log("Authorized shares:", authorizedShares);
+        console2.log("Issued units:", issuedUnits);
+    }
+}

--- a/script/deploy-cyber-agreement-registry.s.sol
+++ b/script/deploy-cyber-agreement-registry.s.sol
@@ -9,7 +9,7 @@ import {DeploymentConstants} from "./libs/DeploymentConstants.sol";
 /// @dev Upgrade the existing proxy separately on each chain after deployment.
 contract DeployCyberAgreementRegistryScript is Script {
     string internal constant DEFAULT_SALT_STRING =
-        "MetaLex.CyberAgreementRegistry.UpgradeV3.2.0";
+        "MetaLex.CyberAgreementRegistry.UpgradeV3.3.0";
 
     function run() public returns (CyberAgreementRegistry implementation) {
         return

--- a/script/deploy-share-class-terms-controller.s.sol
+++ b/script/deploy-share-class-terms-controller.s.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.28;
+
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {Script, console2} from "forge-std/Script.sol";
+
+import {BorgAuth} from "../src/libs/auth.sol";
+import {ShareClassTermsController} from "../src/storage/extensions/ShareClassTermsController.sol";
+import {ShareExtension} from "../src/storage/extensions/ShareExtension.sol";
+
+/// @notice Deploys the externalized P2 class-terms controller as a UUPS proxy.
+/// @dev The existing ShareExtension remains the renderer/parser. New and
+///      migrated share printers point at this facade instead.
+contract DeployShareClassTermsControllerScript is Script {
+    bytes32 internal constant IMPLEMENTATION_SALT = keccak256("MetaLexCyberCorp.ShareClassTermsController.1");
+    bytes32 internal constant PROXY_SALT = keccak256("MetaLexCyberCorp.ShareClassTermsController.Proxy.1");
+
+    function run() external returns (address controllerProxy) {
+        uint256 privateKey = vm.envUint("PRIVATE_KEY_MAIN");
+        address deployer = vm.addr(privateKey);
+        address rendererAddress = vm.envAddress("SHARE_EXTENSION_RENDERER");
+        ShareExtension renderer = ShareExtension(rendererAddress);
+        address authAddress = address(renderer.AUTH());
+        BorgAuth auth = BorgAuth(authAddress);
+
+        if (auth.userRoles(deployer) < auth.OWNER_ROLE()) {
+            revert("Deployer is not ShareExtension AUTH owner");
+        }
+
+        vm.startBroadcast(privateKey);
+        address implementation = address(new ShareClassTermsController{salt: IMPLEMENTATION_SALT}());
+        controllerProxy = address(
+            new ERC1967Proxy{salt: PROXY_SALT}(
+                implementation, abi.encodeCall(ShareClassTermsController.initialize, (authAddress, rendererAddress))
+            )
+        );
+        vm.stopBroadcast();
+
+        ShareClassTermsController controller = ShareClassTermsController(controllerProxy);
+        vm.assertEq(controller.renderer(), rendererAddress, "Controller renderer mismatch");
+        vm.assertTrue(controller.supportsExtensionType(keccak256("SHARE")), "Controller does not advertise SHARE");
+
+        console2.log("ShareClassTermsController proxy:", controllerProxy);
+        console2.log("ShareClassTermsController implementation:", implementation);
+        console2.log("ShareExtension renderer:", rendererAddress);
+    }
+}

--- a/script/deploy-share-extension.s.sol
+++ b/script/deploy-share-extension.s.sol
@@ -9,7 +9,7 @@ import {DeploymentConstants} from "./libs/DeploymentConstants.sol";
 
 contract DeployShareExtensionScript is Script {
     // TODO update before production
-    bytes32 internal constant DEFAULT_SALT = keccak256("MetaLexCyberCorp-ShareExtension.dev1");
+    bytes32 internal constant DEFAULT_SALT = keccak256("MetaLexCyberCorp-ShareExtension.dev2");
 
     function run() external returns (address implementation, address proxy) {
         uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY_MAIN");

--- a/script/upgrade-and-migrate-share-class-terms.s.sol
+++ b/script/upgrade-and-migrate-share-class-terms.s.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.28;
+
+import {Script, console2} from "forge-std/Script.sol";
+
+import {CyberCertPrinter} from "../src/CyberCertPrinter.sol";
+import {IssuanceManager} from "../src/IssuanceManager.sol";
+import {IIssuanceManagerFactory} from "../src/interfaces/IIssuanceManagerFactory.sol";
+import {IShareClassTermsController} from "../src/interfaces/IShareClassTermsController.sol";
+import {BorgAuth} from "../src/libs/auth.sol";
+import {CertificateDetails} from "../src/storage/CyberCertPrinterStorage.sol";
+
+/// @notice Upgrades one corp's IssuanceManager and migrates every supplied
+///         share printer in the same transaction.
+/// @dev Comma-delimit CERT_PRINTERS and SOURCE_TOKEN_IDS in matching order.
+///      Each source certificate must first be reconciled to its legal class
+///      authority. Simulate without --broadcast before any owner-authorized run.
+contract UpgradeAndMigrateShareClassTermsScript is Script {
+    function run() external {
+        uint256 privateKey = vm.envUint("PRIVATE_KEY_MAIN");
+        address deployer = vm.addr(privateKey);
+        address issuanceManagerAddress = vm.envAddress("ISSUANCE_MANAGER");
+        address implementation = vm.envAddress("ISSUANCE_MANAGER_IMPLEMENTATION");
+        address controllerAddress = vm.envAddress("SHARE_CLASS_TERMS_CONTROLLER");
+        address[] memory printers = vm.envAddress("CERT_PRINTERS", ",");
+        uint256[] memory sourceTokenIds = vm.envUint("SOURCE_TOKEN_IDS", ",");
+
+        if (printers.length == 0) revert("No cert printers supplied");
+        if (printers.length != sourceTokenIds.length) {
+            revert("CERT_PRINTERS and SOURCE_TOKEN_IDS length mismatch");
+        }
+        if (implementation.code.length == 0) {
+            revert("IssuanceManager implementation has no code");
+        }
+        if (controllerAddress.code.length == 0) {
+            revert("ShareClassTermsController has no code");
+        }
+
+        IssuanceManager issuanceManager = IssuanceManager(issuanceManagerAddress);
+        IssuanceManager targetImplementation = IssuanceManager(implementation);
+        IShareClassTermsController controller = IShareClassTermsController(controllerAddress);
+        BorgAuth auth = BorgAuth(address(issuanceManager.AUTH()));
+
+        if (auth.userRoles(deployer) < auth.OWNER_ROLE()) {
+            revert("Deployer is not issuance-manager AUTH owner");
+        }
+        if (keccak256(bytes(targetImplementation.DEPLOY_VERSION())) != keccak256(bytes("4.2"))) {
+            revert("Target implementation is not IssuanceManager 4.2");
+        }
+        if (
+            IIssuanceManagerFactory(issuanceManager.getUpgradeFactory()).getRefImplementation()
+                != implementation
+        ) {
+            revert("Target is not the IssuanceManager factory reference");
+        }
+
+        bytes[] memory extensionData = new bytes[](printers.length);
+        for (uint256 i = 0; i < printers.length; ++i) {
+            CyberCertPrinter printer = CyberCertPrinter(printers[i]);
+            if (printer.issuanceManager() != issuanceManagerAddress) {
+                revert("Printer belongs to a different IssuanceManager");
+            }
+            if (printer.isVoided(sourceTokenIds[i])) {
+                revert("Source certificate is voided");
+            }
+            (,,,, bool alreadyConfigured) = controller.getClassTerms(printers[i]);
+            if (alreadyConfigured) revert("Class terms already configured");
+
+            CertificateDetails memory source = printer.getActiveCertificateDetails(sourceTokenIds[i]);
+            if (source.extensionData.length == 0) {
+                revert("Source certificate has no extension data");
+            }
+            extensionData[i] = source.extensionData;
+        }
+
+        bytes memory migrationCall =
+            abi.encodeCall(IssuanceManager.migrateClassTermsControllers, (printers, controllerAddress, extensionData));
+
+        vm.startBroadcast(privateKey);
+        issuanceManager.upgradeToAndCall(implementation, migrationCall);
+        vm.stopBroadcast();
+
+        vm.assertEq(issuanceManager.DEPLOY_VERSION(), "4.2", "IssuanceManager version mismatch");
+        for (uint256 i = 0; i < printers.length; ++i) {
+            CyberCertPrinter printer = CyberCertPrinter(printers[i]);
+            vm.assertEq(printer.getExtension(0), controllerAddress, "Printer controller mismatch");
+            (, bytes32 termsHash, uint256 authorizedShares, uint256 issuedUnits, bool configured) =
+                controller.getClassTerms(printers[i]);
+            vm.assertTrue(configured, "Class terms migration did not persist");
+            vm.assertTrue(termsHash != bytes32(0), "Class terms hash is empty");
+            vm.assertGe(authorizedShares, issuedUnits, "Issued units exceed authorized shares");
+
+            console2.log("Migrated cert printer:", printers[i]);
+            console2.logBytes32(termsHash);
+            console2.log("Authorized shares:", authorizedShares);
+            console2.log("Issued units:", issuedUnits);
+        }
+    }
+}

--- a/script/upgrade-board-authority-forward-path.s.sol
+++ b/script/upgrade-board-authority-forward-path.s.sol
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.28;
+
+import {Script} from "forge-std/Script.sol";
+import {console2} from "forge-std/console2.sol";
+import {ERC1967Proxy} from "openzeppelin-contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+import {CyberCorp} from "../src/CyberCorp.sol";
+import {CyberCorpFactory} from "../src/CyberCorpFactory.sol";
+import {CyberCorpSingleFactory} from "../src/CyberCorpSingleFactory.sol";
+import {MetaDAOFactory} from "../src/MetaDAOFactory.sol";
+import {ParentCoFactory} from "../src/ParentCoFactory.sol";
+import {PumpCorpFactory} from "../src/PumpCorpFactory.sol";
+import {BorgAuth} from "../src/libs/auth.sol";
+
+interface IUUPSBoardFactory {
+    function AUTH() external view returns (BorgAuth);
+    function cyberCorpSingleFactory() external view returns (address);
+    function setCyberCorpSingleFactory(address newSingleFactory) external;
+    function upgradeToAndCall(
+        address newImplementation,
+        bytes calldata data
+    ) external payable;
+}
+
+/// @notice Installs the v5 Board-authority path for future deployments only.
+/// @dev Deploys a separate v5 single factory and atomically pairs each supplied
+///      top-level proxy upgrade with that pointer. The legacy single factory is
+///      read for auth/reference checks but never mutated. This deliberately
+///      does not migrate or activate any existing CyberCorp.
+contract UpgradeBoardAuthorityForwardPathScript is Script {
+    bytes32 internal constant CYBERCORP_SALT =
+        keccak256("MetaLexCyberCorp.BoardAuthority.CyberCorp.v5");
+    bytes32 internal constant SINGLE_FACTORY_IMPLEMENTATION_SALT =
+        keccak256(
+            "MetaLexCyberCorp.BoardAuthority.CyberCorpSingleFactory.implementation.v1"
+        );
+    bytes32 internal constant SINGLE_FACTORY_PROXY_SALT =
+        keccak256(
+            "MetaLexCyberCorp.BoardAuthority.CyberCorpSingleFactory.proxy.v1"
+        );
+    bytes32 internal constant CYBERCORP_FACTORY_SALT =
+        keccak256("MetaLexCyberCorp.BoardAuthority.CyberCorpFactory.v1");
+    bytes32 internal constant PUMP_FACTORY_SALT =
+        keccak256("MetaLexCyberCorp.BoardAuthority.PumpCorpFactory.v1");
+    bytes32 internal constant PARENT_FACTORY_SALT =
+        keccak256("MetaLexCyberCorp.BoardAuthority.ParentCoFactory.v1");
+    bytes32 internal constant METADAO_FACTORY_SALT =
+        keccak256("MetaLexCyberCorp.BoardAuthority.MetaDAOFactory.v1");
+
+    function run() external {
+        uint256 privateKey = vm.envUint("PRIVATE_KEY_MAIN");
+        address deployer = vm.addr(privateKey);
+        address legacySingleFactoryAddress = vm.envAddress(
+            "CYBERCORP_SINGLE_FACTORY"
+        );
+
+        address cyberCorpFactoryAddress = vm.envOr(
+            "CYBERCORP_FACTORY",
+            address(0)
+        );
+        address pumpFactoryAddress = vm.envOr(
+            "PUMP_CORP_FACTORY",
+            address(0)
+        );
+        address parentFactoryAddress = vm.envOr(
+            "PARENT_CO_FACTORY",
+            address(0)
+        );
+        address metaDAOFactoryAddress = vm.envOr(
+            "METADAO_FACTORY",
+            address(0)
+        );
+
+        _assertOwner(legacySingleFactoryAddress, deployer);
+        _assertOptionalOwner(cyberCorpFactoryAddress, deployer);
+        _assertOptionalOwner(pumpFactoryAddress, deployer);
+        _assertOptionalOwner(parentFactoryAddress, deployer);
+        _assertOptionalOwner(metaDAOFactoryAddress, deployer);
+
+        CyberCorpSingleFactory legacySingleFactory =
+            CyberCorpSingleFactory(legacySingleFactoryAddress);
+        address legacyReference =
+            legacySingleFactory.getRefImplementation();
+        BorgAuth singleFactoryAuth = legacySingleFactory.AUTH();
+
+        vm.startBroadcast(privateKey);
+
+        CyberCorp newCyberCorp = new CyberCorp{salt: CYBERCORP_SALT}();
+        CyberCorpSingleFactory newSingleFactory = CyberCorpSingleFactory(
+            address(
+                new ERC1967Proxy{salt: SINGLE_FACTORY_PROXY_SALT}(
+                    address(
+                        new CyberCorpSingleFactory{
+                            salt: SINGLE_FACTORY_IMPLEMENTATION_SALT
+                        }()
+                    ),
+                    abi.encodeCall(
+                        CyberCorpSingleFactory.initialize,
+                        (address(singleFactoryAuth), address(newCyberCorp))
+                    )
+                )
+            )
+        );
+
+        if (cyberCorpFactoryAddress != address(0)) {
+            CyberCorpFactory implementation = new CyberCorpFactory{
+                salt: CYBERCORP_FACTORY_SALT
+            }();
+            IUUPSBoardFactory(cyberCorpFactoryAddress).upgradeToAndCall(
+                address(implementation),
+                abi.encodeCall(
+                    IUUPSBoardFactory.setCyberCorpSingleFactory,
+                    (address(newSingleFactory))
+                )
+            );
+        }
+        if (pumpFactoryAddress != address(0)) {
+            PumpCorpFactory implementation = new PumpCorpFactory{
+                salt: PUMP_FACTORY_SALT
+            }();
+            IUUPSBoardFactory(pumpFactoryAddress).upgradeToAndCall(
+                address(implementation),
+                abi.encodeCall(
+                    IUUPSBoardFactory.setCyberCorpSingleFactory,
+                    (address(newSingleFactory))
+                )
+            );
+        }
+        if (parentFactoryAddress != address(0)) {
+            ParentCoFactory implementation = new ParentCoFactory{
+                salt: PARENT_FACTORY_SALT
+            }();
+            IUUPSBoardFactory(parentFactoryAddress).upgradeToAndCall(
+                address(implementation),
+                abi.encodeCall(
+                    IUUPSBoardFactory.setCyberCorpSingleFactory,
+                    (address(newSingleFactory))
+                )
+            );
+        }
+        if (metaDAOFactoryAddress != address(0)) {
+            MetaDAOFactory implementation = new MetaDAOFactory{
+                salt: METADAO_FACTORY_SALT
+            }();
+            IUUPSBoardFactory(metaDAOFactoryAddress).upgradeToAndCall(
+                address(implementation),
+                abi.encodeCall(
+                    IUUPSBoardFactory.setCyberCorpSingleFactory,
+                    (address(newSingleFactory))
+                )
+            );
+        }
+
+        vm.stopBroadcast();
+
+        require(
+            newSingleFactory.getRefImplementation() == address(newCyberCorp),
+            "CyberCorp reference implementation mismatch"
+        );
+        require(
+            legacySingleFactory.getRefImplementation() == legacyReference,
+            "legacy single-factory reference changed"
+        );
+        require(
+            keccak256(bytes(newCyberCorp.DEPLOY_VERSION())) ==
+                keccak256(bytes("5")),
+            "unexpected CyberCorp version"
+        );
+        _assertOptionalSingleFactory(
+            cyberCorpFactoryAddress,
+            address(newSingleFactory)
+        );
+        _assertOptionalSingleFactory(
+            pumpFactoryAddress,
+            address(newSingleFactory)
+        );
+        _assertOptionalSingleFactory(
+            parentFactoryAddress,
+            address(newSingleFactory)
+        );
+        _assertOptionalSingleFactory(
+            metaDAOFactoryAddress,
+            address(newSingleFactory)
+        );
+
+        console2.log("CyberCorp v5 reference:", address(newCyberCorp));
+        console2.log(
+            "Legacy CyberCorpSingleFactory (unchanged):",
+            legacySingleFactoryAddress
+        );
+        console2.log(
+            "CyberCorpSingleFactory v5:",
+            address(newSingleFactory)
+        );
+        console2.log(
+            "Existing corps were not upgraded or governance-activated."
+        );
+    }
+
+    function _assertOptionalOwner(
+        address target,
+        address deployer
+    ) internal view {
+        if (target != address(0)) _assertOwner(target, deployer);
+    }
+
+    function _assertOptionalSingleFactory(
+        address target,
+        address expectedSingleFactory
+    ) internal view {
+        if (target == address(0)) return;
+        if (
+            IUUPSBoardFactory(target).cyberCorpSingleFactory() !=
+                expectedSingleFactory
+        ) {
+            revert("top-level factory single-factory mismatch");
+        }
+    }
+
+    function _assertOwner(address target, address deployer) internal view {
+        BorgAuth auth = IUUPSBoardFactory(target).AUTH();
+        if (auth.userRoles(deployer) < auth.OWNER_ROLE()) {
+            revert("deployer is not target AUTH owner");
+        }
+    }
+}

--- a/script/upgrade-cyber-agreement-registry.s.sol
+++ b/script/upgrade-cyber-agreement-registry.s.sol
@@ -8,10 +8,13 @@ import {BorgAuth} from "../src/libs/auth.sol";
 contract UpgradeCyberAgreementRegistryScript is Script {
     function run() public {
         bytes32 salt = bytes32(
-            keccak256("MetaLex.CyberAgreementRegistry.UpgradeV3.2.0")
+            keccak256("MetaLex.CyberAgreementRegistry.UpgradeV3.3.0")
         );
         uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY_MAIN");
-        address registryProxy = 0xa9E808B8eCBB60Bb19abF026B5b863215BC4c134;
+        address registryProxy = vm.envOr(
+            "CYBER_AGREEMENT_REGISTRY",
+            0xa9E808B8eCBB60Bb19abF026B5b863215BC4c134
+        );
 
         address deployer = vm.addr(deployerPrivateKey);
         console2.log("deployer: %s", deployer);
@@ -37,11 +40,11 @@ contract UpgradeCyberAgreementRegistryScript is Script {
             newRegistryImpl
         );
 
-       /* registry.upgradeToAndCall(newRegistryImpl, "");
+        registry.upgradeToAndCall(newRegistryImpl, "");
         console2.log(
             "CyberAgreementRegistry upgraded (proxy): %s",
             registryProxy
-        );*/
+        );
 
         vm.stopBroadcast();
     }

--- a/script/upgrade-issuance-manager-ref.s.sol
+++ b/script/upgrade-issuance-manager-ref.s.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.28;
 
+import {CyberCorpFactory} from "../src/CyberCorpFactory.sol";
+import {IssuanceManager} from "../src/IssuanceManager.sol";
+import {IssuanceManagerFactory} from "../src/IssuanceManagerFactory.sol";
+import {BorgAuth} from "../src/libs/auth.sol";
+import {DeploymentConstants} from "./libs/DeploymentConstants.sol";
 import {Script} from "forge-std/Script.sol";
 import {console2} from "forge-std/console2.sol";
-import {BorgAuth} from "../src/libs/auth.sol";
-import {CyberCorpFactory} from "../src/CyberCorpFactory.sol";
-import {IssuanceManagerFactory} from "../src/IssuanceManagerFactory.sol";
-import {IssuanceManager} from "../src/IssuanceManager.sol";
-import {DeploymentConstants} from "./libs/DeploymentConstants.sol";
 
 /// @notice Deploy a new `IssuanceManager` implementation and set it as the
 ///         reference implementation on `IssuanceManagerFactory` (used for new
@@ -15,57 +15,34 @@ import {DeploymentConstants} from "./libs/DeploymentConstants.sol";
 /// @dev Uses `DeploymentConstants.coreV2` for defaults; override with env vars.
 ///      Requires `PRIVATE_KEY_MAIN` for an address with `AUTH.OWNER_ROLE()`.
 contract UpgradeIssuanceManagerRefScript is Script {
-    bytes32 internal constant UPGRADE_SALT =
-        keccak256("MetaLexCyberCorp.IssuanceManager.RefUpgrade.4.1");
+    bytes32 internal constant UPGRADE_SALT = keccak256("MetaLexCyberCorp.IssuanceManager.RefUpgrade.4.2");
 
     function run() public {
         uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY_MAIN");
         address deployer = vm.addr(deployerPrivateKey);
         console2.log("deployer: %s", deployer);
 
-        DeploymentConstants.CoreDeployment memory deployment = DeploymentConstants
-            .coreV2(block.chainid);
+        DeploymentConstants.CoreDeployment memory deployment = DeploymentConstants.coreV2(block.chainid);
 
-        address issuanceManagerFactoryAddr = vm.envOr(
-            "ISSUANCE_MANAGER_FACTORY",
-            address(0)
-        );
+        address issuanceManagerFactoryAddr = vm.envOr("ISSUANCE_MANAGER_FACTORY", address(0));
         if (issuanceManagerFactoryAddr == address(0)) {
-            address cyberCorpFactoryProxyAddr = vm.envOr(
-                "CYBERCORP_FACTORY",
-                deployment.cyberCorpFactory
-            );
-            issuanceManagerFactoryAddr = CyberCorpFactory(
-                cyberCorpFactoryProxyAddr
-            ).issuanceManagerFactory();
+            address cyberCorpFactoryProxyAddr = vm.envOr("CYBERCORP_FACTORY", deployment.cyberCorpFactory);
+            issuanceManagerFactoryAddr = CyberCorpFactory(cyberCorpFactoryProxyAddr).issuanceManagerFactory();
         }
 
-        IssuanceManagerFactory issuanceManagerFactory = IssuanceManagerFactory(
-            issuanceManagerFactoryAddr
-        );
+        IssuanceManagerFactory issuanceManagerFactory = IssuanceManagerFactory(issuanceManagerFactoryAddr);
         address auth = address(issuanceManagerFactory.AUTH());
 
         uint256 role = BorgAuth(auth).userRoles(deployer);
-       /* if (role < BorgAuth(auth).OWNER_ROLE()) {
-            revert(
-                "Deployer is not AUTH owner; use the AUTH owner key to run upgrades"
-            );
-        }*/
+        if (role < BorgAuth(auth).OWNER_ROLE()) {
+            revert("Deployer is not AUTH owner; use the AUTH owner key to run upgrades");
+        }
 
         vm.startBroadcast(deployerPrivateKey);
 
-        address newIssuanceManagerImpl = address(
-            new IssuanceManager{salt: UPGRADE_SALT}()
-        );
-        console2.log(
-            "New IssuanceManager implementation:",
-            newIssuanceManagerImpl
-        );
-        console2.log(
-            "New IssuanceManager DEPLOY_VERSION: %s",
-            IssuanceManager(newIssuanceManagerImpl).DEPLOY_VERSION()
-        );
-
+        address newIssuanceManagerImpl = address(new IssuanceManager{salt: UPGRADE_SALT}());
+        console2.log("New IssuanceManager implementation:", newIssuanceManagerImpl);
+        console2.log("New IssuanceManager DEPLOY_VERSION: %s", IssuanceManager(newIssuanceManagerImpl).DEPLOY_VERSION());
         address oldRef = issuanceManagerFactory.getRefImplementation();
         console2.log("IssuanceManagerFactory:", issuanceManagerFactoryAddr);
         console2.log("  previous ref implementation:", oldRef);
@@ -77,7 +54,6 @@ contract UpgradeIssuanceManagerRefScript is Script {
             newIssuanceManagerImpl,
             "IssuanceManagerFactory reference implementation mismatch"
         );
-
         console2.log("  new ref implementation:", newIssuanceManagerImpl);
 
         vm.stopBroadcast();

--- a/script/upgrade-share-extension.s.sol
+++ b/script/upgrade-share-extension.s.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.28;
+
+import {Script, console2} from "forge-std/Script.sol";
+import {BorgAuth} from "../src/libs/auth.sol";
+import {ShareExtension} from "../src/storage/extensions/ShareExtension.sol";
+
+/// @notice Upgrades an existing ShareExtension proxy with the P2 terms extractor.
+/// @dev Run without `--broadcast` first. Broadcasting requires the extension
+///      proxy's BorgAuth owner and an explicit SHARE_EXTENSION_PROXY.
+contract UpgradeShareExtensionScript is Script {
+    bytes32 internal constant UPGRADE_SALT =
+        keccak256("MetaLexCyberCorp.ShareExtension.P2.v1");
+
+    function run() external {
+        uint256 privateKey = vm.envUint("PRIVATE_KEY_MAIN");
+        address deployer = vm.addr(privateKey);
+        address proxyAddress = vm.envAddress("SHARE_EXTENSION_PROXY");
+        ShareExtension proxy = ShareExtension(proxyAddress);
+        BorgAuth auth = BorgAuth(address(proxy.AUTH()));
+
+        if (auth.userRoles(deployer) < auth.OWNER_ROLE()) {
+            revert("Deployer is not ShareExtension AUTH owner");
+        }
+
+        vm.startBroadcast(privateKey);
+        address implementation = address(
+            new ShareExtension{salt: UPGRADE_SALT}()
+        );
+        proxy.upgradeToAndCall(implementation, "");
+        vm.stopBroadcast();
+
+        vm.assertTrue(
+            proxy.supportsExtensionType(keccak256("SHARE")),
+            "Upgraded extension does not advertise SHARE"
+        );
+        console2.log("ShareExtension proxy:", proxyAddress);
+        console2.log("ShareExtension implementation:", implementation);
+    }
+}

--- a/src/CyberAgreementRegistry.sol
+++ b/src/CyberAgreementRegistry.sol
@@ -175,6 +175,7 @@ contract CyberAgreementRegistry is Initializable, UUPSUpgradeable, BorgAuthACL {
     error InvalidSecret();
     error MismatchedPartyValuesLength();
     error FinalizerNotDefined();
+    error LegalContractUriEmpty();
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {}
@@ -225,15 +226,16 @@ contract CyberAgreementRegistry is Initializable, UUPSUpgradeable, BorgAuthACL {
         _;
     }
 
-    /// @notice Create a new agreement template. Only the owner can do it externally; however, the registry itself can
-    /// do it as well for just-in-time operations.
+    /// @notice Create a curated agreement template with a caller-chosen ID.
+    /// @dev Caller-chosen IDs are owner-gated because making this path public
+    ///      allows namespace squatting and front-running.
     function createTemplate(
         bytes32 templateId,
         string memory title,
         string memory legalContractUri,
         string[] memory globalFields,
         string[] memory partyFields
-    ) external {
+    ) external onlyOwner {
         _createTemplate(
             templateId,
             title,
@@ -241,6 +243,31 @@ contract CyberAgreementRegistry is Initializable, UUPSUpgradeable, BorgAuthACL {
             globalFields,
             partyFields
         );
+    }
+
+    /// @notice Permissionlessly register a content-addressed agreement template.
+    /// @dev The ID is the hash of the complete template content, so another
+    ///      caller cannot squat or front-run an ID with different content.
+    ///      Re-registering identical content is intentionally idempotent.
+    function createTemplatePublic(
+        string memory title,
+        string memory legalContractUri,
+        string[] memory globalFields,
+        string[] memory partyFields
+    ) external returns (bytes32 templateId) {
+        templateId = keccak256(
+            abi.encode(title, legalContractUri, globalFields, partyFields)
+        );
+
+        if (bytes(templates[templateId].legalContractUri).length == 0) {
+            _createTemplate(
+                templateId,
+                title,
+                legalContractUri,
+                globalFields,
+                partyFields
+            );
+        }
     }
 
     function createContract(
@@ -995,6 +1022,9 @@ contract CyberAgreementRegistry is Initializable, UUPSUpgradeable, BorgAuthACL {
 
         if (bytes(title).length == 0) {
             revert TitleEmpty();
+        }
+        if (bytes(legalContractUri).length == 0) {
+            revert LegalContractUriEmpty();
         }
 
         templates[templateId] = Template({

--- a/src/CyberCorp.sol
+++ b/src/CyberCorp.sol
@@ -51,7 +51,7 @@ import "./storage/extensions/ICyberCorpExtension.sol";
 /// @notice Main contract representing a corporation's on-chain presence and management
 /// @dev Implements UUPS upgradeable pattern and BorgAuth access control
 contract CyberCorp is Initializable, BorgAuthACL, UUPSUpgradeable {
-    string public constant DEPLOY_VERSION = "4"; // For version-tracking on all deployment and future upgrades
+    string public constant DEPLOY_VERSION = "5"; // For version-tracking on all deployment and future upgrades
 
     // cyberCORP details
     /// @notice Legal name of the entity, including designation (e.g., "Inc." or "LLC")
@@ -87,6 +87,11 @@ contract CyberCorp is Initializable, BorgAuthACL, UUPSUpgradeable {
     bytes32 public extensionType;
     /// @notice Raw extension payload interpreted by the active extension contract
     bytes public extensionData;
+    /// @notice Board state is appended for proxy storage compatibility.
+    CompanyDirector[] public companyDirectors;
+    mapping(address => bool) public boardMembers;
+    mapping(address => bool) public officerMembers;
+    bool public boardGovernanceEnforced;
 
     event CyberCORPDetailsUpdated(string cyberCORPName, string cyberCORPType, string cyberCORPJurisdiction, string cyberCORPContactDetails, string defaultDisputeResolution);
     event OfficerAdded(address indexed officer, uint256 index);
@@ -96,6 +101,10 @@ contract CyberCorp is Initializable, BorgAuthACL, UUPSUpgradeable {
     event EscrowedOfficerSignatureUpdated(uint256 indexed index, address indexed officer);
     event CyberCORPExtensionSet(address indexed extension, bytes32 indexed extensionType);
     event CyberCORPExtensionDataUpdated(bytes32 indexed extensionType, bytes extensionData);
+    event DirectorAdded(address indexed director, uint256 index);
+    event DirectorRemoved(address indexed director, uint256 index);
+    event BoardGovernanceActivated(address indexed initialDirector);
+    event BoardAuthorityAdapterUpdated(address indexed adapter);
 
     error NotRefImplementation();
     error SignatureRequired();
@@ -103,6 +112,32 @@ contract CyberCorp is Initializable, BorgAuthACL, UUPSUpgradeable {
     error InvalidExtension();
     error ExtensionTypeNotSupported();
     error ExtensionNotConfigured();
+    error BoardGovernanceNotEnforced();
+    error BoardGovernanceAlreadyEnforced();
+    error RoleManagerNotCyberCorp();
+    error InvalidOfficer();
+    error InvalidDirector();
+    error DuplicateOfficer();
+    error DuplicateDirector();
+    error LastOfficer();
+    error LastDirector();
+
+    modifier onlyBoardAuthority() {
+        if (boardGovernanceEnforced) {
+            AUTH.onlyRole(AUTH.BOARD_ROLE(), msg.sender);
+        } else {
+            // Explicit legacy compatibility. The app and plans do not label
+            // this compatibility path as Board enforcement.
+            AUTH.onlyRole(AUTH.OWNER_ROLE(), msg.sender);
+        }
+        _;
+    }
+
+    modifier onlyEnforcedBoard() {
+        if (!boardGovernanceEnforced) revert BoardGovernanceNotEnforced();
+        AUTH.onlyRole(AUTH.BOARD_ROLE(), msg.sender);
+        _;
+    }
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -142,8 +177,30 @@ contract CyberCorp is Initializable, BorgAuthACL, UUPSUpgradeable {
         issuanceManager = _issuanceManager;
         companyPayable = _companyPayable;
         companyOfficers.push(_officer);
+        officerMembers[_officer.eoa] = true;
+        companyDirectors.push(
+            CompanyDirector({
+                eoa: _officer.eoa,
+                name: _officer.name,
+                contact: _officer.contact
+            })
+        );
+        boardMembers[_officer.eoa] = true;
         upgradeFactory = _upgradeFactory;
         roundManager = _roundManager;
+    }
+
+    /// @notice Finalizes the one-way BorgAuth role-manager handoff for a newly
+    ///         deployed corp and promotes the founder to the Board role.
+    function activateBoardGovernance() external {
+        if (boardGovernanceEnforced) revert BoardGovernanceAlreadyEnforced();
+        if (AUTH.roleManager() != address(this)) revert RoleManagerNotCyberCorp();
+        if (companyDirectors.length == 0) revert LastDirector();
+
+        address initialDirector = companyDirectors[0].eoa;
+        AUTH.updateRole(initialDirector, AUTH.BOARD_ROLE());
+        boardGovernanceEnforced = true;
+        emit BoardGovernanceActivated(initialDirector);
     }
 
     /// @notice Updates the corporation's basic details
@@ -159,7 +216,7 @@ contract CyberCorp is Initializable, BorgAuthACL, UUPSUpgradeable {
         string memory _cyberCORPJurisdiction,
         string memory _cyberCORPContactDetails,
         string memory _defaultDisputeResolution
-    ) external onlyOwner() {
+    ) external onlyBoardAuthority {
         cyberCORPName = _cyberCORPName;
         cyberCORPType = _cyberCORPType;
         cyberCORPJurisdiction = _cyberCORPJurisdiction;
@@ -172,21 +229,21 @@ contract CyberCorp is Initializable, BorgAuthACL, UUPSUpgradeable {
     /// @notice Updates the issuance manager address
     /// @dev Only callable by owner
     /// @param _issuanceManager New issuance manager contract address
-    function setIssuanceManager(address _issuanceManager) external onlyOwner() {
+    function setIssuanceManager(address _issuanceManager) external onlyBoardAuthority {
         issuanceManager = _issuanceManager;
     }
 
     /// @notice Updates the deal manager address
     /// @dev Only callable by owner
     /// @param _dealManager New deal manager contract address
-    function setDealManager(address _dealManager) external onlyOwner() {
+    function setDealManager(address _dealManager) external onlyBoardAuthority {
         dealManager = _dealManager;
     }
 
     /// @notice Updates the round manager address
     /// @dev Only callable by owner
     /// @param _roundManager New round manager contract address
-    function setRoundManager(address _roundManager) external onlyOwner() {
+    function setRoundManager(address _roundManager) external onlyBoardAuthority {
         roundManager = _roundManager;
     }
 
@@ -194,46 +251,135 @@ contract CyberCorp is Initializable, BorgAuthACL, UUPSUpgradeable {
     /// @param _address Address to check
     /// @return bool True if the address belongs to an officer
     function isCyberCORPOfficer(address _address) external view returns (bool) {
+        if (boardGovernanceEnforced) return officerMembers[_address];
         return (AUTH.userRoles(_address) >= AUTH.OWNER_ROLE());
+    }
+
+    function isCyberCORPDirector(address account) external view returns (bool) {
+        return boardMembers[account];
+    }
+
+    function getCompanyOfficerCount() external view returns (uint256) {
+        return companyOfficers.length;
+    }
+
+    function getCompanyDirectorCount() external view returns (uint256) {
+        return companyDirectors.length;
     }
 
     /// @notice Adds a new officer to the company
     /// @dev Only callable by owner, sets officer role to 200
     /// @param _officer Officer details including address and role
-    function addOfficer(CompanyOfficer memory _officer) external onlyOwner() {
+    function addOfficer(CompanyOfficer memory _officer) external onlyBoardAuthority {
+        if (_officer.eoa == address(0)) revert InvalidOfficer();
+        if (officerMembers[_officer.eoa]) revert DuplicateOfficer();
         companyOfficers.push(_officer);
-        AUTH.updateRole(_officer.eoa, 200);
+        officerMembers[_officer.eoa] = true;
+        if (!boardMembers[_officer.eoa]) {
+            AUTH.updateRole(_officer.eoa, AUTH.OFFICER_ROLE());
+        }
         emit OfficerAdded(_officer.eoa, companyOfficers.length - 1);
     }
 
     /// @notice Removes an officer by their address
     /// @dev Only callable by owner, revokes officer role
     /// @param _address Address of the officer to remove
-    function removeOfficer(address _address) external onlyOwner() {
-        AUTH.updateRole(_address, 0);
+    function removeOfficer(address _address) external onlyBoardAuthority {
+        if (!officerMembers[_address]) revert InvalidOfficer();
+        if (companyOfficers.length == 1) revert LastOfficer();
         for (uint256 i = 0; i < companyOfficers.length; i++) {
             if (companyOfficers[i].eoa == _address) {
                 companyOfficers[i] = companyOfficers[companyOfficers.length - 1];
                 companyOfficers.pop();
+                officerMembers[_address] = false;
+                AUTH.updateRole(
+                    _address,
+                    boardMembers[_address] ? AUTH.BOARD_ROLE() : 0
+                );
                 emit OfficerRemoved(_address, i);
-                break;
+                return;
             }
         }
+        revert InvalidOfficer();
     }
 
     /// @notice Removes an officer by their index in the officers array
     /// @dev Only callable by owner, revokes officer role
     /// @param _index Index of the officer to remove
-    function removeOfficerAt(uint256 _index) external onlyOwner() {
-        require(_index < companyOfficers.length, "Index out of bounds");
+    function removeOfficerAt(uint256 _index) external onlyBoardAuthority {
+        if (_index >= companyOfficers.length) revert InvalidOfficer();
+        if (companyOfficers.length == 1) revert LastOfficer();
         address officerEOA = companyOfficers[_index].eoa;
-        AUTH.updateRole(officerEOA, 0);
         companyOfficers[_index] = companyOfficers[companyOfficers.length - 1];
         companyOfficers.pop();
+        officerMembers[officerEOA] = false;
+        AUTH.updateRole(
+            officerEOA,
+            boardMembers[officerEOA] ? AUTH.BOARD_ROLE() : 0
+        );
         emit OfficerRemoved(officerEOA, _index);
     }
 
-    function setCompanyPayable(address _companyPayable) external onlyOwner() {
+    function addDirector(
+        CompanyDirector calldata director
+    ) external onlyEnforcedBoard {
+        if (director.eoa == address(0)) revert InvalidDirector();
+        if (boardMembers[director.eoa]) revert DuplicateDirector();
+        companyDirectors.push(director);
+        boardMembers[director.eoa] = true;
+        AUTH.updateRole(director.eoa, AUTH.BOARD_ROLE());
+        emit DirectorAdded(director.eoa, companyDirectors.length - 1);
+    }
+
+    function removeDirector(address director) external onlyEnforcedBoard {
+        if (!boardMembers[director]) revert InvalidDirector();
+        if (companyDirectors.length == 1) revert LastDirector();
+        for (uint256 i = 0; i < companyDirectors.length; i++) {
+            if (companyDirectors[i].eoa == director) {
+                companyDirectors[i] =
+                    companyDirectors[companyDirectors.length - 1];
+                companyDirectors.pop();
+                boardMembers[director] = false;
+                AUTH.updateRole(
+                    director,
+                    officerMembers[director] ? AUTH.OFFICER_ROLE() : 0
+                );
+                emit DirectorRemoved(director, i);
+                return;
+            }
+        }
+        revert InvalidDirector();
+    }
+
+    function removeDirectorAt(uint256 index) external onlyEnforcedBoard {
+        if (index >= companyDirectors.length) revert InvalidDirector();
+        if (companyDirectors.length == 1) revert LastDirector();
+        address director = companyDirectors[index].eoa;
+        companyDirectors[index] =
+            companyDirectors[companyDirectors.length - 1];
+        companyDirectors.pop();
+        boardMembers[director] = false;
+        AUTH.updateRole(
+            director,
+            officerMembers[director] ? AUTH.OFFICER_ROLE() : 0
+        );
+        emit DirectorRemoved(director, index);
+    }
+
+    function setBoardAuthorityAdapter(
+        address adapter
+    ) external onlyEnforcedBoard {
+        AUTH.setRoleAdapter(AUTH.BOARD_ROLE(), adapter);
+        emit BoardAuthorityAdapterUpdated(adapter);
+    }
+
+    function initTransferAuthOwnership(
+        address newOwner
+    ) external onlyEnforcedBoard {
+        AUTH.initTransferOwnership(newOwner);
+    }
+
+    function setCompanyPayable(address _companyPayable) external onlyBoardAuthority {
         address oldCompanyPayable = companyPayable;
         companyPayable = _companyPayable;
         emit CompanyPayableUpdated(companyPayable, oldCompanyPayable);
@@ -280,7 +426,7 @@ contract CyberCorp is Initializable, BorgAuthACL, UUPSUpgradeable {
     function setExtension(
         address _extension,
         bytes32 _extensionType
-    ) external onlyOwner {
+    ) external onlyBoardAuthority {
         if (_extension == address(0)) {
             if (_extensionType != bytes32(0)) revert InvalidExtension();
             extension = address(0);
@@ -304,14 +450,14 @@ contract CyberCorp is Initializable, BorgAuthACL, UUPSUpgradeable {
     }
 
     /// @notice Update the raw extension payload for the active CyberCorp extension
-    function setExtensionData(bytes calldata _extensionData) external onlyOwner {
+    function setExtensionData(bytes calldata _extensionData) external onlyBoardAuthority {
         if (extension == address(0)) revert ExtensionNotConfigured();
         extensionData = _extensionData;
         emit CyberCORPExtensionDataUpdated(extensionType, _extensionData);
     }
 
     /// @notice Clear the active CyberCorp extension and any stored extension data
-    function clearExtension() external onlyOwner {
+    function clearExtension() external onlyBoardAuthority {
         extension = address(0);
         extensionType = bytes32(0);
         delete extensionData;
@@ -334,7 +480,7 @@ contract CyberCorp is Initializable, BorgAuthACL, UUPSUpgradeable {
     /// and the CyberCorp owner can decide if or when he wants to perform the upgrade
     function _authorizeUpgrade(
         address newImplementation
-    ) internal override onlyOwner {
+    ) internal override onlyBoardAuthority {
         if(
             ICyberCorpSingleFactory(upgradeFactory).getRefImplementation() != newImplementation) {
             revert NotRefImplementation();

--- a/src/CyberCorpConstants.sol
+++ b/src/CyberCorpConstants.sol
@@ -83,6 +83,12 @@ struct CompanyOfficer {
     string title;
 }
 
+struct CompanyDirector {
+    address eoa;
+    string name;
+    string contact;
+}
+
 enum ExercisePriceMethod {
     perToken,
     perWarrant

--- a/src/CyberCorpFactory.sol
+++ b/src/CyberCorpFactory.sol
@@ -277,6 +277,11 @@ contract CyberCorpFactory is UUPSUpgradeable, BorgAuthACL {
         BorgAuth(authAddress).updateRole(dealManagerAddress, 99);
         BorgAuth(authAddress).updateRole(roundManagerAddress, 99);
 
+        // Lock direct role mutation to the CyberCorp, then activate the
+        // governance-correct Board -> officer authority path.
+        BorgAuth(authAddress).setRoleManager(cyberCorpAddress);
+        ICyberCorp(cyberCorpAddress).activateBoardGovernance();
+
         emit CyberCorpDeployed(
             cyberCorpAddress,
             authAddress,

--- a/src/IssuanceManager.sol
+++ b/src/IssuanceManager.sol
@@ -49,13 +49,14 @@ import "./interfaces/ITransferRestrictionHook.sol";
 
 import "./interfaces/ICertificateConverter.sol";
 import "./interfaces/IIssuanceManagerFactory.sol";
+import "./interfaces/IShareClassTermsController.sol";
 import "./storage/IssuanceManagerStorage.sol";
 
 /// @title IssuanceManager
 /// @notice Manages the issuance and lifecycle of digital certificates representing securities and more
 /// @dev Implements UUPS upgradeable pattern and BorgAuth access control
 contract IssuanceManager is Initializable, BorgAuthACL, UUPSUpgradeable {
-    string public constant DEPLOY_VERSION = "4.1"; // For version-tracking on all deployment and future upgrades
+    string public constant DEPLOY_VERSION = "4.2"; // For version-tracking on all deployment and future upgrades
 
     // IssuanceManager errors
     error CompanyDetailsNotSet();
@@ -72,6 +73,8 @@ contract IssuanceManager is Initializable, BorgAuthACL, UUPSUpgradeable {
     error RecertificationApprovalRequired();
     error InvalidInvestor();
     error InvalidInvestorName();
+    error ClassTermsControllerAlreadyInstalled();
+    error ClassTermsMigrationLengthMismatch();
     event ScripifiedCert(
         address indexed certAddress,
         uint256 indexed id,
@@ -232,6 +235,57 @@ contract IssuanceManager is Initializable, BorgAuthACL, UUPSUpgradeable {
             _securityType,
             _securitySeries,
             _extension
+        );
+    }
+
+    /// @notice Creates a share printer and establishes its canonical terms in
+    ///         the same transaction.
+    function createCertPrinterWithClassTerms(
+        string[] memory _ledger,
+        string memory _name,
+        string memory _ticker,
+        string memory _certificateUri,
+        SecurityClass _securityType,
+        SecuritySeries _securitySeries,
+        address _extension,
+        bytes calldata _extensionData
+    ) external onlyOwner returns (address certAddress) {
+        certAddress = IssuanceManagerStorage.executeCreateCertPrinter(
+            _ledger,
+            _name,
+            _ticker,
+            _certificateUri,
+            _securityType,
+            _securitySeries,
+            _extension
+        );
+        IShareClassTermsController(_extension).configureClassTerms(
+            certAddress,
+            _extensionData
+        );
+    }
+
+    /// @notice Atomically moves supplied legacy share printers to the
+    ///         externalized class-terms controller.
+    function migrateClassTermsControllers(
+        address[] calldata certAddresses,
+        address controller,
+        bytes[] calldata extensionData
+    ) external onlyOwner {
+        IssuanceManagerStorage.executeMigrateClassTermsControllers(
+            certAddresses,
+            controller,
+            extensionData
+        );
+    }
+
+    function amendClassTerms(
+        address certAddress,
+        bytes calldata extensionData
+    ) external onlyOwner {
+        IssuanceManagerStorage.executeAmendClassTerms(
+            certAddress,
+            extensionData
         );
     }
 

--- a/src/MetaDAOFactory.sol
+++ b/src/MetaDAOFactory.sol
@@ -321,6 +321,8 @@ contract MetaDAOFactory is UUPSUpgradeable, BorgAuthACL, IERC721Receiver {
 
         BorgAuth(authAddress).updateRole(issuanceManagerAddress, 99);
         BorgAuth(authAddress).updateRole(dealManagerAddress, 99);
+        BorgAuth(authAddress).setRoleManager(cyberCorpAddress);
+        ICyberCorp(cyberCorpAddress).activateBoardGovernance();
 
         emit MetaCorpDeployed(cyberCorpAddress, authAddress, issuanceManagerAddress, dealManagerAddress, roundManagerAddress, address(0), 0, _officer.eoa);
     }

--- a/src/ParentCoFactory.sol
+++ b/src/ParentCoFactory.sol
@@ -286,6 +286,39 @@ contract ParentCoFactory is UUPSUpgradeable, BorgAuthACL, IERC721Receiver {
             address roundManagerAddress
         )
     {
+        return _deployCorp(
+            salt,
+            companyName,
+            companyType,
+            companyJurisdiction,
+            companyContactDetails,
+            defaultDisputeResolution,
+            _companyPayable,
+            _officer,
+            true
+        );
+    }
+
+    function _deployCorp(
+        bytes32 salt,
+        string memory companyName,
+        string memory companyType,
+        string memory companyJurisdiction,
+        string memory companyContactDetails,
+        string memory defaultDisputeResolution,
+        address _companyPayable,
+        CompanyOfficer memory _officer,
+        bool activateGovernance
+    )
+        internal
+        returns (
+            address cyberCorpAddress,
+            address authAddress,
+            address issuanceManagerAddress,
+            address dealManagerAddress,
+            address roundManagerAddress
+        )
+    {
         if (salt == bytes32(0)) revert InvalidSalt();
 
         // Deploy BorgAuth with CREATE2 with new param address owner
@@ -365,6 +398,10 @@ contract ParentCoFactory is UUPSUpgradeable, BorgAuthACL, IERC721Receiver {
         BorgAuth(authAddress).updateRole(issuanceManagerAddress, 99);
         BorgAuth(authAddress).updateRole(dealManagerAddress, 99);
         BorgAuth(authAddress).updateRole(roundManagerAddress, 99);
+        if (activateGovernance) {
+            BorgAuth(authAddress).setRoleManager(cyberCorpAddress);
+            ICyberCorp(cyberCorpAddress).activateBoardGovernance();
+        }
 
         emit CorpDeployed(cyberCorpAddress, authAddress, issuanceManagerAddress, dealManagerAddress, roundManagerAddress, address(0), 0, _officer.eoa);
     }
@@ -395,7 +432,7 @@ contract ParentCoFactory is UUPSUpgradeable, BorgAuthACL, IERC721Receiver {
             issuance,
             dealMgr,
             roundMgr
-        ) = deployCorp(
+        ) = _deployCorp(
             salt,
             companyName,
             companyType,
@@ -403,13 +440,16 @@ contract ParentCoFactory is UUPSUpgradeable, BorgAuthACL, IERC721Receiver {
             companyContactDetails,
             defaultDisputeResolution,
             _companyPayable,
-            officer
+            officer,
+            false
         );
 
         // Add the remaining officers
         for (uint256 i = 1; i < parentCoOfficers.length; i++) {
             ICyberCorp(corp).addOfficer(parentCoOfficers[i]);
         }
+        BorgAuth(auth).setRoleManager(corp);
+        ICyberCorp(corp).activateBoardGovernance();
 
         parentCorp = corp;
         parentAuth = auth;

--- a/src/PumpCorpFactory.sol
+++ b/src/PumpCorpFactory.sol
@@ -333,6 +333,8 @@ contract PumpCorpFactory is UUPSUpgradeable, BorgAuthACL {
         BorgAuth(authAddress).updateRole(issuanceManagerAddress, 99);
         BorgAuth(authAddress).updateRole(dealManagerAddress, 99);
         BorgAuth(authAddress).updateRole(roundManagerAddress, 99);
+        BorgAuth(authAddress).setRoleManager(cyberCorpAddress);
+        ICyberCorp(cyberCorpAddress).activateBoardGovernance();
 
         emit CyberCorpDeployed(
             cyberCorpAddress,

--- a/src/interfaces/ICyberAgreementRegistry.sol
+++ b/src/interfaces/ICyberAgreementRegistry.sol
@@ -87,6 +87,13 @@ interface ICyberAgreementRegistry {
         string[] memory partyFields
     ) external;
 
+    function createTemplatePublic(
+        string memory title,
+        string memory legalContractUri,
+        string[] memory globalFields,
+        string[] memory partyFields
+    ) external returns (bytes32 templateId);
+
     function createContract(
         bytes32 templateId,
         uint256 salt,

--- a/src/interfaces/ICyberCertPrinter.sol
+++ b/src/interfaces/ICyberCertPrinter.sol
@@ -231,6 +231,8 @@ interface ICyberCertPrinter is IERC721 {
         uint256 tokenId
     ) external view returns (CertificateDetails memory);
     function getExtension(uint256 tokenId) external view returns (address);
+    function setExtension(uint256 tokenId, address extension) external;
+    function issuanceManager() external view returns (address);
     function getIssuerSignatureCount(uint256 tokenId) external view returns (uint256);
     function getIssuerSignatureAt(uint256 tokenId, uint256 index) external view returns (bytes memory);
     function addCertLegend(uint256 tokenId, string memory newLegend) external;

--- a/src/interfaces/ICyberCorp.sol
+++ b/src/interfaces/ICyberCorp.sol
@@ -39,7 +39,7 @@ distributed, transmitted, sublicensed, sold, or otherwise used in any form or by
 mechanical, including photocopying, recording, or by any information storage and retrieval system, 
 except with the express prior written permission of the copyright holder.*/
 
-import {CompanyOfficer} from "../CyberCorpConstants.sol";
+import {CompanyDirector, CompanyOfficer} from "../CyberCorpConstants.sol";
 
 pragma solidity 0.8.28;
 
@@ -62,13 +62,35 @@ interface ICyberCorp {
     function cyberCORPContactDetails() external view returns (string memory);
     function defaultDisputeResolution() external view returns (string memory);
     function companyPayable() external view returns (address);
-    function companyOfficers() external view returns (address[] memory);
+    function companyOfficers(
+        uint256 index
+    ) external view returns (
+        address eoa,
+        string memory name,
+        string memory contact,
+        string memory title
+    );
+    function companyDirectors(
+        uint256 index
+    ) external view returns (
+        address eoa,
+        string memory name,
+        string memory contact
+    );
+    function getCompanyOfficerCount() external view returns (uint256);
+    function getCompanyDirectorCount() external view returns (uint256);
     function cyberCORPType() external view returns (string memory);
     function dealManager() external view returns (address);
     function setDealManager(address _dealManager) external;
     function setRoundManager(address _roundManager) external;   
     function roundManager() external view returns (address);
     function addOfficer(CompanyOfficer memory _officer) external;
+    function activateBoardGovernance() external;
+    function boardGovernanceEnforced() external view returns (bool);
+    function isCyberCORPDirector(address account) external view returns (bool);
+    function addDirector(CompanyDirector calldata director) external;
+    function removeDirector(address director) external;
+    function setBoardAuthorityAdapter(address adapter) external;
     function addEscrowedOfficerSignature(bytes calldata signature) external;
     function setEscrowedOfficerSignature(uint256 index, bytes calldata signature) external;
     function getEscrowedOfficerSignature(uint256 index) external view returns (bytes memory);

--- a/src/interfaces/IIssuanceManager.sol
+++ b/src/interfaces/IIssuanceManager.sol
@@ -118,6 +118,28 @@ interface IIssuanceManager {
         address _extension
     ) external returns (address);
 
+    function createCertPrinterWithClassTerms(
+        string[] memory _ledger,
+        string memory _name,
+        string memory _ticker,
+        string memory _certificateUri,
+        SecurityClass _securityType,
+        SecuritySeries _securitySeries,
+        address _extension,
+        bytes calldata _extensionData
+    ) external returns (address);
+
+    function migrateClassTermsControllers(
+        address[] calldata certAddresses,
+        address controller,
+        bytes[] calldata extensionData
+    ) external;
+
+    function amendClassTerms(
+        address certAddress,
+        bytes calldata extensionData
+    ) external;
+
     function createCert(
         address certAddress,
         address to,

--- a/src/interfaces/IShareClassTermsController.sol
+++ b/src/interfaces/IShareClassTermsController.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.28;
+
+interface IShareClassTermsController {
+    function configureClassTerms(address certPrinter, bytes calldata extensionData) external;
+
+    function amendClassTerms(address certPrinter, bytes calldata extensionData) external;
+
+    function accountNewIssuance(
+        address certPrinter,
+        bytes calldata extensionData,
+        uint256 units,
+        bool increasesIssuedUnits
+    ) external;
+
+    function accountCertificateUpdate(
+        address certPrinter,
+        uint256 tokenId,
+        bytes calldata extensionData,
+        uint256 activeUnits,
+        bool changesIssuedUnits
+    ) external;
+
+    function releaseCertificateUnits(address certPrinter, uint256 tokenId) external;
+
+    function restoreCertificateUnits(address certPrinter, uint256 tokenId) external;
+
+    function getClassTerms(address certPrinter)
+        external
+        view
+        returns (
+            bytes memory termsData,
+            bytes32 termsHash,
+            uint256 authorizedShares,
+            uint256 issuedUnits,
+            bool configured
+        );
+}

--- a/src/interfaces/IShareClassTermsExtension.sol
+++ b/src/interfaces/IShareClassTermsExtension.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.28;
+
+/// @notice Optional interface implemented by share certificate extensions.
+/// @dev Keeps the printer independent from the large ShareCertData ABI while
+///      still allowing it to make SeriesTerms authoritative at class level.
+interface IShareClassTermsExtension {
+    function getSeriesTermsData(
+        bytes calldata extensionData
+    ) external view returns (bytes memory termsData, uint256 authorizedShares);
+}

--- a/src/libs/auth.sol
+++ b/src/libs/auth.sol
@@ -52,19 +52,29 @@ contract BorgAuth is Initializable {
     uint256 public constant OWNER_ROLE = 99;
     uint256 public constant ADMIN_ROLE = 98;
     uint256 public constant PRIVILEGED_ROLE = 97;
+    uint256 public constant OFFICER_ROLE = 200;
+    uint256 public constant BOARD_ROLE = 300;
     address public pendingOwner;
 
     //mappings and events
     mapping(address => uint256) public userRoles;
     mapping(uint256 => address) public roleAdapters;
+    /// @notice Optional one-time role-management lock for newly deployed corps.
+    /// @dev Existing auth deployments keep the legacy owner-managed behavior
+    ///      because their bytecode is immutable and this slot/function does not
+    ///      exist there.
+    address public roleManager;
 
     event RoleUpdated(address indexed user, uint256 role);
     event AdapterUpdated(uint256 indexed role, address adapter);
+    event RoleManagerSet(address indexed roleManager);
 
     /// @dev user not authorized with given role
     error BorgAuth_NotAuthorized(uint256 role, address user);
     error BorgAuth_SetAnotherOwner();
     error BorgAuth_ZeroAddress();
+    error BorgAuth_RoleManagerAlreadySet();
+    error BorgAuth_NotRoleManager(address caller);
 
     /// @notice Empty constructor for implementation contract
     constructor(address owner) {
@@ -84,15 +94,28 @@ contract BorgAuth is Initializable {
         address user,
         uint256 role
     ) external {
-         onlyRole(OWNER_ROLE, msg.sender);
+        _authorizeRoleManagement();
         _updateRole(user, role);
+    }
+
+    /// @notice Permanently delegates role mutations to a governance contract.
+    /// @dev One-way by design: allowing replacement would recreate the direct
+    ///      officer bypass this lock is meant to close.
+    function setRoleManager(address manager) external {
+        if (manager == address(0)) revert BorgAuth_ZeroAddress();
+        if (roleManager != address(0)) {
+            revert BorgAuth_RoleManagerAlreadySet();
+        }
+        onlyRole(OWNER_ROLE, msg.sender);
+        roleManager = manager;
+        emit RoleManagerSet(manager);
     }
     
     /// @notice initialize ownership transfer
     /// @param newOwner address of new owner
     function initTransferOwnership(address newOwner) external {
         if (newOwner == address(0) || newOwner == msg.sender) revert BorgAuth_ZeroAddress();
-        onlyRole(OWNER_ROLE, msg.sender);
+        _authorizeRoleManagement();
         pendingOwner = newOwner;
     }
 
@@ -107,7 +130,7 @@ contract BorgAuth is Initializable {
     /// @notice function to purposefully revoke all roles from owner, rendering subsequent role updates impossible
     /// @dev this function is intended for use to remove admin controls from subsequent contracts using this auth
     function zeroOwner() external {
-        onlyRole(OWNER_ROLE, msg.sender);
+        _authorizeRoleManagement();
         _updateRole(msg.sender, 0);
     }
 
@@ -115,7 +138,7 @@ contract BorgAuth is Initializable {
     /// @param _role role to set adapter for
     /// @param _adapter address of adapter
     function setRoleAdapter(uint256 _role, address _adapter) external {
-        onlyRole(OWNER_ROLE, msg.sender);
+        _authorizeRoleManagement();
         roleAdapters[_role] = _adapter;
         emit AdapterUpdated(_role, _adapter);
     }
@@ -159,6 +182,17 @@ contract BorgAuth is Initializable {
     ) internal {
         userRoles[user] = role;
         emit RoleUpdated(user, role);
+    }
+
+    function _authorizeRoleManagement() internal view {
+        address manager = roleManager;
+        if (manager != address(0)) {
+            if (msg.sender != manager) {
+                revert BorgAuth_NotRoleManager(msg.sender);
+            }
+            return;
+        }
+        onlyRole(OWNER_ROLE, msg.sender);
     }
 }
 

--- a/src/storage/IssuanceManagerStorage.sol
+++ b/src/storage/IssuanceManagerStorage.sol
@@ -50,11 +50,14 @@ import "../interfaces/ICyberCorp.sol";
 import "../interfaces/ICyberScrip.sol";
 import "../interfaces/IIssuanceManager.sol";
 import "../interfaces/IIssuanceManagerFactory.sol";
+import "../interfaces/IShareClassTermsController.sol";
 import "../interfaces/ITransferRestrictionHook.sol";
 import {ExemptionPathway, HostingMode} from "../interfaces/ISecondaryTradeStorage.sol";
 import "./CyberCertPrinterStorage.sol";
+import "./extensions/ICertificateExtension.sol";
 
 library IssuanceManagerStorage {
+    bytes32 private constant SHARE_EXTENSION_TYPE = keccak256("SHARE");
     error ConditionCheckFailed();
     error ScripifiedCertNotAllowed();
     error ScripToCertMinimumNotMet();
@@ -74,6 +77,8 @@ library IssuanceManagerStorage {
     error EmptyVault();
     error VaultRedemptionExceedsClaim();
     error VaultWithdrawalExceedsAssets();
+    error ClassTermsControllerAlreadyInstalled();
+    error ClassTermsMigrationLengthMismatch();
 
     /// @dev Ray precision for vault price-per-share (assets per 1 nominal share, 1e27 = 1.0).
     uint256 internal constant VAULT_RAY = 1e27;
@@ -148,6 +153,48 @@ library IssuanceManagerStorage {
         uint256 newUnitsRepresented,
         uint256 newUnitsScripified
     );
+
+    function executeMigrateClassTermsControllers(
+        address[] calldata certAddresses,
+        address controller,
+        bytes[] calldata extensionData
+    ) external {
+        if (certAddresses.length != extensionData.length) {
+            revert ClassTermsMigrationLengthMismatch();
+        }
+        for (uint256 i = 0; i < certAddresses.length; ++i) {
+            address certAddress = certAddresses[i];
+            ICyberCertPrinter printer = ICyberCertPrinter(certAddress);
+            address currentExtension = printer.getExtension(0);
+            if (currentExtension != controller) {
+                (bool isController,) = currentExtension.staticcall(
+                    abi.encodeCall(
+                        IShareClassTermsController.getClassTerms,
+                        (certAddress)
+                    )
+                );
+                if (currentExtension.code.length != 0 && isController) {
+                    revert ClassTermsControllerAlreadyInstalled();
+                }
+                printer.setExtension(0, controller);
+            }
+            IShareClassTermsController(controller).configureClassTerms(
+                certAddress,
+                extensionData[i]
+            );
+        }
+    }
+
+    function executeAmendClassTerms(
+        address certAddress,
+        bytes calldata extensionData
+    ) external {
+        address controller = ICyberCertPrinter(certAddress).getExtension(0);
+        IShareClassTermsController(controller).amendClassTerms(
+            certAddress,
+            extensionData
+        );
+    }
 
     // Storage slot for our struct
     bytes32 constant STORAGE_POSITION = keccak256("cybercorp.issuancemanager.storage.v1");
@@ -609,6 +656,7 @@ library IssuanceManagerStorage {
         CertificateDetails memory details
     ) external returns (uint256 id) {
         ICyberCertPrinter cert = ICyberCertPrinter(certAddress);
+        _accountNewIssuance(certAddress, details, true);
         uint256 tokenId = cert.totalSupply();
         id = cert.safeMint(tokenId, to, details);
         _emitCertificateCreated(tokenId, certAddress, details);
@@ -621,6 +669,7 @@ library IssuanceManagerStorage {
         address investor,
         CertificateDetails memory details
     ) external {
+        _accountCertificateUpdate(certAddress, tokenId, details, true);
         ICyberCertPrinter(certAddress).assignCert(from, tokenId, investor, details);
     }
 
@@ -755,6 +804,12 @@ library IssuanceManagerStorage {
         CertificateDetails memory sellerDetails = cert.getActiveCertificateDetails(tokenId);
         if (units > sellerDetails.unitsRepresented) revert AmountExceedsAvailableUnits();
         sellerDetails.unitsRepresented -= units;
+        _accountCertificateUpdate(
+            certPrinter,
+            tokenId,
+            sellerDetails,
+            true
+        );
         cert.updateCertificateDetails(tokenId, sellerDetails);
         bool sellerVoided = sellerDetails.unitsRepresented == 0;
         if (sellerVoided) {
@@ -957,6 +1012,7 @@ library IssuanceManagerStorage {
 
         _depositCertScripUnits(certAddress, id, amount);
         details.unitsRepresented = details.unitsRepresented - amount;
+        _accountCertificateUpdate(certAddress, id, details, false);
         certificate.updateCertificateDetails(id, details);
         ICyberScrip(scripifiedCert).mint(toSend, scripAmount);
         (uint256 newTotalAssetsWad, uint256 newTotalNominalShares) = getCertScripUnitVault(
@@ -1061,6 +1117,12 @@ library IssuanceManagerStorage {
             activeDetails.unitsRepresented =
                 activeDetails.unitsRepresented +
                 units;
+            _accountCertificateUpdate(
+                certAddress,
+                selection.activeTokenId,
+                activeDetails,
+                false
+            );
             certificate.updateCertificateDetails(
                 selection.activeTokenId,
                 activeDetails
@@ -1099,15 +1161,38 @@ library IssuanceManagerStorage {
         } else {
             CertificateDetails memory details = approval.details;
             details.unitsRepresented = units;
-            uint256 createdTokenId = IIssuanceManager(address(this))
-                .createCertAndAssignWithName(
-                    certAddress,
-                    account,
-                    details,
-                    approval.investorName,
-                    approval.officerSignature,
-                    approval.endorsementTimestamp
+            (, uint256 createdTokenId) = _mintAssignedCertFromScrip(
+                certAddress,
+                account,
+                account,
+                details,
+                approval.investorName
+            );
+            Endorsement memory recertificationEndorsement = Endorsement({
+                endorser: address(this),
+                timestamp: approval.endorsementTimestamp,
+                signatureHash: approval.officerSignature,
+                registry: address(0),
+                agreementId: 0,
+                endorsee: account,
+                endorseeName: approval.investorName
+            });
+            certificate.addEndorsement(
+                createdTokenId,
+                recertificationEndorsement
+            );
+            certificate.addIssuerSignature(
+                createdTokenId,
+                approval.officerSignature
+            );
+            bytes memory escrowedOfficerSignature =
+                _getEscrowedOfficerSignature();
+            if (escrowedOfficerSignature.length > 0) {
+                certificate.addIssuerSignature(
+                    createdTokenId,
+                    escrowedOfficerSignature
                 );
+            }
             clearRecertificationApproval(certAddress, account);
             _setCertMaxFromCurrent(
                 certAddress,
@@ -1258,9 +1343,82 @@ library IssuanceManagerStorage {
     {
         _requireCompanyDetailsSet();
         cert = ICyberCertPrinter(certAddress);
+        _accountNewIssuance(certAddress, details, true);
         tokenId = cert.totalSupply();
         cert.safeMintAndAssign(to, owner, tokenId, details, ownerName);
         _emitCertificateCreated(tokenId, certAddress, details);
+    }
+
+    function _mintAssignedCertFromScrip(
+        address certAddress,
+        address to,
+        address owner,
+        CertificateDetails memory details,
+        string memory ownerName
+    )
+        internal
+        returns (ICyberCertPrinter cert, uint256 tokenId)
+    {
+        _requireCompanyDetailsSet();
+        cert = ICyberCertPrinter(certAddress);
+        _accountNewIssuance(certAddress, details, false);
+        tokenId = cert.totalSupply();
+        cert.safeMintAndAssign(to, owner, tokenId, details, ownerName);
+        _emitCertificateCreated(tokenId, certAddress, details);
+    }
+
+    function _accountNewIssuance(
+        address certAddress,
+        CertificateDetails memory details,
+        bool increasesIssuedUnits
+    ) private {
+        address controller = _shareClassTermsController(certAddress);
+        if (controller != address(0)) {
+            IShareClassTermsController(controller).accountNewIssuance(
+                certAddress,
+                details.extensionData,
+                details.unitsRepresented,
+                increasesIssuedUnits
+            );
+        }
+    }
+
+    function _accountCertificateUpdate(
+        address certAddress,
+        uint256 tokenId,
+        CertificateDetails memory details,
+        bool changesIssuedUnits
+    ) private {
+        address controller = _shareClassTermsController(certAddress);
+        if (controller != address(0)) {
+            IShareClassTermsController(controller).accountCertificateUpdate(
+                certAddress,
+                tokenId,
+                details.extensionData,
+                details.unitsRepresented,
+                changesIssuedUnits
+            );
+        }
+    }
+
+    function _shareClassTermsController(
+        address certAddress
+    ) private view returns (address extension) {
+        try ICyberCertPrinter(certAddress).getExtension(0) returns (
+            address foundExtension
+        ) {
+            extension = foundExtension;
+        } catch {
+            return address(0);
+        }
+        if (extension == address(0)) return address(0);
+        try ICertificateExtension(extension).supportsExtensionType(
+            SHARE_EXTENSION_TYPE
+        ) returns (bool supported) {
+            return supported ? extension : address(0);
+        } catch {
+            return address(0);
+        }
     }
 
     function _requireCompanyDetailsSet() internal view {

--- a/src/storage/extensions/ShareClassTermsController.sol
+++ b/src/storage/extensions/ShareClassTermsController.sol
@@ -1,0 +1,301 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.28;
+
+import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+
+import "../../interfaces/ICyberCertPrinter.sol";
+import "../../interfaces/IIssuanceManager.sol";
+import "../../interfaces/IShareClassTermsController.sol";
+import "../../interfaces/IShareClassTermsExtension.sol";
+import "../../libs/auth.sol";
+import "../CyberCertPrinterStorage.sol";
+import "./ICertificateExtension.sol";
+
+/// @notice Share extension facade and canonical class-terms accounting controller.
+/// @dev CyberCertPrinter v4 is already at the EIP-170 size ceiling. This contract
+///      keeps enforcement in a separately upgradeable component while the
+///      IssuanceManager remains the only mutating path into a printer.
+contract ShareClassTermsController is
+    UUPSUpgradeable,
+    ICertificateExtension,
+    IShareClassTermsExtension,
+    IShareClassTermsController,
+    BorgAuthACL
+{
+    bytes32 public constant EXTENSION_TYPE = keccak256("SHARE");
+    string public constant DEPLOY_VERSION = "1";
+
+    error NotPrinterIssuanceManager();
+    error PrinterUsesDifferentExtension();
+    error InvalidRenderer();
+    error InvalidShareExtensionData();
+    error ClassTermsNotConfigured();
+    error ClassTermsAlreadyConfigured();
+    error ClassTermsMismatch();
+    error AuthorizedSharesExceeded(uint256 authorizedShares, uint256 attemptedIssuedUnits);
+    error AuthorizedSharesBelowIssued(uint256 authorizedShares, uint256 issuedUnits);
+    error CertificateAlreadyVoided();
+    error CertificateNotVoided();
+
+    event RendererSet(address indexed renderer);
+    event ClassTermsConfigured(
+        address indexed certPrinter,
+        bytes32 indexed termsHash,
+        uint256 authorizedShares,
+        uint256 issuedUnits,
+        bool migrated
+    );
+    event ClassTermsAmended(
+        address indexed certPrinter,
+        bytes32 indexed previousTermsHash,
+        bytes32 indexed newTermsHash,
+        uint256 authorizedShares
+    );
+
+    struct ClassTermsState {
+        bytes termsData;
+        bytes32 termsHash;
+        uint256 authorizedShares;
+        uint256 issuedUnits;
+        bool configured;
+    }
+
+    address public renderer;
+    mapping(address certPrinter => ClassTermsState) private classTerms;
+    uint256[48] private __gap;
+
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(address auth, address renderer_) external initializer {
+        __UUPSUpgradeable_init();
+        __BorgAuthACL_init(auth);
+        _setRenderer(renderer_);
+    }
+
+    function setRenderer(address renderer_) external onlyOwner {
+        _setRenderer(renderer_);
+    }
+
+    function supportsExtensionType(bytes32 extensionType) external pure override returns (bool) {
+        return extensionType == EXTENSION_TYPE;
+    }
+
+    function getExtensionURI(bytes memory data) external view override returns (string memory) {
+        return ICertificateExtension(renderer).getExtensionURI(data);
+    }
+
+    function getSeriesTermsData(bytes calldata extensionData)
+        external
+        view
+        override
+        returns (bytes memory termsData, uint256 authorizedShares)
+    {
+        return IShareClassTermsExtension(renderer).getSeriesTermsData(extensionData);
+    }
+
+    function configureClassTerms(address certPrinter, bytes calldata extensionData) external override {
+        _requireAuthorizedControllerCall(certPrinter);
+        ClassTermsState storage state = classTerms[certPrinter];
+        if (state.configured) revert ClassTermsAlreadyConfigured();
+
+        (bytes memory termsData, uint256 authorizedShares) = _readClassTerms(extensionData);
+        uint256 issuedUnits = _calculateOutstandingUnits(certPrinter);
+        if (issuedUnits > authorizedShares) {
+            revert AuthorizedSharesExceeded(authorizedShares, issuedUnits);
+        }
+
+        _storeClassTerms(state, termsData, authorizedShares);
+        state.issuedUnits = issuedUnits;
+        emit ClassTermsConfigured(
+            certPrinter,
+            state.termsHash,
+            authorizedShares,
+            issuedUnits,
+            ICyberCertPrinter(certPrinter).totalSupply() != 0
+        );
+    }
+
+    function amendClassTerms(address certPrinter, bytes calldata extensionData) external override {
+        _requireAuthorizedControllerCall(certPrinter);
+        ClassTermsState storage state = classTerms[certPrinter];
+        if (!state.configured) revert ClassTermsNotConfigured();
+
+        (bytes memory termsData, uint256 authorizedShares) = _readClassTerms(extensionData);
+        if (authorizedShares < state.issuedUnits) {
+            revert AuthorizedSharesBelowIssued(authorizedShares, state.issuedUnits);
+        }
+
+        bytes32 previousTermsHash = state.termsHash;
+        _storeClassTerms(state, termsData, authorizedShares);
+        emit ClassTermsAmended(certPrinter, previousTermsHash, state.termsHash, authorizedShares);
+    }
+
+    function accountNewIssuance(
+        address certPrinter,
+        bytes calldata extensionData,
+        uint256 units,
+        bool increasesIssuedUnits
+    ) external override {
+        _requireAuthorizedControllerCall(certPrinter);
+        ClassTermsState storage state = classTerms[certPrinter];
+
+        if (!state.configured) {
+            if (ICyberCertPrinter(certPrinter).totalSupply() != 0) {
+                revert ClassTermsNotConfigured();
+            }
+            (bytes memory termsData, uint256 authorizedShares) = _readClassTerms(extensionData);
+            _storeClassTerms(state, termsData, authorizedShares);
+            emit ClassTermsConfigured(certPrinter, state.termsHash, authorizedShares, 0, false);
+        } else {
+            _validateClassTerms(state, extensionData);
+        }
+
+        if (increasesIssuedUnits) {
+            _increaseIssuedUnits(state, units);
+        }
+    }
+
+    function accountCertificateUpdate(
+        address certPrinter,
+        uint256 tokenId,
+        bytes calldata extensionData,
+        uint256 activeUnits,
+        bool changesIssuedUnits
+    ) external override {
+        _requireAuthorizedControllerCall(certPrinter);
+        ClassTermsState storage state = classTerms[certPrinter];
+        if (!state.configured) revert ClassTermsNotConfigured();
+        _validateClassTerms(state, extensionData);
+
+        ICyberCertPrinter printer = ICyberCertPrinter(certPrinter);
+        if (!changesIssuedUnits || printer.isVoided(tokenId)) return;
+
+        uint256 oldUnits =
+            _effectiveUnits(certPrinter, tokenId, printer.getActiveCertificateDetails(tokenId).unitsRepresented);
+        uint256 newUnits = _effectiveUnits(certPrinter, tokenId, activeUnits);
+        if (newUnits > oldUnits) {
+            _increaseIssuedUnits(state, newUnits - oldUnits);
+        } else if (oldUnits > newUnits) {
+            state.issuedUnits -= oldUnits - newUnits;
+        }
+    }
+
+    function releaseCertificateUnits(address certPrinter, uint256 tokenId) external override {
+        _requireAuthorizedControllerCall(certPrinter);
+        ClassTermsState storage state = classTerms[certPrinter];
+        if (!state.configured) revert ClassTermsNotConfigured();
+
+        ICyberCertPrinter printer = ICyberCertPrinter(certPrinter);
+        if (printer.isVoided(tokenId)) revert CertificateAlreadyVoided();
+        state.issuedUnits -= _effectiveUnits(
+            certPrinter, tokenId, printer.getActiveCertificateDetails(tokenId).unitsRepresented
+        );
+    }
+
+    function restoreCertificateUnits(address certPrinter, uint256 tokenId) external override {
+        _requireAuthorizedControllerCall(certPrinter);
+        ClassTermsState storage state = classTerms[certPrinter];
+        if (!state.configured) revert ClassTermsNotConfigured();
+
+        ICyberCertPrinter printer = ICyberCertPrinter(certPrinter);
+        if (!printer.isVoided(tokenId)) revert CertificateNotVoided();
+        CertificateDetails memory details = printer.getActiveCertificateDetails(tokenId);
+        _validateClassTerms(state, details.extensionData);
+        _increaseIssuedUnits(state, _effectiveUnits(certPrinter, tokenId, details.unitsRepresented));
+    }
+
+    function getClassTerms(address certPrinter)
+        external
+        view
+        override
+        returns (
+            bytes memory termsData,
+            bytes32 termsHash,
+            uint256 authorizedShares,
+            uint256 issuedUnits,
+            bool configured
+        )
+    {
+        ClassTermsState storage state = classTerms[certPrinter];
+        return (state.termsData, state.termsHash, state.authorizedShares, state.issuedUnits, state.configured);
+    }
+
+    function _requireAuthorizedControllerCall(address certPrinter) private view {
+        ICyberCertPrinter printer = ICyberCertPrinter(certPrinter);
+        if (printer.issuanceManager() != msg.sender) {
+            revert NotPrinterIssuanceManager();
+        }
+        if (printer.getExtension(0) != address(this)) {
+            revert PrinterUsesDifferentExtension();
+        }
+    }
+
+    function _calculateOutstandingUnits(address certPrinter) private view returns (uint256 outstandingUnits) {
+        ICyberCertPrinter printer = ICyberCertPrinter(certPrinter);
+        uint256 supply = printer.totalSupply();
+        for (uint256 i = 0; i < supply; ++i) {
+            uint256 tokenId = printer.tokenByIndex(i);
+            if (!printer.isVoided(tokenId)) {
+                outstandingUnits += _effectiveUnits(
+                    certPrinter, tokenId, printer.getActiveCertificateDetails(tokenId).unitsRepresented
+                );
+            }
+        }
+    }
+
+    function _effectiveUnits(address certPrinter, uint256 tokenId, uint256 activeUnits) private view returns (uint256) {
+        address issuanceManager = ICyberCertPrinter(certPrinter).issuanceManager();
+        (, uint256 scripifiedUnits,) = IIssuanceManager(issuanceManager).getCertScripifiedStatus(certPrinter, tokenId);
+        return activeUnits + scripifiedUnits;
+    }
+
+    function _validateClassTerms(ClassTermsState storage state, bytes memory extensionData) private view {
+        (bytes memory termsData,) = _readClassTerms(extensionData);
+        if (keccak256(termsData) != state.termsHash) {
+            revert ClassTermsMismatch();
+        }
+    }
+
+    function _increaseIssuedUnits(ClassTermsState storage state, uint256 units) private {
+        uint256 attemptedIssuedUnits = state.issuedUnits + units;
+        if (attemptedIssuedUnits > state.authorizedShares) {
+            revert AuthorizedSharesExceeded(state.authorizedShares, attemptedIssuedUnits);
+        }
+        state.issuedUnits = attemptedIssuedUnits;
+    }
+
+    function _storeClassTerms(ClassTermsState storage state, bytes memory termsData, uint256 authorizedShares) private {
+        state.termsData = termsData;
+        state.termsHash = keccak256(termsData);
+        state.authorizedShares = authorizedShares;
+        state.configured = true;
+    }
+
+    function _readClassTerms(bytes memory extensionData)
+        private
+        view
+        returns (bytes memory termsData, uint256 authorizedShares)
+    {
+        if (extensionData.length == 0) revert InvalidShareExtensionData();
+        try IShareClassTermsExtension(renderer).getSeriesTermsData(extensionData) returns (
+            bytes memory extractedTerms, uint256 extractedAuthorized
+        ) {
+            if (extractedTerms.length == 0) {
+                revert InvalidShareExtensionData();
+            }
+            return (extractedTerms, extractedAuthorized);
+        } catch {
+            revert InvalidShareExtensionData();
+        }
+    }
+
+    function _setRenderer(address renderer_) private {
+        if (renderer_.code.length == 0) revert InvalidRenderer();
+        renderer = renderer_;
+        emit RendererSet(renderer_);
+    }
+
+    function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
+}

--- a/src/storage/extensions/ShareExtension.sol
+++ b/src/storage/extensions/ShareExtension.sol
@@ -247,6 +247,18 @@ contract ShareExtension is UUPSUpgradeable, ICertificateExtension, BorgAuthACL {
         return abi.encode(data);
     }
 
+    /// @notice Returns the canonical class-level portion of share extension data.
+    /// @dev CyberCertPrinter hashes `termsData` and stores it once per printer.
+    ///      CertificateData and the variable-length rights/history arrays remain
+    ///      certificate-specific and are intentionally excluded.
+    function getSeriesTermsData(
+        bytes calldata data
+    ) external pure returns (bytes memory termsData, uint256 authorizedShares) {
+        ShareCertData memory share = abi.decode(data, (ShareCertData));
+        termsData = abi.encode(share.terms);
+        authorizedShares = share.terms.authorizedShares;
+    }
+
     function supportsExtensionType(bytes32 extensionType) external pure override returns (bool) {
         return extensionType == EXTENSION_TYPE;
     }

--- a/test/CyberAgreementRegistryTest.t.sol
+++ b/test/CyberAgreementRegistryTest.t.sol
@@ -97,6 +97,108 @@ contract CyberAgreementRegistryTest is Test {
         vm.stopPrank();
     }
 
+    function test_createTemplateCallerChosenIdIsOwnerOnly() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                BorgAuth.BorgAuth_NotAuthorized.selector,
+                coreAuth.OWNER_ROLE(),
+                alice
+            )
+        );
+        vm.prank(alice);
+        registry.createTemplate(
+            keccak256("squattable-id"),
+            "Untrusted",
+            "ipfs://untrusted",
+            testGlobalFields,
+            testPartyFields
+        );
+    }
+
+    function test_createTemplatePublicIsContentAddressedAndPermissionless()
+        public
+    {
+        vm.prank(alice);
+        bytes32 templateId = registry.createTemplatePublic(
+            testTitle,
+            testLegalContractUri,
+            testGlobalFields,
+            testPartyFields
+        );
+
+        assertEq(templateId, expectedStandaloneTemplateId);
+        (
+            string memory legalContractUri,
+            string memory title,
+            string[] memory globalFields,
+            string[] memory partyFields
+        ) = registry.getTemplateDetails(templateId);
+        assertEq(legalContractUri, testLegalContractUri);
+        assertEq(title, testTitle);
+        assertEq(globalFields, testGlobalFields);
+        assertEq(partyFields, testPartyFields);
+    }
+
+    function test_createTemplatePublicIsIdempotent() public {
+        vm.prank(alice);
+        bytes32 first = registry.createTemplatePublic(
+            testTitle,
+            testLegalContractUri,
+            testGlobalFields,
+            testPartyFields
+        );
+
+        vm.prank(bob);
+        bytes32 second = registry.createTemplatePublic(
+            testTitle,
+            testLegalContractUri,
+            testGlobalFields,
+            testPartyFields
+        );
+
+        assertEq(first, second);
+    }
+
+    function test_createTemplatePublicRejectsEmptyLegalContractUri() public {
+        vm.prank(alice);
+        vm.expectRevert(CyberAgreementRegistry.LegalContractUriEmpty.selector);
+        registry.createTemplatePublic(
+            testTitle,
+            "",
+            testGlobalFields,
+            testPartyFields
+        );
+    }
+
+    function test_upgradePreservesExistingTemplatesAndPublicRegistration()
+        public
+    {
+        address implementation = address(new CyberAgreementRegistry());
+
+        vm.prank(deployer);
+        registry.upgradeToAndCall(implementation, "");
+
+        (
+            string memory legalContractUri,
+            string memory title,
+            string[] memory globalFields,
+            string[] memory partyFields
+        ) = registry.getTemplateDetails(testTemplateId);
+        assertEq(legalContractUri, testLegalContractUri);
+        assertEq(title, "Test");
+        assertEq(globalFields, testGlobalFields);
+        assertEq(partyFields, testPartyFields);
+
+        vm.prank(alice);
+        bytes32 publicTemplateId = registry.createTemplatePublic(
+            testTitle,
+            testLegalContractUri,
+            testGlobalFields,
+            testPartyFields
+        );
+        assertEq(publicTemplateId, expectedStandaloneTemplateId);
+    }
+
     /// @notice Contract should automatically finalize if (1) all parties are signed, and (2) finalizer is undefined
     function test_signContractAndFinalize() public {
         uint256 salt = uint256(keccak256("test_signContractAndFinalize"));

--- a/test/CyberCertPrinterClassTermsTest.t.sol
+++ b/test/CyberCertPrinterClassTermsTest.t.sol
@@ -1,0 +1,405 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.28;
+
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {Test} from "forge-std/Test.sol";
+
+import {CyberCertPrinter} from "../src/CyberCertPrinter.sol";
+import {SecurityClass, SecuritySeries} from "../src/CyberCorpConstants.sol";
+import {CyberScrip} from "../src/CyberScrip.sol";
+import {IssuanceManager} from "../src/IssuanceManager.sol";
+import {IssuanceManagerFactory} from "../src/IssuanceManagerFactory.sol";
+import {BorgAuth} from "../src/libs/auth.sol";
+import {CertificateDetails} from "../src/storage/CyberCertPrinterStorage.sol";
+import {IssuanceManagerStorage} from "../src/storage/IssuanceManagerStorage.sol";
+import {ShareClassTermsController} from "../src/storage/extensions/ShareClassTermsController.sol";
+import {
+    CertificateData,
+    MandatoryConversionTrigger,
+    SeriesTerms,
+    ShareCertData,
+    ShareExtension,
+    ShareRepresentationType,
+    SpecialVotingRight,
+    SplitRecord,
+    TransferRestriction
+} from "../src/storage/extensions/ShareExtension.sol";
+import {ERC1967ProxyLib} from "./libs/ERC1967ProxyLib.sol";
+
+contract ClassTermsMigrationHarness {
+    function migrate(address[] calldata certPrinters, address controller, bytes[] calldata extensionData) external {
+        IssuanceManagerStorage.executeMigrateClassTermsControllers(certPrinters, controller, extensionData);
+    }
+}
+
+contract CyberCertPrinterClassTermsTest is Test {
+    using ERC1967ProxyLib for address;
+
+    CyberCertPrinter internal printer;
+    ShareExtension internal shareExtension;
+    ShareClassTermsController internal controller;
+    mapping(uint256 => uint256) internal scripifiedUnits;
+
+    function setUp() public {
+        shareExtension = new ShareExtension();
+        BorgAuth auth = new BorgAuth(address(this));
+        ShareClassTermsController controllerImplementation = new ShareClassTermsController();
+        controller = ShareClassTermsController(
+            address(
+                new ERC1967Proxy(
+                    address(controllerImplementation),
+                    abi.encodeCall(ShareClassTermsController.initialize, (address(auth), address(shareExtension)))
+                )
+            )
+        );
+        CyberCertPrinter implementation = new CyberCertPrinter();
+        string[] memory legends = new string[](0);
+        printer = CyberCertPrinter(
+            address(
+                new ERC1967Proxy(
+                    address(implementation),
+                    abi.encodeCall(
+                        CyberCertPrinter.initialize,
+                        (
+                            legends,
+                            "Common Stock",
+                            "COMMON",
+                            "ipfs://certificate",
+                            address(this),
+                            SecurityClass.CommonStock,
+                            SecuritySeries.NA,
+                            address(controller)
+                        )
+                    )
+                )
+            )
+        );
+    }
+
+    function test_FirstMintMakesTermsCanonicalAndEnforcesCap() public {
+        CertificateDetails memory first = _details(_terms("Common", 10), 6);
+        controller.accountNewIssuance(address(printer), first.extensionData, first.unitsRepresented, true);
+        printer.safeMint(0, address(0xA11CE), first);
+
+        (bytes memory termsData, bytes32 termsHash, uint256 authorized, uint256 issued, bool configured) =
+            controller.getClassTerms(address(printer));
+        assertTrue(configured);
+        assertEq(authorized, 10);
+        assertEq(issued, 6);
+        assertEq(termsHash, keccak256(termsData));
+
+        vm.expectRevert(abi.encodeWithSelector(ShareClassTermsController.AuthorizedSharesExceeded.selector, 10, 11));
+        CertificateDetails memory overCap = _details(_terms("Common", 10), 5);
+        controller.accountNewIssuance(address(printer), overCap.extensionData, overCap.unitsRepresented, true);
+    }
+
+    function test_ClassTermsCanBeConfiguredBeforeFirstIssuance() public {
+        controller.configureClassTerms(address(printer), _extensionData(_terms("Common", 10)));
+        assertEq(_authorizedShares(), 10);
+        assertEq(_issuedUnits(), 0);
+
+        _mint(0, address(0xA11CE), _details(_terms("Common", 10), 4));
+        assertEq(_issuedUnits(), 4);
+    }
+
+    function test_RejectsDifferentTermsForSameClass() public {
+        _mint(0, address(0xA11CE), _details(_terms("Common", 10), 2));
+
+        vm.expectRevert(ShareClassTermsController.ClassTermsMismatch.selector);
+        CertificateDetails memory mismatch = _details(_terms("Common B", 10), 1);
+        controller.accountNewIssuance(address(printer), mismatch.extensionData, mismatch.unitsRepresented, true);
+    }
+
+    function test_VoidUnvoidAndBurnMaintainIssuedUnits() public {
+        _mint(0, address(0xA11CE), _details(_terms("Common", 10), 6));
+        controller.releaseCertificateUnits(address(printer), 0);
+        printer.voidCert(0);
+        assertEq(_issuedUnits(), 0);
+
+        controller.restoreCertificateUnits(address(printer), 0);
+        printer.unvoidCert(0);
+        assertEq(_issuedUnits(), 6);
+
+        controller.releaseCertificateUnits(address(printer), 0);
+        printer.burn(0);
+        assertEq(_issuedUnits(), 0);
+    }
+
+    function test_ScripRepresentationChangesDoNotDoubleCount() public {
+        CertificateDetails memory details = _details(_terms("Common", 10), 6);
+        _mint(0, address(0xA11CE), details);
+
+        scripifiedUnits[0] = 2;
+        details.unitsRepresented = 4;
+        controller.accountCertificateUpdate(address(printer), 0, details.extensionData, details.unitsRepresented, false);
+        printer.updateCertificateDetails(0, details);
+        assertEq(_issuedUnits(), 6);
+
+        controller.releaseCertificateUnits(address(printer), 0);
+        printer.voidCert(0);
+        assertEq(_issuedUnits(), 0);
+        controller.restoreCertificateUnits(address(printer), 0);
+        printer.unvoidCert(0);
+        assertEq(_issuedUnits(), 6);
+    }
+
+    function test_RecertificationMintValidatesTermsWithoutIncrementing() public {
+        _mint(0, address(0xA11CE), _details(_terms("Common", 10), 10));
+
+        CertificateDetails memory recert = _details(_terms("Common", 10), 3);
+        controller.accountNewIssuance(address(printer), recert.extensionData, recert.unitsRepresented, false);
+        printer.safeMintAndAssign(address(0xB0B), 1, recert, "Bob");
+        assertEq(_issuedUnits(), 10);
+    }
+
+    function test_AmendmentCannotReduceAuthorizationBelowIssued() public {
+        _mint(0, address(0xA11CE), _details(_terms("Common", 10), 6));
+
+        vm.expectRevert(abi.encodeWithSelector(ShareClassTermsController.AuthorizedSharesBelowIssued.selector, 5, 6));
+        controller.amendClassTerms(address(printer), _extensionData(_terms("Common", 5)));
+
+        controller.amendClassTerms(address(printer), _extensionData(_terms("Common", 20)));
+        assertEq(_authorizedShares(), 20);
+    }
+
+    function test_MigrationIsAtomicAndInstalledControllerCannotBeReplaced() public {
+        ClassTermsMigrationHarness harness = new ClassTermsMigrationHarness();
+        CyberCertPrinter firstLegacyPrinter = _deployPrinter(address(harness), address(shareExtension));
+        CyberCertPrinter secondLegacyPrinter = _deployPrinter(address(harness), address(shareExtension));
+        ShareClassTermsController firstController = _deployController();
+
+        address[] memory printers = new address[](2);
+        printers[0] = address(firstLegacyPrinter);
+        printers[1] = address(secondLegacyPrinter);
+        bytes[] memory extensionData = new bytes[](2);
+        extensionData[0] = _extensionData(_terms("Legacy Common", 100));
+
+        vm.expectRevert(ShareClassTermsController.InvalidShareExtensionData.selector);
+        harness.migrate(printers, address(firstController), extensionData);
+        assertEq(firstLegacyPrinter.getExtension(0), address(shareExtension));
+        assertEq(secondLegacyPrinter.getExtension(0), address(shareExtension));
+
+        extensionData[1] = _extensionData(_terms("Legacy Preferred", 200));
+        harness.migrate(printers, address(firstController), extensionData);
+
+        assertEq(firstLegacyPrinter.getExtension(0), address(firstController));
+        assertEq(secondLegacyPrinter.getExtension(0), address(firstController));
+        (,, uint256 authorized,, bool configured) = firstController.getClassTerms(address(firstLegacyPrinter));
+        assertTrue(configured);
+        assertEq(authorized, 100);
+        (,, uint256 secondAuthorized,, bool secondConfigured) =
+            firstController.getClassTerms(address(secondLegacyPrinter));
+        assertTrue(secondConfigured);
+        assertEq(secondAuthorized, 200);
+
+        ShareClassTermsController replacementController = _deployController();
+        address[] memory onePrinter = new address[](1);
+        onePrinter[0] = address(firstLegacyPrinter);
+        bytes[] memory oneTerms = new bytes[](1);
+        oneTerms[0] = extensionData[0];
+        vm.expectRevert(IssuanceManagerStorage.ClassTermsControllerAlreadyInstalled.selector);
+        harness.migrate(onePrinter, address(replacementController), oneTerms);
+        assertEq(firstLegacyPrinter.getExtension(0), address(firstController));
+    }
+
+    function test_MigrationRejectsMismatchedBatchLengths() public {
+        ClassTermsMigrationHarness harness = new ClassTermsMigrationHarness();
+        address[] memory printers = new address[](1);
+        bytes[] memory noTerms = new bytes[](0);
+
+        vm.expectRevert(IssuanceManagerStorage.ClassTermsMigrationLengthMismatch.selector);
+        harness.migrate(printers, address(controller), noTerms);
+    }
+
+    function test_UpgradeToAndCallMigratesEveryPrinterAtomically() public {
+        BorgAuth upgradeAuth = new BorgAuth(address(this));
+        ShareClassTermsController controllerImplementation = new ShareClassTermsController();
+        ShareClassTermsController upgradeController = ShareClassTermsController(
+            address(
+                new ERC1967Proxy(
+                    address(controllerImplementation),
+                    abi.encodeCall(
+                        ShareClassTermsController.initialize, (address(upgradeAuth), address(shareExtension))
+                    )
+                )
+            )
+        );
+
+        IssuanceManager initialImplementation = new IssuanceManager();
+        IssuanceManagerFactory factory = IssuanceManagerFactory(
+            address(
+                new ERC1967Proxy(
+                    address(new IssuanceManagerFactory()),
+                    abi.encodeCall(
+                        IssuanceManagerFactory.initialize,
+                        (
+                            address(upgradeAuth),
+                            address(initialImplementation),
+                            address(new CyberCertPrinter()),
+                            address(new CyberScrip())
+                        )
+                    )
+                )
+            )
+        );
+        IssuanceManager manager = IssuanceManager(factory.deployIssuanceManager(keccak256("ClassTermsAtomicUpgrade")));
+        manager.initialize(address(upgradeAuth), address(this), address(0xBEEF), address(factory));
+
+        string[] memory legends = new string[](0);
+        address[] memory printers = new address[](2);
+        printers[0] = manager.createCertPrinter(
+            legends,
+            "Legacy Common",
+            "LCOM",
+            "ipfs://common",
+            SecurityClass.CommonStock,
+            SecuritySeries.NA,
+            address(shareExtension)
+        );
+        printers[1] = manager.createCertPrinter(
+            legends,
+            "Legacy Preferred",
+            "LPREF",
+            "ipfs://preferred",
+            SecurityClass.PreferredStock,
+            SecuritySeries.SeriesA,
+            address(shareExtension)
+        );
+
+        bytes[] memory extensionData = new bytes[](2);
+        extensionData[0] = _extensionData(_terms("Legacy Common", 100));
+        IssuanceManager newImplementation = new IssuanceManager();
+        factory.setRefImplementation(address(newImplementation));
+        address oldImplementation = address(manager).getErc1967Implementation();
+
+        bytes memory invalidMigrationCall = abi.encodeCall(
+            IssuanceManager.migrateClassTermsControllers, (printers, address(upgradeController), extensionData)
+        );
+        vm.expectRevert(ShareClassTermsController.InvalidShareExtensionData.selector);
+        manager.upgradeToAndCall(address(newImplementation), invalidMigrationCall);
+
+        assertEq(address(manager).getErc1967Implementation(), oldImplementation);
+        assertEq(CyberCertPrinter(printers[0]).getExtension(0), address(shareExtension));
+        assertEq(CyberCertPrinter(printers[1]).getExtension(0), address(shareExtension));
+
+        extensionData[1] = _extensionData(_terms("Legacy Preferred", 200));
+        bytes memory migrationCall = abi.encodeCall(
+            IssuanceManager.migrateClassTermsControllers, (printers, address(upgradeController), extensionData)
+        );
+        manager.upgradeToAndCall(address(newImplementation), migrationCall);
+
+        assertEq(address(manager).getErc1967Implementation(), address(newImplementation));
+        assertEq(CyberCertPrinter(printers[0]).getExtension(0), address(upgradeController));
+        assertEq(CyberCertPrinter(printers[1]).getExtension(0), address(upgradeController));
+        (,, uint256 firstAuthorized,, bool firstConfigured) = upgradeController.getClassTerms(printers[0]);
+        (,, uint256 secondAuthorized,, bool secondConfigured) = upgradeController.getClassTerms(printers[1]);
+        assertTrue(firstConfigured);
+        assertTrue(secondConfigured);
+        assertEq(firstAuthorized, 100);
+        assertEq(secondAuthorized, 200);
+    }
+
+    function getCertScripifiedStatus(address, uint256 tokenId)
+        external
+        view
+        returns (bool isScripified, uint256 units, uint256 maxUnitsRepresented)
+    {
+        units = scripifiedUnits[tokenId];
+        return (units > 0, units, units);
+    }
+
+    function companyName() external pure returns (string memory) {
+        return "Test Corp";
+    }
+
+    function _issuedUnits() internal view returns (uint256 issued) {
+        (,,, issued,) = controller.getClassTerms(address(printer));
+    }
+
+    function _authorizedShares() internal view returns (uint256 authorized) {
+        (,, authorized,,) = controller.getClassTerms(address(printer));
+    }
+
+    function _mint(uint256 tokenId, address recipient, CertificateDetails memory details) internal {
+        controller.accountNewIssuance(address(printer), details.extensionData, details.unitsRepresented, true);
+        printer.safeMint(tokenId, recipient, details);
+    }
+
+    function _deployController() internal returns (ShareClassTermsController deployedController) {
+        BorgAuth auth = new BorgAuth(address(this));
+        ShareClassTermsController implementation = new ShareClassTermsController();
+        deployedController = ShareClassTermsController(
+            address(
+                new ERC1967Proxy(
+                    address(implementation),
+                    abi.encodeCall(ShareClassTermsController.initialize, (address(auth), address(shareExtension)))
+                )
+            )
+        );
+    }
+
+    function _deployPrinter(address issuanceManager, address extension)
+        internal
+        returns (CyberCertPrinter deployedPrinter)
+    {
+        CyberCertPrinter implementation = new CyberCertPrinter();
+        string[] memory legends = new string[](0);
+        deployedPrinter = CyberCertPrinter(
+            address(
+                new ERC1967Proxy(
+                    address(implementation),
+                    abi.encodeCall(
+                        CyberCertPrinter.initialize,
+                        (
+                            legends,
+                            "Common Stock",
+                            "COMMON",
+                            "ipfs://certificate",
+                            issuanceManager,
+                            SecurityClass.CommonStock,
+                            SecuritySeries.NA,
+                            extension
+                        )
+                    )
+                )
+            )
+        );
+    }
+
+    function _details(SeriesTerms memory terms, uint256 units) internal pure returns (CertificateDetails memory) {
+        return CertificateDetails({
+            signingOfficerName: "Officer",
+            signingOfficerTitle: "President",
+            investmentAmountUSD: 0,
+            issuerUSDValuationAtTimeOfInvestment: 0,
+            unitsRepresented: units,
+            legalDetails: "",
+            extensionData: _extensionData(terms)
+        });
+    }
+
+    function _extensionData(SeriesTerms memory terms) internal pure returns (bytes memory) {
+        ShareCertData memory share;
+        share.terms = terms;
+        share.certificateData = CertificateData({
+            isPartlyPaid: false,
+            amountPaid: 0,
+            totalConsideration: 0,
+            sourceAuthorityURI: "",
+            representationType: ShareRepresentationType.Certificated,
+            holdingPeriodTackingApplied: false
+        });
+        share.mandatoryConversionTriggers = new MandatoryConversionTrigger[](0);
+        share.specialVotingRights = new SpecialVotingRight[](0);
+        share.transferRestrictions = new TransferRestriction[](0);
+        share.splitHistory = new SplitRecord[](0);
+        return abi.encode(share);
+    }
+
+    function _terms(string memory name, uint256 authorized) internal pure returns (SeriesTerms memory terms) {
+        terms.seriesName = name;
+        terms.authorizedShares = authorized;
+        terms.sourceAuthorityURI = "ipfs://board-resolution";
+        terms.votesPerShare = 1;
+    }
+}

--- a/test/CyberCorpBoardAuthorityTest.t.sol
+++ b/test/CyberCorpBoardAuthorityTest.t.sol
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+import {CyberCorp} from "../src/CyberCorp.sol";
+import {
+    CompanyDirector,
+    CompanyOfficer
+} from "../src/CyberCorpConstants.sol";
+import {IAuthAdapter} from "../src/interfaces/IAuthAdapter.sol";
+import {BorgAuth} from "../src/libs/auth.sol";
+
+contract BoardAuthorityAdapterMock is IAuthAdapter {
+    mapping(address => uint256) internal roles;
+
+    function setRole(address account, uint256 role) external {
+        roles[account] = role;
+    }
+
+    function isAuthorized(
+        address account
+    ) external view returns (uint256) {
+        return roles[account];
+    }
+}
+
+contract CyberCorpBoardAuthorityTest is Test {
+    address internal founder = address(0xF0);
+    address internal officer = address(0x0F);
+    address internal director = address(0xD1);
+    address internal stockholderExecutor = address(0x57);
+
+    BorgAuth internal auth;
+    CyberCorp internal corp;
+
+    function setUp() public {
+        auth = new BorgAuth(address(this));
+        auth.updateRole(founder, auth.OFFICER_ROLE());
+
+        CompanyOfficer memory initialOfficer = CompanyOfficer({
+            eoa: founder,
+            name: "Founder",
+            contact: "founder@example.com",
+            title: "President"
+        });
+        corp = CyberCorp(
+            address(
+                new ERC1967Proxy(
+                    address(new CyberCorp()),
+                    abi.encodeCall(
+                        CyberCorp.initialize,
+                        (
+                            address(auth),
+                            "Test Corp, Inc.",
+                            "Corporation",
+                            "Delaware",
+                            "contact@example.com",
+                            "Delaware courts",
+                            address(0x1),
+                            address(0x2),
+                            initialOfficer,
+                            address(0x3),
+                            address(0x4)
+                        )
+                    )
+                )
+            )
+        );
+        auth.updateRole(address(corp), auth.OFFICER_ROLE());
+        auth.setRoleManager(address(corp));
+        corp.activateBoardGovernance();
+    }
+
+    function test_ActivationSeatsFounderAsDirectorAndOfficer() public view {
+        assertTrue(corp.boardGovernanceEnforced());
+        assertTrue(corp.isCyberCORPDirector(founder));
+        assertTrue(corp.isCyberCORPOfficer(founder));
+        assertEq(corp.getCompanyDirectorCount(), 1);
+        assertEq(corp.getCompanyOfficerCount(), 1);
+        assertEq(auth.userRoles(founder), auth.BOARD_ROLE());
+        assertEq(auth.roleManager(), address(corp));
+    }
+
+    function test_OfficerCannotMutateAuthOrAppointOfficers() public {
+        vm.prank(founder);
+        corp.addOfficer(_officer(officer));
+        assertEq(auth.userRoles(officer), auth.OFFICER_ROLE());
+
+        uint256 boardRole = auth.BOARD_ROLE();
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                BorgAuth.BorgAuth_NotRoleManager.selector,
+                officer
+            )
+        );
+        vm.prank(officer);
+        auth.updateRole(officer, boardRole);
+
+        vm.expectRevert();
+        vm.prank(officer);
+        corp.addOfficer(_officer(address(0x22)));
+    }
+
+    function test_BoardControlsOfficersAndLastOfficerGuard() public {
+        vm.startPrank(founder);
+        corp.addOfficer(_officer(officer));
+        corp.removeOfficer(officer);
+        assertEq(auth.userRoles(officer), 0);
+
+        vm.expectRevert(CyberCorp.LastOfficer.selector);
+        corp.removeOfficer(founder);
+        vm.stopPrank();
+    }
+
+    function test_BoardSelfManagementPreservesOfficerRoleOnRemoval() public {
+        vm.startPrank(founder);
+        corp.addOfficer(_officer(director));
+        corp.addDirector(_director(director));
+        assertEq(auth.userRoles(director), auth.BOARD_ROLE());
+
+        corp.removeDirector(director);
+        assertFalse(corp.isCyberCORPDirector(director));
+        assertTrue(corp.isCyberCORPOfficer(director));
+        assertEq(auth.userRoles(director), auth.OFFICER_ROLE());
+
+        vm.expectRevert(CyberCorp.LastDirector.selector);
+        corp.removeDirector(founder);
+        vm.stopPrank();
+    }
+
+    function test_StockholderAdapterCanExecuteBoardReplacement() public {
+        BoardAuthorityAdapterMock adapter =
+            new BoardAuthorityAdapterMock();
+        adapter.setRole(stockholderExecutor, auth.BOARD_ROLE());
+
+        vm.prank(founder);
+        corp.setBoardAuthorityAdapter(address(adapter));
+
+        vm.prank(stockholderExecutor);
+        corp.addDirector(_director(director));
+        assertTrue(corp.isCyberCORPDirector(director));
+        assertEq(auth.userRoles(director), auth.BOARD_ROLE());
+    }
+
+    function test_RootConfigurationIsBoardOnlyWhenEnforced() public {
+        vm.prank(founder);
+        corp.addOfficer(_officer(officer));
+
+        uint256 boardRole = auth.BOARD_ROLE();
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                BorgAuth.BorgAuth_NotAuthorized.selector,
+                boardRole,
+                officer
+            )
+        );
+        vm.prank(officer);
+        corp.setCompanyPayable(address(0xCAFE));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                BorgAuth.BorgAuth_NotAuthorized.selector,
+                boardRole,
+                officer
+            )
+        );
+        vm.prank(officer);
+        corp.setIssuanceManager(address(0xBEEF));
+
+        vm.prank(founder);
+        corp.setCompanyPayable(address(0xCAFE));
+        assertEq(corp.companyPayable(), address(0xCAFE));
+    }
+
+    function test_RoleManagerLockIsOneWay() public {
+        vm.expectRevert(BorgAuth.BorgAuth_RoleManagerAlreadySet.selector);
+        auth.setRoleManager(address(0x999));
+    }
+
+    function _officer(
+        address account
+    ) internal pure returns (CompanyOfficer memory) {
+        return CompanyOfficer({
+            eoa: account,
+            name: "Officer",
+            contact: "officer@example.com",
+            title: "Secretary"
+        });
+    }
+
+    function _director(
+        address account
+    ) internal pure returns (CompanyDirector memory) {
+        return CompanyDirector({
+            eoa: account,
+            name: "Director",
+            contact: "director@example.com"
+        });
+    }
+}

--- a/test/DeployParentCoFactory.t.sol
+++ b/test/DeployParentCoFactory.t.sol
@@ -9,6 +9,7 @@ import {DeploymentConstants} from "../script/libs/DeploymentConstants.sol";
 import {CyberAgreementRegistry} from "../src/CyberAgreementRegistry.sol";
 import {ParentCoFactory} from "../src/ParentCoFactory.sol";
 import {CyberCorp} from "../src/CyberCorp.sol";
+import {CyberCorpSingleFactory} from "../src/CyberCorpSingleFactory.sol";
 import {CompanyOfficer} from "../src/CyberCorpConstants.sol";
 import {BorgAuth} from "../src/libs/auth.sol";
 
@@ -50,6 +51,13 @@ contract DeployParentCoFactoryForkTest is Test {
         vm.createSelectFork("base_sepolia", 40732512); // pinned to an old block before ParentCoFactory is deployed
         coreDeployment = DeploymentConstants.coreV2(block.chainid);
         deps = DeploymentConstants.deps(block.chainid);
+
+        // Model the production forward-path rollout: the shared factory must
+        // point at CyberCorp v5 before a P1-aware top-level factory is used.
+        CyberCorp cyberCorpV5 = new CyberCorp();
+        vm.prank(coreDeployment.metalexSafe);
+        CyberCorpSingleFactory(coreDeployment.cyberCorpSingleFactory)
+            .setRefImplementation(address(cyberCorpV5));
 
         registry = CyberAgreementRegistry(coreDeployment.cyberAgreementRegistry);
 
@@ -258,11 +266,14 @@ contract DeployParentCoFactoryForkTest is Test {
         assertGe(parentCoFactory.userRoles(parentCoOfficer2), ownerRole);
     }
 
-    function test_parentCoOfficersAreOwnersOfParentCyberCorp() public {
+    function test_parentCorpGovernanceActivatesAfterOfficerBootstrap() public {
         CyberCorp corp = CyberCorp(parentCoFactory.parentCorp());
-        uint256 ownerRole = corp.AUTH().OWNER_ROLE();
-        assertGe(corp.userRoles(parentCoOfficer1), ownerRole);
-        assertGe(corp.userRoles(parentCoOfficer2), ownerRole);
+        BorgAuth corpAuth = corp.AUTH();
+
+        assertTrue(corp.boardGovernanceEnforced());
+        assertEq(corpAuth.roleManager(), address(corp));
+        assertEq(corpAuth.userRoles(parentCoOfficer1), corpAuth.BOARD_ROLE());
+        assertEq(corpAuth.userRoles(parentCoOfficer2), corpAuth.OFFICER_ROLE());
     }
 
     function test_deploySubCorp_revertIfEscrowSignerNotOfficer() public {

--- a/test/LifeCycleGasLimitTest.t.sol
+++ b/test/LifeCycleGasLimitTest.t.sol
@@ -27,6 +27,7 @@ import {
     DividendType,
     RedemptionType
 } from "../src/storage/extensions/ShareExtension.sol";
+import {ShareClassTermsController} from "../src/storage/extensions/ShareClassTermsController.sol";
 import {BorgAuth} from "../src/libs/auth.sol";
 import {ERC1967Proxy} from "../dependencies/openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {CyberCorpHelper} from "./RoundManagerTest.t.sol";
@@ -122,6 +123,7 @@ contract LifeCycleGasLimitTest is Test {
     CyberCorpFactory corpFactory;
     MockERC20 usdc;
     ShareExtension shareExtension;
+    ShareClassTermsController shareClassTermsController;
 
     address officer;
     uint256 officerKey;
@@ -139,6 +141,13 @@ contract LifeCycleGasLimitTest is Test {
         shareExtension = ShareExtension(address(new ERC1967Proxy(
             address(new ShareExtension()),
             abi.encodeWithSelector(ShareExtension.initialize.selector, address(shareAuth))
+        )));
+        shareClassTermsController = ShareClassTermsController(address(new ERC1967Proxy(
+            address(new ShareClassTermsController()),
+            abi.encodeCall(
+                ShareClassTermsController.initialize,
+                (address(shareAuth), address(shareExtension))
+            )
         )));
     }
 
@@ -397,7 +406,7 @@ contract LifeCycleGasLimitTest is Test {
             uri: IPFS_URI,
             securityClass: SecurityClass.PreferredStock,
             securitySeries: SecuritySeries.SeriesSeed,
-            extension: address(shareExtension),
+            extension: address(shareClassTermsController),
             defaultLegend: legend
         });
     }

--- a/test/PumpCorpFactory.t.sol
+++ b/test/PumpCorpFactory.t.sol
@@ -11,6 +11,7 @@ import {ILexScrowStorage} from "../src/interfaces/ILexScrowStorage.sol";
 import {RoundManagerFactory} from "../src/RoundManagerFactory.sol";
 import {FeeOverride} from "../src/interfaces/IRoundManagerFactory.sol";
 import {CyberCorpSingleFactory} from "../src/CyberCorpSingleFactory.sol";
+import {CyberCorp} from "../src/CyberCorp.sol";
 import {EIP712Lib} from "../src/libs/EIP712Lib.sol";
 import {BorgAuth} from "../src/libs/auth.sol";
 import {Round, RoundType} from "../src/libs/RoundLib.sol";
@@ -121,6 +122,13 @@ contract PumpCorpFactoryForkTest is Test {
         (officer, officerPk) = makeAddrAndKey("officer");
         (attacker, attackerPk) = makeAddrAndKey("attacker");
         (investor, investorPk) = makeAddrAndKey("investor");
+
+        // Model the production forward-path rollout: the shared factory must
+        // point at CyberCorp v5 before a P1-aware top-level factory is used.
+        CyberCorp cyberCorpV5 = new CyberCorp();
+        vm.prank(metalexSafe);
+        CyberCorpSingleFactory(CYBERCORP_SINGLE_FACTORY)
+            .setRefImplementation(address(cyberCorpV5));
 
         // Deploy mock zkPassport condition
         zkpassportCondition = new MockZkPassportCondition();
@@ -467,6 +475,17 @@ contract PumpCorpFactoryForkTest is Test {
         FeeOverride memory fo = rmFactory.getInstanceFeeOverride(rm);
         assertFalse(fo.enabled, "there should be no fee overrides");
         assertEq(RoundManager(rm).computeFee(1 ether), 0.003 ether, "expect fee ratio of 0.3%");
+    }
+
+    function test_DeployActivatesBoardGovernance() public {
+        (address corpAddress,,) =
+            _deployLifecycle(299998, RoundType.FCFS, new address[](0));
+        CyberCorp corp = CyberCorp(corpAddress);
+        BorgAuth corpAuth = corp.AUTH();
+
+        assertTrue(corp.boardGovernanceEnforced());
+        assertEq(corpAuth.roleManager(), corpAddress);
+        assertEq(corpAuth.userRoles(officer), corpAuth.BOARD_ROLE());
     }
 
     // ═══════════════════════════════════════════════════════════════════════════

--- a/test/RoundManagerTest.t.sol
+++ b/test/RoundManagerTest.t.sol
@@ -2684,7 +2684,7 @@ contract RoundManagerFCFSTest is Test {
 
         // Deploy upgraded corp and round manager
         (address corp, , , , address roundManager) = CyberCorpHelper.deployCorp(corpFactory, "Upgraded Corp", me, me);
-        vm.prank(address(corpFactory));
+        vm.prank(me);
         CyberCorp(corp).setDealManager(address(roundManager));
 
         RoundManager rm = RoundManager(payable(roundManager));
@@ -2832,7 +2832,7 @@ contract RoundManagerFCFSTest is Test {
         RoundManager rm = RoundManager(rmAddr);
 
         // Allow RoundManager to transfer certs by setting it as the corp's dealManager
-        vm.prank(address(corpFactory));
+        vm.prank(me);
         CyberCorp(corp).setDealManager(address(rm));
 
         MockPaymentToken usdc = new MockPaymentToken();
@@ -2931,7 +2931,7 @@ contract RoundManagerFCFSTest is Test {
         );
         RoundManager rm = RoundManager(rmAddr);
 
-        vm.prank(address(corpFactory));
+        vm.prank(me);
         CyberCorp(corp).setDealManager(address(rm));
 
         // Simulate a round where `maxTicket` > `raiseCap` so an investor could deposit more than remaining
@@ -3079,7 +3079,7 @@ contract RoundManagerFCFSTest is Test {
             me
         );
         RoundManager rm = RoundManager(rmAddr);
-        vm.prank(address(corpFactory));
+        vm.prank(me);
         CyberCorp(corp).setDealManager(address(rm));
         MockPaymentToken usdc = new MockPaymentToken();
 


### PR DESCRIPTION
## Executive summary

This PR completes the protocol work needed for a deliberately scoped first real cyberCORP pilot and makes the repository's planning material match the actual code. It delivers three coordinated changes:

1. **P1 — corporate authority:** new corporations receive a distinct on-chain Board and officer hierarchy instead of a flat officer ACL.
2. **P2 — canonical share-class terms:** each share printer can have one authoritative class-terms record and an enforced authorized-share ceiling.
3. **P3 — agreement-template integrity:** public template creation uses deterministic content-derived IDs, while arbitrary curated IDs remain owner-controlled.

The implementation is intentionally forward-oriented. Almost all existing corporations are test corporations, so this PR does not attempt a blanket migration of every historical deployment. It provides explicit, dry-runnable rollout tooling for new deployments and for the small set of named demo or real-pilot printers that actually matter.

This is a **draft**. It contains no broadcast, deployment, proxy upgrade, environment promotion, or merge to a protected branch.

## Why this is needed

The prior protocol had three release-critical integrity gaps:

- Officers effectively occupied a flat role tier. An officer could participate in appointing or removing peers, and there was no protocol-level last-officer protection. That did not encode the intended stockholders → Board → officers → managers authority chain.
- Share economic terms such as authorized shares, par value, original issue price, and liquidation/conversion terms were supplied per certificate. Two certificates under the same legal class could therefore disagree, and `authorizedShares` was descriptive rather than enforced.
- The public agreement-template path accepted caller-selected IDs. That allowed arbitrary namespace occupation and made equivalent templates unnecessarily duplicative.

The plans also mixed four different states—historical ideas, merged foundations, implemented-but-unreleased work, and deployment operations. This PR rewrites those status records so reviewers can distinguish code readiness from live rollout evidence.

## P1: Board and officer authority

### Authority model

`BorgAuth` now defines explicit role constants:

- `OFFICER_ROLE = 200`
- `BOARD_ROLE = 300`

It also supports a one-time `roleManager`. Once a factory hands role management to its `CyberCorp`, direct ACL mutation through `BorgAuth.updateRole` or `setRoleAdapter` can no longer bypass corporate policy. The handoff is irreversible for that auth instance.

`CyberCorp` deploy version 5 adds:

- separate director and officer rosters and membership lookups;
- Board-governance activation;
- `addDirector` / `removeDirector` and indexed removal;
- Board-controlled officer appointment and removal;
- last-director and last-officer guards;
- preservation of the other capacity when a person is both director and officer;
- a Board role adapter hook for future stockholder-governance execution; and
- Board gating for root corporate actions once enforcement is active.

Root actions covered by the new authority boundary include legal identity configuration, manager pointers, treasury/payable configuration, role-adapter configuration, and corporation upgrades. Reusable escrowed signatures remain an officer operation.

### New-corporation bootstrap

New deployments seed the founder as both the first director and first officer. The factory completes manager-role initialization first, then hands the ACL to the corporation and activates Board enforcement. This ordering prevents initialization from losing authority midway through deployment.

The change is wired through `CyberCorpFactory`, `MetaDAOFactory`, `PumpCorpFactory`, and `ParentCoFactory`. ParentCo completes its configured multi-officer bootstrap before the one-way handoff.

### Upgrade shape and compatibility

The forward rollout deploys a separate v5 `CyberCorpSingleFactory`, then atomically pairs each upgraded top-level factory implementation with that exact single-factory reference through `upgradeToAndCall`. The legacy single factory remains unchanged, so an omitted top-level factory cannot silently begin producing partly configured v5 corporations.

Existing upgraded `CyberCorp` proxies remain in explicit compatibility mode until Board governance is activated. They must not be represented as Board-enforced before that transition. Existing immutable `BorgAuth` deployments also require per-corporation disposition; the intended approach is to inventory only corporations with meaningful records and choose migration, redeployment, or continued legacy treatment individually.

### What this does not claim

The adapter hook is an execution boundary, not a completed stockholder-voting system. A class-aware voting adapter still needs historical voting checkpoints, legal-owner aggregation, canonical per-class voting rights, class voting, quorum/threshold rules, replay protection, and timelocks. A founder-seeded Board pilot is acceptable only if it is labeled as bootstrap policy rather than as proof of on-chain stockholder elections.

## P2: canonical share-class terms and authorized-share enforcement

### Storage and rendering architecture

The rejected first design placed canonical state inside `CyberCertPrinter` and exceeded EIP-170. The deployable design instead introduces an external UUPS `ShareClassTermsController`.

For each printer, the controller stores:

- canonical ABI-encoded `SeriesTerms`;
- the canonical terms hash;
- authorized shares;
- currently issued units; and
- whether class terms have been configured.

`ShareExtension` remains the renderer/parser and now exposes exact `SeriesTerms` extraction. `CyberCertPrinter` remains deploy version 4: this PR does **not** require a printer storage-layout or beacon-version change.

Certificate-specific data—holder, units represented, investment amount, restrictions, triggers, and split history—remains certificate-specific. Only legal class invariants are centralized.

### Enforcement behavior

`IssuanceManager` 4.2 integrates controller checks across the share lifecycle:

- a new share printer can be created and configured atomically with `createCertPrinterWithClassTerms`;
- each new share issuance must match the canonical terms hash;
- issuance reverts when `issuedUnits + newUnits > authorizedShares`;
- certificate unit updates apply the appropriate delta;
- void and burn release units;
- unvoid restores units and rechecks capacity;
- secondary transfers preserve class accounting;
- scripification and recertification are representation changes, so the same economic units are counted exactly once; and
- governed amendments cannot reduce authorized shares below issued units.

The controller only accepts accounting calls from the printer's actual IssuanceManager and verifies that the printer points to the expected extension/controller.

### Existing-printer migration

`migrateClassTermsControllers` accepts aligned printer and extension-data arrays. For each printer it:

1. rejects an already-installed controller;
2. extracts the proposed canonical terms;
3. derives outstanding active certificate and scrip units on-chain;
4. rejects a cap below those outstanding units; and
5. installs/configures the controller.

The complete migration can be supplied as the calldata to `upgradeToAndCall`, so implementation upgrade and all named printer migrations are one transaction. A failure on any printer rolls back the implementation upgrade and every earlier printer mutation in the batch.

Once upgraded, an IssuanceManager deliberately fails closed for an unmigrated legacy share renderer. The deployment operator must therefore upgrade and migrate every in-scope share printer together. Test-only printers are not release scope.

### Rollout tooling

This PR adds scripts for:

- deploying the class-terms controller;
- upgrading the share extension renderer;
- setting the IssuanceManager 4.2 factory reference;
- configuring class terms;
- atomically upgrading and migrating a corporation's named printers; and
- reading back the resulting controller, renderer, terms hash, authorization, issued units, and version state.

Every script is designed to be simulated without `--broadcast` first. Repository access does not imply the on-chain owner authority needed to execute these operations.

## P3: agreement-template integrity

`CyberAgreementRegistry` now separates curated and permissionless creation:

- `createTemplate(bytes32 templateId, ...)` remains owner-only for intentionally curated IDs;
- `createTemplatePublic(...)` derives the ID from the template content;
- submitting equivalent public content is idempotent and returns the existing template ID;
- a caller cannot select an arbitrary public namespace ID; and
- empty legal-contract URIs are rejected.

The upgrade keeps the existing proxy/storage model and is paired with matching interfaces, deployment scripts, tests, and the companion webapp ABI/call-site update.

## Deployment and review order

The intended release sequence is:

1. Review and approve the Board/root-action policy.
2. Dry-run the P1 forward deployment at the intended target block.
3. Deploy the separate v5 single factory and atomically pair each enabled top-level factory route.
4. Deploy/upgrade the P2 renderer, controller, and IssuanceManager reference.
5. Atomically migrate only the named demo or pilot share printers after reconciling their legal terms and issued units.
6. Upgrade P3 with the matching webapp release if award templates are in pilot scope.
7. Deploy a fresh test corporation through every enabled route and complete authenticated app acceptance before any production cutover.
8. Start with one named real pilot and retain rollback/incident ownership.

The P1 and P2/P3 runbooks included in this PR contain the executable environment inputs, preflight reads, transaction ordering, stop conditions, and post-transaction evidence requirements.

## Verification performed

### Current `develop` integration branch

- All **50 current non-fork Foundry test files** passed individually.
- `CyberCorpBoardAuthorityTest`: **7/7**.
- `CyberCertPrinterClassTermsTest`: **10/10**.
- `CyberAgreementRegistryTest`: **18/18** in the focused pre-port evidence and covered again by the current non-fork sweep.
- `IssuanceManagerScripComplianceTest`: **7/7**.
- `ScripPOCTest`: **15/15**.
- `git diff --check origin/develop...HEAD` passed.

### Fork evidence

Before the clean port onto the latest `develop`, the pinned P1 acceptance suites passed:

- CyberCorp: **47/47**
- PumpCorp: **36/36**
- ParentCo: **25/25**

Those network-dependent suites were not rerun during the clean port. A target-block dry run and fresh-route deployment remain required before release.

### Production runtime-size gate

Built with Solidity 0.8.28, via-IR, optimizer enabled, and optimizer runs 15. The full `--sizes` build passed. Notable runtime sizes/margins:

| Contract | Runtime bytes | EIP-170 margin |
| --- | ---: | ---: |
| CertificateImageBuilderContract | 24,529 | 47 |
| CyberCorp | 23,913 | 663 |
| CyberCertPrinter | 23,644 | 932 |
| CyberAgreementRegistry | 23,394 | 1,182 |
| IssuanceManager 4.2 | 18,662 | 5,914 |
| ShareClassTermsController | 7,531 | 17,045 |
| ShareExtension renderer | 23,311 | 1,265 |

The 47-byte image-builder margin is pre-existing but makes the production size build a mandatory future regression gate.

## Reviewer guide

Suggested review order:

1. `src/libs/auth.sol` and `src/CyberCorp.sol` — authority model and storage additions.
2. Factory changes and `script/upgrade-board-authority-forward-path.s.sol` — bootstrap and atomic rollout order.
3. `ShareClassTermsController.sol`, `IssuanceManager.sol`, and `IssuanceManagerStorage.sol` — class invariants and lifecycle accounting.
4. `script/upgrade-and-migrate-share-class-terms.s.sol` — migration atomicity and stop conditions.
5. `CyberAgreementRegistry.sol` — public template ID behavior.
6. New focused test suites.
7. Runbooks and plan status revisions.

## Explicitly remaining / not part of this PR

- No live deployment, broadcast, proxy upgrade, or protected-branch merge.
- No target-environment or target-block dry run.
- No fresh-corporation acceptance across enabled factory routes.
- No authenticated hosted Board/consent/issuance acceptance.
- No legal/product approval of the founder-seeded Board policy.
- No real-pilot printer migration or issued-unit reconciliation.
- No class-aware stockholder-voting implementation.
- No blanket migration or cleanup of presumed test corporations.
- P4 control-agreement liens and permissionless foreclosure remain proposal-stage only.

## Companion application PR

https://github.com/MetaLex-Tech/metalex-webapp/pull/828

The protocol and application changes should be reviewed and released as a coordinated pair. **Do not merge this draft without explicit authorization.**