### PR TITLE
ci: notify the webapp when the GitBook changes

### DIFF
--- a/.github/workflows/notify-gaibe.yml
+++ b/.github/workflows/notify-gaibe.yml
@@ -5,10 +5,15 @@
 # redeploys. This dispatch triggers that repo's "Refresh GAIBE knowledge"
 # workflow, which opens a PR there; a human still merges and promotes it.
 #
-# Requires a repo secret WEBAPP_DISPATCH_TOKEN with actions:write on
-# MetaLex-Tech/metalex-webapp. If the dispatch fails or the secret is missing,
-# the webapp workflow's nightly schedule picks the change up anyway - this
-# only makes it prompt.
+# Requires a repo secret WEBAPP_DISPATCH_TOKEN scoped to
+# MetaLex-Tech/metalex-webapp with Actions: write (fine-grained) - nothing
+# else. Note the endpoint: this fires the workflow-dispatch API rather than
+# repository_dispatch, because repository_dispatch needs Contents: write,
+# which would also let anything holding this secret push code to the webapp
+# repo. Triggering a workflow is all this needs to do.
+#
+# If the dispatch fails or the secret is missing, the webapp workflow's
+# nightly schedule picks the change up anyway - this only makes it prompt.
 
 name: Notify GAIBE of docs changes
 
@@ -29,7 +34,11 @@ jobs:
           GH_TOKEN: ${{ secrets.WEBAPP_DISPATCH_TOKEN }}
         run: |
           set -euo pipefail
-          gh api /repos/MetaLex-Tech/metalex-webapp/dispatches \
+          echo "Docs changed at $GITHUB_SHA - triggering the webapp knowledge refresh."
+          # ref=develop is the webapp's default branch, where the workflow
+          # lives. It re-imports from that branch's head regardless, so there
+          # is nothing to pass through: its workflow_dispatch takes no inputs,
+          # and sending an undeclared one is a 422.
+          gh api /repos/MetaLex-Tech/metalex-webapp/actions/workflows/gaibe-knowledge-refresh.yml/dispatches \
             --method POST \
-            --field event_type=gitbook-updated \
-            --field "client_payload[sha]=$GITHUB_SHA"
+            --field ref=develop

--- a/.github/workflows/notify-gaibe.yml
+++ b/.github/workflows/notify-gaibe.yml
@@ -1,0 +1,35 @@
+# Tells the webapp repo that the GitBook changed.
+#
+# GAIBE (the in-app assistant) compiles docs/ into its system prompt at build
+# time, so docs only reach users after the webapp re-imports them and
+# redeploys. This dispatch triggers that repo's "Refresh GAIBE knowledge"
+# workflow, which opens a PR there; a human still merges and promotes it.
+#
+# Requires a repo secret WEBAPP_DISPATCH_TOKEN with actions:write on
+# MetaLex-Tech/metalex-webapp. If the dispatch fails or the secret is missing,
+# the webapp workflow's nightly schedule picks the change up anyway - this
+# only makes it prompt.
+
+name: Notify GAIBE of docs changes
+
+on:
+  push:
+    branches:
+      - develop
+    paths:
+      - "docs/**"
+  workflow_dispatch:
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger the webapp knowledge refresh
+        env:
+          GH_TOKEN: ${{ secrets.WEBAPP_DISPATCH_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh api /repos/MetaLex-Tech/metalex-webapp/dispatches \
+            --method POST \
+            --field event_type=gitbook-updated \
+            --field "client_payload[sha]=$GITHUB_SHA"


### PR DESCRIPTION
Companion to [MetaLex-Tech/metalex-webapp#874](https://github.com/MetaLex-Tech/metalex-webapp/pull/874).

## Why

GAIBE — the assistant in the MetaLeX webapp — compiles this repo's `docs/` into its system prompt **at build time**. Docs merged here don't reach users until the webapp re-imports them and redeploys, which today only happens when someone remembers. The knowledge base the webapp currently ships is about 12.7k tokens behind this repo's `develop`, so GAIBE has been answering from a stale copy of these docs.

## What this does

On a push to `develop` that touches `docs/`, trigger the *Refresh GAIBE knowledge* workflow in the webapp repo ([#874](https://github.com/MetaLex-Tech/metalex-webapp/pull/874)), which re-imports the docs and opens a PR there. Merge and deploy stay human on that side.

Nothing about this repo's build or tests changes — it's one `gh api` call in a new workflow.

## Setup required

A **`WEBAPP_DISPATCH_TOKEN`** repo secret: a fine-grained token scoped to `MetaLex-Tech/metalex-webapp` with **Actions: write**, and nothing else.

It fires the workflow-dispatch endpoint rather than `repository_dispatch` deliberately (`98163a1`, after review). `POST /repos/{owner}/{repo}/dispatches` requires `Contents: write` — which would also let anything holding this secret push code into the webapp repo, across a repo boundary, to fire one workflow. `POST /repos/{owner}/{repo}/actions/workflows/{id}/dispatches` needs only `Actions: write`.

This is a convenience, not a dependency: the webapp workflow also runs nightly, so a missing secret or a failed dispatch delays the refresh by up to a day rather than losing it. That also means this PR is safe to merge before the secret exists — the step just fails and the nightly run covers it. Merge #874 first, or the dispatch has nothing to trigger.

## Verification

YAML parses and the `run:` block passes `bash -n`. Confirmed the dispatch target resolves: `gaibe-knowledge-refresh.yml` is registered and `active` on the webapp repo, whose default branch is `develop`. The dispatch call itself is unverified until it fires against a real token — the first docs merge after setup will exercise it, and a failure is loud rather than silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
