### PR TITLE
fix: revoked and registry-voided deals no longer strand the escrow

### DIFF
--- a/docs/reference/contracts/DealManager.md
+++ b/docs/reference/contracts/DealManager.md
@@ -107,9 +107,11 @@ the entry points is how much DealManager-side teardown follows.
   It reverts `DealNotVoided` while the agreement is still live, and
   `DealVoided` once the escrow is already synced.
 
-Whichever entry point a party uses, a void request that succeeds registry-side
-always tears the DealManager escrow down with it — there is no path that
-leaves certificates live against a voided agreement.
+The DealManager entry points tear the escrow down in the same call; a direct
+registry void does not touch the DealManager, so the certificates stay live
+and the escrow stays `PENDING` or `PAID` until someone calls
+`refundVoidedDeal`. What holds on every route is that the teardown is always
+reachable: no voided agreement can leave its escrow permanently stranded.
 
 ## Secondary trading
 

--- a/docs/reference/contracts/DealManager.md
+++ b/docs/reference/contracts/DealManager.md
@@ -93,21 +93,23 @@ as the proposer (party index 0) requests while still the only signer, or —
 for a nonzero expiry only — once that expiry has passed. What differs between
 the entry points is how much DealManager-side teardown follows.
 
-* `signToVoid` is the complete route. It forwards the request and, once the
-  registry reports the agreement voided, voids the escrowed corp certificates
-  and settles the escrow: a `PAID` escrow is refunded, a `PENDING` one is
-  marked `VOIDED`.
-* `revokeDeal` is **not** a full unwind. It only forwards the request for a
-  still-pending deal (it reverts `DealNotPending` otherwise) and performs no
-  teardown of its own, so a request that tips the agreement into voided — the
-  sole-signer proposer, say — leaves the escrow `PENDING` and its certificates
-  live. Another allocated party's `signToVoid` is what cleans that up
-  afterwards.
+* `signToVoid` forwards the request and, once the registry reports the
+  agreement voided, voids the escrowed corp certificates and settles the
+  escrow: a `PAID` escrow is refunded, a `PENDING` one is marked `VOIDED`.
+* `revokeDeal` does the same for a still-pending deal (it reverts
+  `DealNotPending` otherwise): it forwards the request, and if that request
+  is the one that voids the agreement — the sole-signer proposer, say — the
+  certificates are voided and the escrow marked `VOIDED` in the same call.
 * Requests may also go straight to the registry, bypassing the DealManager
-  entirely. The escrow then lags the agreement until `refundVoidedDeal` syncs
-  it, which voids the corp certificates and refunds — but only for a `PAID`
-  escrow (`voidAndRefund` reverts `EscrowNotPaid` on a `PENDING` one, so an
-  unpaid deal voided this way still needs a party's `signToVoid`).
+  entirely. The escrow then lags the agreement until anyone calls
+  `refundVoidedDeal`, which voids the corp certificates and settles either
+  state — a `PAID` escrow is refunded, a `PENDING` one just marked `VOIDED`.
+  It reverts `DealNotVoided` while the agreement is still live, and
+  `DealVoided` once the escrow is already synced.
+
+Whichever entry point a party uses, a void request that succeeds registry-side
+always tears the DealManager escrow down with it — there is no path that
+leaves certificates live against a voided agreement.
 
 ## Secondary trading
 

--- a/src/DealManager.sol
+++ b/src/DealManager.sol
@@ -280,11 +280,12 @@ contract DealManager is
     }
 
     /// @notice Revokes a pending deal
-    /// @dev Can only be called for deals in pending status
+    /// @dev Can only be called for deals in pending status; if the revoke voids the
+    /// registry agreement, the escrow is torn down (certs voided, status VOIDED) in the same call
     /// @param agreementId Unique identifier for the agreement
     /// @param signer Address of the signer
     /// @param signature Signature of the signer
-    function revokeDeal(bytes32 agreementId, address signer, bytes memory signature) public {
+    function revokeDeal(bytes32 agreementId, address signer, bytes memory signature) public nonReentrant {
         // Thin wrapper over the linked DealManagerStorage logic (delegatecall keeps storage/msg.sender)
         DealManagerStorage.revokeDeal(agreementId, signer, signature);
     }
@@ -299,9 +300,10 @@ contract DealManager is
         DealManagerStorage.signToVoid(agreementId, signer, signature);
     }
 
-    /// @notice Refund a voided deal
-    /// @dev Use this method to initiate refund if the deal agreement has been voided externally
-    /// (e.g. directly to CyberAgreementRegistry without being processed by Deal Manager)
+    /// @notice Sync and (if paid) refund a deal whose agreement has been voided externally
+    /// @dev Use this method if the deal agreement was voided directly in the
+    /// CyberAgreementRegistry without being processed by Deal Manager; works for both
+    /// PAID (refunds) and PENDING (voids escrow, nothing to refund) deals
     /// @param agreementId Unique identifier for the agreement
     function refundVoidedDeal(bytes32 agreementId) public nonReentrant {
         // Thin wrapper over the linked DealManagerStorage logic (delegatecall keeps storage/msg.sender)

--- a/src/storage/DealManagerStorage.sol
+++ b/src/storage/DealManagerStorage.sol
@@ -329,14 +329,25 @@ library DealManagerStorage {
     }
 
     /// @notice Revokes a pending deal
-    /// @dev Access modifiers (if any) are carried by the DealManager wrapper that delegatecalls here.
+    /// @dev nonReentrant is carried by the DealManager wrapper that delegatecalls here.
+    ///      If this request tips the registry agreement into voided (e.g. the sole-signer proposer
+    ///      revokes), the same teardown as signToVoid must run here: voidContractFor rejects repeat
+    ///      requesters, so no later signToVoid could clean up and the escrow would be stranded
+    ///      PENDING with its corp certificates still live.
     function revokeDeal(bytes32 agreementId, address signer, bytes memory signature) public {
         if (!LexScrowStorage.hasPrimaryEscrow(agreementId)) revert LexScrowStorage.DealDoesNotExist();
         if(msg.sender != signer) revert IDealManagerStorage.CounterPartyValueMismatch();
-        if(LexScrowStorage.getEscrow(agreementId).status == EscrowStatus.PENDING)
-            ICyberAgreementRegistry(LexScrowStorage.getDealRegistry()).voidContractFor(agreementId, signer, signature);
-        else
-            revert IDealManagerStorage.DealNotPending();
+        Escrow storage deal = LexScrowStorage.getEscrow(agreementId);
+        if(deal.status != EscrowStatus.PENDING) revert IDealManagerStorage.DealNotPending();
+
+        address registry = LexScrowStorage.getDealRegistry();
+        ICyberAgreementRegistry(registry).voidContractFor(agreementId, signer, signature);
+        // The agreement is only voided once enough parties have requested; until then there is nothing to tear down.
+        if (!ICyberAgreementRegistry(registry).isVoided(agreementId)) return;
+
+        _voidCorpCerts(deal);
+        // Effect: update status (the deal is PENDING per the guard above, so there is no payment to refund)
+        LexScrowStorage.voidEscrow(agreementId);
     }
 
     /// @notice Signs to void a deal; refunds if the deal was paid
@@ -365,13 +376,29 @@ library DealManagerStorage {
             LexScrowStorage.voidEscrow(agreementId);
     }
 
-    /// @notice Refund a voided deal
+    /// @notice Sync the escrow of a deal whose agreement was voided externally, refunding if paid
     /// @dev nonReentrant is carried by the DealManager wrapper that delegatecalls here.
+    ///      Handles PENDING as well as PAID escrows: parties can void the agreement directly in the
+    ///      registry before payment, and requiring PAID here would leave that escrow stranded with
+    ///      its corp certificates still live (voidAndRefund reverts EscrowNotPaid).
     function refundVoidedDeal(bytes32 agreementId) public {
         if (!LexScrowStorage.hasPrimaryEscrow(agreementId)) revert LexScrowStorage.DealDoesNotExist();
-        _voidCorpCerts(LexScrowStorage.getEscrow(agreementId));
-        // Interaction: Re-sync Deal Manager internal escrow to VOIDED, then refund
-        LexScrowStorage.voidAndRefund(agreementId);
+        if (!ICyberAgreementRegistry(LexScrowStorage.getDealRegistry()).isVoided(agreementId))
+            revert LexScrowStorage.DealNotVoided();
+
+        Escrow storage deal = LexScrowStorage.getEscrow(agreementId);
+        if (deal.status == EscrowStatus.PAID) {
+            _voidCorpCerts(deal);
+            // Interaction: Re-sync Deal Manager internal escrow to VOIDED, then refund
+            LexScrowStorage.voidAndRefund(agreementId);
+        } else if (deal.status == EscrowStatus.PENDING) {
+            _voidCorpCerts(deal);
+            // Effect: update status (nothing was paid, so there is nothing to refund)
+            LexScrowStorage.voidEscrow(agreementId);
+        } else {
+            // Already VOIDED (certs already torn down, nothing left to sync) or FINALIZED
+            revert LexScrowStorage.DealVoided();
+        }
     }
 
     /// @dev Teardown shared by every void path: the corp's certificates were minted to this manager at

--- a/test/DealManagerTest.t.sol
+++ b/test/DealManagerTest.t.sol
@@ -796,6 +796,38 @@ contract DealManagerTest is Test {
         _assertCertVoided(certIds[0]);
     }
 
+    function test_RevokeDeal_VoidingRevokeVoidsEscrowAndCert() public {
+        // A revoke that tips the agreement into voided (e.g. the sole-signer proposer revokes) must
+        // run the same teardown as signToVoid. voidContractFor rejects repeat requesters, so if this
+        // path skipped teardown, no later signToVoid could clean up: the escrow would be stranded
+        // PENDING with its certs live.
+
+        (bytes32 agreementId, uint256[] memory certIds) = _proposeSignedDeal();
+
+        registry.mockIsReadyToVoid(agreementId, true);
+        vm.prank(companyOwner);
+        dm.revokeDeal(agreementId, companyOwner, GOOD_SIGNATURE);
+
+        assertTrue(registry.isVoided(agreementId), "Agreement should be voided");
+        assertEq(uint8(dm.getEscrowDetails(agreementId).status), uint8(EscrowStatus.VOIDED), "Escrow should be voided");
+        _assertCertVoided(certIds[0]);
+    }
+
+    function test_RevokeDeal_NonVoidingRevokeLeavesEscrowPending() public {
+        // A revoke that only records a void request (other parties still have to consent) must not
+        // touch the escrow: the deal can still be voided later, or the request outvoted by nothing —
+        // the agreement simply isn't voided yet.
+
+        (bytes32 agreementId, uint256[] memory certIds) = _proposeSignedDeal();
+
+        vm.prank(companyOwner);
+        dm.revokeDeal(agreementId, companyOwner, GOOD_SIGNATURE);
+
+        assertFalse(registry.isVoided(agreementId), "Agreement should not be voided yet");
+        assertEq(uint8(dm.getEscrowDetails(agreementId).status), uint8(EscrowStatus.PENDING), "Escrow should stay pending");
+        assertEq(CyberCertPrinterMock(defaultCertPrinters[0]).ownerOf(certIds[0]), address(dm), "Cert should still be escrowed");
+    }
+
     function test_PaymentFlow_RefundVoidedDeal() public {
         // If the agreement is voided through the registry instead of Deal Manager,
         // DealManager should still be able to refund through other means
@@ -849,6 +881,34 @@ contract DealManagerTest is Test {
 
         // Refund should fail because the deal is not voided
         vm.expectRevert(LexScrowStorage.DealNotVoided.selector);
+        dm.refundVoidedDeal(agreementId);
+    }
+
+    function test_RefundVoidedDeal_PendingDealVoidsEscrowAndCert() public {
+        // Parties can void the agreement directly in the registry before anyone pays. The escrow is
+        // then out of sync with no signToVoid available (every requester is rejected as a repeat),
+        // so refundVoidedDeal must handle the PENDING case: void the certs and the escrow, nothing
+        // to refund.
+
+        (bytes32 agreementId, uint256[] memory certIds) = _proposeSignedDeal();
+
+        registry.mockIsVoided(agreementId, true);
+        dm.refundVoidedDeal(agreementId);
+
+        assertEq(uint8(dm.getEscrowDetails(agreementId).status), uint8(EscrowStatus.VOIDED), "Escrow should be voided");
+        _assertCertVoided(certIds[0]);
+    }
+
+    function test_RevertIf_RefundVoidedDeal_AlreadySynced() public {
+        // A second sync has nothing to do — the escrow is already VOIDED — and must revert rather
+        // than silently succeed.
+
+        (bytes32 agreementId, ) = _proposeSignedDeal();
+
+        registry.mockIsVoided(agreementId, true);
+        dm.refundVoidedDeal(agreementId);
+
+        vm.expectRevert(LexScrowStorage.DealVoided.selector);
         dm.refundVoidedDeal(agreementId);
     }
 


### PR DESCRIPTION
## The bug

Codex review on #137 (a docs PR) turned up a real contract defect: two of the three ways to void a primary deal left the DealManager escrow behind.

Every void request goes through the registry's `voidContractFor`, and the registry rejects a party who requests twice. So whoever tips an agreement into voided gets exactly one shot at cleanup, in that same call. `signToVoid` used that shot: once the registry reported the agreement voided, it voided the escrowed certificates and settled the escrow. `revokeDeal` didn't. It forwarded the request to the registry and returned.

Concretely: a proposer revokes a deal while still the only signer, which is the normal way to withdraw an offer nobody has countersigned. The registry agreement becomes void. The DealManager escrow stays `PENDING` and the corp's certificates stay live. And from that point nothing can fix it:

- `signToVoid` reverts `ContractAlreadyVoided`, because every party who could call it has already requested the void
- `refundVoidedDeal` reverts `EscrowNotPaid`, because it only handled `PAID` escrows
- `voidExpiredDeal` reverts `DealNotExpired` on a zero-expiry deal, which never expires
- `finalizeDeal` reverts `DealVoided`

The same dead end existed for unpaid deals voided directly in the registry (parties can always call `voidContractFor` themselves, bypassing the DealManager), because `refundVoidedDeal` refused anything that wasn't `PAID`.

## Impact: no funds at risk, ledger integrity only

No money could be lost or locked by this bug. Payment is atomic: `handleCounterPartyPayment` pulls all buyer assets and flips the escrow from `PENDING` to `PAID` in a single call, so a `PENDING` escrow holds zero buyer funds. And both stranded scenarios required a `PENDING` escrow. `revokeDeal` refuses anything else (`DealNotPending`), and the direct-registry dead end only bit when the deal was unpaid, because `refundVoidedDeal` already worked for `PAID` escrows (that is the pre-existing `test_PaymentFlow_RefundVoidedDeal`). Any deal with actual money in escrow always had a working refund path.

What did get stuck: the corp's certificates, minted to the DealManager at proposal time, stayed live forever against a dead deal. Until voided they keep counting toward the cert printer's look-through holder tally, the number that feeds holder-count compliance thresholds, and the cap table shows certificates outstanding for a deal that was voided. The escrow record also sat permanently at `PENDING`, misreporting state to anything that reads it. The bug corrupts issuer-side bookkeeping and compliance data; it does not put funds at risk.

## The fix

Two functions in `DealManagerStorage`, plus one wrapper in `DealManager`.

**`revokeDeal`** now checks whether its request voided the agreement. If it did, the same teardown as `signToVoid` runs in the same call: certificates voided, escrow marked `VOIDED`. There is nothing to refund, since the pending-only guard means nobody has paid. The `DealManager` wrapper gains `nonReentrant` to match the other void entry points, since the function now makes external calls.

**`refundVoidedDeal`** now settles both escrow states. `PAID` refunds exactly as before. `PENDING` voids the certificates and the escrow, with nothing to refund. It also checks the registry's void status up front and reverts `DealNotVoided` before touching anything. Calling it again after the escrow is synced reverts `DealVoided`.

Two behavior changes reviewers may want to weigh:

1. `refundVoidedDeal` on the `PENDING` escrow of a voided agreement used to revert and now succeeds. The call is permissionless, but all it can do is bring the escrow in line with a void the parties already executed registry-side.
2. Error ordering: `refundVoidedDeal` on a deal that is not voided in the registry now always reverts `DealNotVoided`. Previously the error depended on payment state, because the check sat inside `voidAndRefund` behind the `EscrowNotPaid` check.

## Tests

Four new tests in `DealManagerTest.t.sol`:

- `test_RevokeDeal_VoidingRevokeVoidsEscrowAndCert`: sole-signer revoke voids escrow and certs in one call
- `test_RevokeDeal_NonVoidingRevokeLeavesEscrowPending`: a revoke that only records a request touches nothing
- `test_RefundVoidedDeal_PendingDealVoidsEscrowAndCert`: direct registry void before payment, then sync
- `test_RevertIf_RefundVoidedDeal_AlreadySynced`: second sync reverts instead of silently succeeding

`testRevokeDealBeforePayment` in `CyberCorpTest.t.sol` already runs the sole-signer revoke against the real registry and real cert printers, so it now exercises the new teardown end to end.

## Docs

The "Voiding a primary deal" section of `docs/reference/contracts/DealManager.md` (added in #137) is updated to describe the fixed behavior. DealManager entry points tear the escrow down in the same call; a direct registry void still needs a follow-up `refundVoidedDeal`, which now works in every escrow state. Teardown is always reachable, though on the direct route it is not automatic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
