### PR TITLE
docs(webapp): zkPassport override how-to cross-link and scope caution

### DIFF
--- a/docs/webapp/ace.md
+++ b/docs/webapp/ace.md
@@ -59,11 +59,19 @@ for individually negotiated tickets (Reg D or Reg S).
 
 ### zkPassport overrides
 
-If an ACE round restricts investment to non-U.S. persons, founders can
-manually approve a verified investor as an exception: enter their
-**investor wallet** and **Add override** (an onchain transaction; removing
-one is too). The page lists active overrides with when and by whom they
-were added.
+If a round restricts investment to non-U.S. persons, founders can
+manually approve a verified investor as an exception. This applies to
+any of your rounds carrying the non-U.S. condition, ACE or otherwise;
+the **Manage zkPassport Overrides** button on the round's management
+view opens the page. Enter the **investor wallet** and **Add override**
+(an onchain transaction; removing one is too). The page lists active
+overrides with when and by whom they were added.
+
+One caution: an override is granted against your company's round
+manager, not against the single round you opened it from. It satisfies
+the non-U.S. check on **every** round of yours that shares the
+condition, so grant one only to an investor you would except from all
+of them.
 
 ## For investors: taking part
 

--- a/docs/webapp/cyberraise.md
+++ b/docs/webapp/cyberraise.md
@@ -52,7 +52,9 @@ cloud** for a shareable link.
   accredited via [LeXcheX](lexchex.md)), or **Publicly or Privately
   Advertised — U.S. Excluded** (a Regulation S round: participants prove
   non-U.S.-person status with a passport scan in the zkPassport mobile app,
-  unless you manually approve them as an exception). The Reg S option is
+  unless you manually approve them as an exception — the how-to, and a
+  caution about override scope, is
+  [zkPassport overrides](ace.md#zkpassport-overrides)). The Reg S option is
   not available on every network.
 * **Admission mode** — **First-Come, First-Served** (offers are accepted
   automatically in order, funds escrowed immediately, until the round


### PR DESCRIPTION
Follow-up to #138, closing a gap in the zkPassport-override coverage:

- **cyberraise.md** mentioned that a founder can manually except an investor from a Reg S round's non-U.S. check, but never said where to do it. The Reg S round-type bullet now links the how-to.
- **ace.md**'s "zkPassport overrides" section is broadened beyond ACE (the overrides page gates on corp ownership, and the button appears on any non-U.S.-gated round's management view) and gains a scope caution: an override is granted against the corp's round manager, so it satisfies the condition on every round sharing it, not just the round it was opened from.

The scope behavior is verified against the webapp code (`setFounderOverride` is keyed on the condition + round-manager pair).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
