### PR TITLE
docs: zero-expiry means no deadline after PR #135 void fixes

### DIFF
--- a/docs/how-to/sign-a-cyberagreement.md
+++ b/docs/how-to/sign-a-cyberagreement.md
@@ -79,16 +79,16 @@ ICyberAgreementRegistry(registry).finalizeContract(contractId);
 
 `voidContractFor(contractId, party, signature)` records a party's void
 request (EIP-712-signed, or submitted by the finalizer). The contract voids
-when all parties request it, when it has expired, or when the first party
-requests it while only one signature has been collected.
+when every allocated party requests it (unfilled open slots don't count
+toward unanimity), when its nonzero expiry has passed, or when the first
+party requests it while only one signature has been collected.
 
-{% hint style="warning" %}
-An agreement created with `expiry == 0` (no deadline) counts as **expired**
-for this check, so any single party's void request voids it immediately.
-Setting a future expiry restores unanimous-void semantics only **until that
-expiry passes** — an unfinalized agreement past its expiry is again voidable
-by a single party's request. (And independent of expiry, the proposing
-party can void unilaterally while it is the only signer.)
+{% hint style="info" %}
+An agreement created with `expiry == 0` has **no deadline**: it never counts
+as expired, so it voids only by unanimous request (or by the proposer while
+it is the only signer). With a nonzero expiry, unanimous-void semantics hold
+only **until that expiry passes** — an unfinalized agreement past its expiry
+is voidable by a single party's request.
 {% endhint %}
 
 ## Checking status

--- a/docs/reference/contracts/CyberAgreementRegistry.md
+++ b/docs/reference/contracts/CyberAgreementRegistry.md
@@ -113,17 +113,20 @@ function finalizeContract(bytes32 contractId) external; // onlyFinalizerIfSet
   With no finalizer set, the contract auto-finalizes at that point;
   otherwise the finalizer calls `finalizeContract`.
 * `voidContractFor` records a party's void request (event `VoidRequested`).
-  The contract becomes voided when **all** parties have requested, when it
-  has expired, or when the proposing party (index 0) voids while still the
-  only signer. The finalizer may submit void requests without a signature;
-  anyone else needs the party's EIP-712 `VoidSignatureData` signature.
-  Finalized contracts cannot be voided.
+  The contract becomes voided when every **allocated** party has requested
+  (unfilled `address(0)` slots in an open agreement cannot request, so they
+  don't count toward unanimity — though a party who fills a slot must then
+  also request), when its nonzero expiry has passed, or when the proposing
+  party (index 0) voids while still the only signer. The finalizer may
+  submit void requests without a signature; anyone else needs the party's
+  EIP-712 `VoidSignatureData` signature. Finalized contracts cannot be
+  voided.
 
-{% hint style="warning" %}
-**Zero-expiry caveat**: the void path's expiry check has no nonzero guard
-(unlike signing/finalization), so an agreement created with `expiry == 0`
-("no deadline") satisfies the expired branch immediately — the first valid
-void request voids it unilaterally.
+{% hint style="info" %}
+`expiry == 0` means **no deadline**, in the void path just as in signing and
+finalization: the expired branch never applies, so a zero-expiry agreement
+voids only by unanimous request of its allocated parties (or by the
+proposer while sole signer).
 {% endhint %}
 
 ## Events

--- a/docs/reference/contracts/DealManager.md
+++ b/docs/reference/contracts/DealManager.md
@@ -74,22 +74,40 @@ defaultLegend}`.
 * `conditions` are `ICondition` addresses that gate the deal; the owner can
   `addCondition` / `removeConditionAt` while the deal is still pending.
 * `expiry` and `secretHash` support timed and secret-gated deals;
-  `voidExpiredDeal` cleans up expired deals, and `refundVoidedDeal` releases
-  escrowed payment when an agreement was voided directly in the registry.
-  `expiry == 0` means **no deadline**: such a deal can pay and finalize at
-  any time and is never void-expirable, so it unwinds only by void request —
-  either through the DealManager (`signToVoid`, or `revokeDeal` while the
-  escrow is still pending) or by submitting `voidContractFor` straight to the
-  registry and then calling `refundVoidedDeal` to resync the escrow and
-  release payment. Either route voids the agreement once every allocated
-  party has requested it, or as soon as the proposer (party index 0) requests
-  it while still the only signer.
+  `voidExpiredDeal` cleans up expired deals. `expiry == 0` means **no
+  deadline**: such a deal can pay and finalize at any time and is never
+  void-expirable (`voidExpiredDeal` reverts `DealNotExpired`), so it unwinds
+  only by void request — see [Voiding a primary deal](#voiding-a-primary-deal).
 * On `finalizeDeal` the deal's certificate effects (mint/assign/endorse) are
   applied via the IssuanceManager, and escrowed payment (less the platform
   fee — see `computeFee` / `getPlatformPayable`) is released.
 * Escrow state lives in the shared `LexScrowStorage` library — see
   [LeXscroWLite](LeXscroWLite.md). `getEscrowDetails(agreementId)` and
   `conditionCheck(agreementId)` expose it.
+
+### Voiding a primary deal
+
+Every void ultimately runs through the registry's `voidContractFor`, which
+voids the agreement once every **allocated** party has requested it, as soon
+as the proposer (party index 0) requests while still the only signer, or —
+for a nonzero expiry only — once that expiry has passed. What differs between
+the entry points is how much DealManager-side teardown follows.
+
+* `signToVoid` is the complete route. It forwards the request and, once the
+  registry reports the agreement voided, voids the escrowed corp certificates
+  and settles the escrow: a `PAID` escrow is refunded, a `PENDING` one is
+  marked `VOIDED`.
+* `revokeDeal` is **not** a full unwind. It only forwards the request for a
+  still-pending deal (it reverts `DealNotPending` otherwise) and performs no
+  teardown of its own, so a request that tips the agreement into voided — the
+  sole-signer proposer, say — leaves the escrow `PENDING` and its certificates
+  live. Another allocated party's `signToVoid` is what cleans that up
+  afterwards.
+* Requests may also go straight to the registry, bypassing the DealManager
+  entirely. The escrow then lags the agreement until `refundVoidedDeal` syncs
+  it, which voids the corp certificates and refunds — but only for a `PAID`
+  escrow (`voidAndRefund` reverts `EscrowNotPaid` on a `PENDING` one, so an
+  unpaid deal voided this way still needs a party's `signToVoid`).
 
 ## Secondary trading
 

--- a/docs/reference/contracts/DealManager.md
+++ b/docs/reference/contracts/DealManager.md
@@ -76,6 +76,9 @@ defaultLegend}`.
 * `expiry` and `secretHash` support timed and secret-gated deals;
   `voidExpiredDeal` cleans up expired deals, and `refundVoidedDeal` releases
   escrowed payment when an agreement was voided directly in the registry.
+  `expiry == 0` means **no deadline**: such a deal can pay and finalize at
+  any time, is never void-expirable, and unwinds only via `signToVoid`
+  (all parties) or `revokeDeal` while pending.
 * On `finalizeDeal` the deal's certificate effects (mint/assign/endorse) are
   applied via the IssuanceManager, and escrowed payment (less the platform
   fee — see `computeFee` / `getPlatformPayable`) is released.

--- a/docs/reference/contracts/DealManager.md
+++ b/docs/reference/contracts/DealManager.md
@@ -77,8 +77,13 @@ defaultLegend}`.
   `voidExpiredDeal` cleans up expired deals, and `refundVoidedDeal` releases
   escrowed payment when an agreement was voided directly in the registry.
   `expiry == 0` means **no deadline**: such a deal can pay and finalize at
-  any time, is never void-expirable, and unwinds only via `signToVoid`
-  (all parties) or `revokeDeal` while pending.
+  any time and is never void-expirable, so it unwinds only by void request —
+  either through the DealManager (`signToVoid`, or `revokeDeal` while the
+  escrow is still pending) or by submitting `voidContractFor` straight to the
+  registry and then calling `refundVoidedDeal` to resync the escrow and
+  release payment. Either route voids the agreement once every allocated
+  party has requested it, or as soon as the proposer (party index 0) requests
+  it while still the only signer.
 * On `finalizeDeal` the deal's certificate effects (mint/assign/endorse) are
   applied via the IssuanceManager, and escrowed payment (less the platform
   fee — see `computeFee` / `getPlatformPayable`) is released.


### PR DESCRIPTION
Follow-up to #135, which fixed `voidContractFor`'s zero-expiry handling and its knock-on effects. These docs passages still described the old behavior as caveats:

- `docs/reference/contracts/CyberAgreementRegistry.md` — the "Zero-expiry caveat" warning (single party could instantly void a zero-expiry agreement) is replaced with the fixed rule: `expiry == 0` means no deadline in the void path, matching signing/finalization. The void bullet now also notes unanimity is measured against allocated (nonzero) party slots.
- `docs/how-to/sign-a-cyberagreement.md` — same caveat replaced; the nonzero-expiry nuance (past-expiry agreements voidable by one party) is retained.
- `docs/reference/contracts/DealManager.md` — adds the primary-deal side: a zero-expiry deal can pay and finalize at any time, is never void-expirable, and unwinds via `signToVoid` or `revokeDeal`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)