### PR TITLE
Added issuer permissions to LexChexBadge (for LegionSoulboundCondition) 

### DIFF
--- a/specs/analysis/conditions.md
+++ b/specs/analysis/conditions.md
@@ -39,6 +39,10 @@ under it. Every condition is a shared singleton — see `Config scope` for what 
 `AccreditedInvestorCondition` (`K_ACCREDITED`, buyer), `QualifiedPurchaserCondition` (`K_QP`, buyer +
 seller), `QualifiedInstitutionalBuyerCondition` (`K_QIB`, buyer), `NonUSNationalityCondition`
 (`K_NON_US`, buyer), plus the SPV-scoped entitlements (`K_SPV_WHITELIST`, `K_SYNDICATE`).
+A `K_SYNDICATE` parameterization answers membership in an issuer's circle. `LegionSoulboundCondition` is the
+gate for one operator's own circle and answers both halves: the seat (`K_SYNDICATE`, scoped to the SPV) and
+the rank within it (an ordered tier in `K_DATA`, read through a query hook, which a fact-key bitmask cannot
+express). A gate wanting membership alone names the lowest rung.
 `HolderCapCondition` covers §3(c)(1), §3(c)(1)(C) and Touche Remnant through its per-SPV config.
 
 **Badge** — `printer` = read from `offer.certPrinter.lookThroughBadge()`, which is the only registry that
@@ -59,7 +63,7 @@ never a finding. `USStateOfResidenceCondition` is the exception:
 | `CFIUSCondition`              | **blocks**   | no TID U.S. business determination; a recorded `tidUsBusiness = false` is the fund exception and passes |
 | `HolderCapCondition`          | **blocks**   | no ICA exception named — `cap == 0` is a real §3(c)(7) setting, so a `configured` flag keeps it apart   |
 | `RegSDistributionCompliance`  | **blocks**   | no issuer category or compliance period — same `configured` flag                                        |
-| `LegionSoulboundCondition`    | **blocks**   | no circle named                                                                                         |
+| `LegionSoulboundCondition`    | **blocks**   | no minimum rank named — and no rank means no circle to be seated in                                     |
 | `EligibilityCondition`        | **blocks**   | that SPV has cleared nobody                                                                             |
 | `Rule144` / `Section4a7`      | **blocks**   | no disclosure package on record                                                                         |
 | `USStateOfResidenceCondition` | **passes**   | nothing — it is a deny-list, so an empty one permits (NY still blocks by the Martin Act default)        |
@@ -203,7 +207,7 @@ automatically.
 | `HolderCapCondition`          | All SPVs                                                                    | ICA exception (`§3(c)(1)`, `§3(c)(1)(C)`, or `§3(c)(7)`); SPV domicile (for Touche Remnant U.S.-resident-only count); cap (100 / 250 / none)                                                        |
 | `QualifiedPurchaserCondition` | §3(c)(7) funds only                                                         | Parameterizes `LexChexBadgeKindCondition` with `kindKey = K_QP`, buyer + seller                                                                                                                     |
 | `CFIUSCondition`              | SPVs that do not satisfy the FIRRMA §800.307 fund exception                 | SPV CFIUS sensitivity flag; blocked jurisdictions                                                                                                                                                   |
-| `LegionSoulboundCondition`    | Optional; GP-configurable                                                   | Soulbound credential category/tier required of buyer (and optionally seller)                                                                                                                        |
+| `LegionSoulboundCondition`    | Optional; GP-configurable                                                   | Seat in the issuer's circle for this SPV plus a minimum rank on its ladder, required of buyer (and optionally seller); platform names whose circle counts                                           |
 | `GPLPApprovalCondition`       | Optional; only if governing documents require per-deal approval             | Authorized approver address (GP, managing member, or delegated compliance officer)                                                                                                                  |
 | `QMSModeCondition`            | Optional; per-SPV opt-in for §1.7704-1(g) QMS safe harbor                   | Frequency cap value (counsel-determined per SPV); listing timestamp stored at `postOffer`                                                                                                           |
 

--- a/src/creds/lexchexBadge.sol
+++ b/src/creds/lexchexBadge.sol
@@ -34,6 +34,7 @@ import "./LeXcheXBadgeRender.sol";
 import "../libs/auth.sol";
 import "../interfaces/IERC5484.sol";
 import "../interfaces/ILexChexBadge.sol";
+import "../interfaces/ICredentialQueryHook.sol";
 
 /// @title  LeXcheXBadge - Unified Soulbound Credential Contract (LeXcheX v2)
 /// @author MetaLeX Labs, Inc.
@@ -48,6 +49,8 @@ import "../interfaces/ILexChexBadge.sol";
 /// Spec
 /// - A credential's `asserts` (K_* fact-keys) is the sole authority axis: a field answers a read only when
 ///   its key is asserted; VALUE keys require a non-empty field, SCOPE keys require `scope` (the SPV).
+/// - `scope` narrows a credential to one SPV. Any key may carry one and every read can filter on it; for SCOPE
+///   keys it is mandatory.
 /// - Credentials are IMMUTABLE once minted: change a fact by minting a newer credential (most-recent valid
 ///   wins), and revoke by voiding. There is no in-place edit.
 /// - Changing a fact is not the same as retracting one. No credential can say a fact stopped being true, and
@@ -84,10 +87,12 @@ import "../interfaces/ILexChexBadge.sol";
 /// | K_SYNDICATE                  | hasValidSyndicateFor             | absent / scoped to an SPV   | issuer circle (§4.1.3A)  |
 ///
 /// Invariants
+/// - Issuing authority is per-key: `issuerKeys` is the entire grant, so a delegated issuer needs no BorgAuth
+///   role and picks up none of the admin power a shared auth would carry with it. `mint` records who issued,
+///   and an issuer voids only its own work. So one deployment can host several operators, and a reader can
+///   tell whose word a fact rests on. Admins run the deployment and issue anything.
 /// - Tokens are deliberately NOT burnable — revocation is void-only, so every credential (voided, expired, or
 ///   superseded) is retained on-chain for audit. Void is one-way.
-/// - `categoryId` is a free-form issuer label carried for off-chain bookkeeping, never interpreted on-chain
-///   (category schemas live off-chain, not in this contract).
 /// - `data` is a generic programmable payload gated by
 ///   K_DATA that the badge stores but never interprets — downstream programs read the authoritative value via
 ///   getData.
@@ -116,22 +121,52 @@ contract LeXcheXBadge is
     }
 
     // ─────────────────────────────────────────────────────────────────────────
+    // Issuing authority — who may assert which facts
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// @notice Sets the complete set of fact-keys `issuer` may assert; pass 0 to stop it issuing entirely.
+    function setIssuerKeys(address issuer, uint256 keys) external onlyAdmin {
+        if (keys & ~ALL_KEYS != 0) revert LexChexBadge_BadAsserts();
+        LeXcheXBadgeStorage.badgeStorage().issuerKeys[issuer] = keys;
+        emit IssuerKeysUpdated(issuer, keys);
+    }
+
+    /// @notice The fact-keys `issuer` was granted; 0 means it cannot mint. Admins run the deployment and are
+    /// not listed — read this as the authority of every issuer other than the operator itself.
+    function issuerKeys(address issuer) public view returns (uint256) {
+        return LeXcheXBadgeStorage.badgeStorage().issuerKeys[issuer];
+    }
+
+    /// @dev Non-reverting ADMIN_ROLE test. Mirrors BorgAuth's hierarchy (roles at or above the level pass)
+    function _isAdmin(address user) internal view returns (bool) {
+        return AUTH.userRoles(user) >= AUTH.ADMIN_ROLE();
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
     // Lifecycle entry points (§0.5) — append-only; never edited or burned
     // ─────────────────────────────────────────────────────────────────────────
 
     /// @notice Issues an immutable credential. Validates that every asserted fact-key carries its value (or
-    /// scope), stamps issuanceDate, and requires a future expiry. To change a fact later, mint a newer
-    /// credential asserting the changed key (most-recent valid wins); to revoke, void.
-    function mint(address to, Credential memory cred) public onlyAdmin returns (uint256 tokenId) {
+    /// scope), checks the caller may assert those keys, stamps issuer and issuanceDate, and requires a future
+    /// expiry. To change a fact later, mint a newer credential asserting the changed key (most-recent valid
+    /// wins); to revoke, void.
+    function mint(address to, Credential memory cred) public returns (uint256 tokenId) {
         _validate(cred);
+        // The grant IS the authority to issue — no role needed on top, so a delegated issuer can be given one
+        // without any of the admin power that a shared BorgAuth would carry with it. A caller with no grant
+        // has an empty mask and fails here. Admins run the deployment, so they issue anything.
+        uint256 allowed = _isAdmin(msg.sender) ? ALL_KEYS : issuerKeys(msg.sender);
+        uint256 unauthorized = cred.asserts & ~allowed;
+        if (unauthorized != 0) revert LexChexBadge_KeysNotAuthorized(msg.sender, unauthorized);
         if (cred.expiryDate <= block.timestamp) revert LexChexBadge_InvalidExpiry();
+        cred.issuer = msg.sender;
         cred.issuanceDate = uint64(block.timestamp);
         cred.voided = "";
 
         tokenId = LeXcheXBadgeStorage.getSupply();
         _mint(to, tokenId);
         LeXcheXBadgeStorage.setCredential(tokenId, cred);
-        LeXcheXBadgeStorage.addActive(to, tokenId, cred.categoryId);
+        LeXcheXBadgeStorage.addActive(to, tokenId);
         LeXcheXBadgeStorage.incrementSupply();
 
         emit CredentialIssued(to, tokenId, cred);
@@ -142,11 +177,10 @@ contract LeXcheXBadge is
     /// @dev How to retract a fact. Minting a corrected credential is not enough — the old one keeps answering
     /// until it is voided, so a holder who emigrates would keep their old U.S. state. Both steps happen here
     /// so a correction cannot be issued half-finished.
-    function supersede(
-        uint256 staleTokenId,
-        Credential memory cred,
-        string memory reason
-    ) external onlyAdmin returns (uint256 tokenId) {
+    function supersede(uint256 staleTokenId, Credential memory cred, string memory reason)
+        external
+        returns (uint256 tokenId)
+    {
         address holder = _requireOwned(staleTokenId);
         void(staleTokenId, reason);
         return mint(holder, cred);
@@ -154,13 +188,17 @@ contract LeXcheXBadge is
 
     /// @notice Revocation: failed re-KYC, discovered bad-actor status, relocation, sanctions hits. The
     /// credential is retained (never burned) with the reason recorded, so the record survives for audit.
-    function void(uint256 tokenId, string memory reason) public onlyAdmin {
+    function void(uint256 tokenId, string memory reason) public {
         if (bytes(reason).length == 0) revert LexChexBadge_MissingVoidReason();
         Credential storage cred = LeXcheXBadgeStorage.getCredential(tokenId);
         if (cred.issuanceDate == 0) revert LexChexBadge_TokenDoesNotExist();
+        // An issuer revokes only its own credentials, or per-key authority would stop a delegated operator
+        // writing facts but not destroying everyone else's. An admin can void anything, for a rogue issuer.
+        // No grant is required to revoke, so an issuer cut off from minting can still clean up its own work.
+        if (cred.issuer != msg.sender) AUTH.onlyRole(AUTH.ADMIN_ROLE(), msg.sender);
         address holder = _requireOwned(tokenId);
         cred.voided = reason;
-        LeXcheXBadgeStorage.removeActive(holder, tokenId, cred.categoryId); // evict from the active set at once
+        LeXcheXBadgeStorage.removeActive(holder, tokenId); // evict from the active set at once
         emit CredentialVoided(holder, tokenId, reason);
     }
 
@@ -176,7 +214,7 @@ contract LeXcheXBadge is
             uint256 id = ids[i];
             Credential storage cred = LeXcheXBadgeStorage.getCredential(id);
             if (block.timestamp > cred.expiryDate) {
-                LeXcheXBadgeStorage.removeActive(holder, id, cred.categoryId); // swap-pop → re-check index i
+                LeXcheXBadgeStorage.removeActive(holder, id); // swap-pop → re-check index i
                 emit CredentialSwept(holder, id);
             } else {
                 ++i;
@@ -210,7 +248,7 @@ contract LeXcheXBadge is
             if (holder == address(0)) continue;
             Credential storage cred = LeXcheXBadgeStorage.getCredential(tokenId);
             if (block.timestamp <= cred.expiryDate) continue;
-            if (LeXcheXBadgeStorage.removeActive(holder, tokenId, cred.categoryId)) {
+            if (LeXcheXBadgeStorage.removeActive(holder, tokenId)) {
                 ++evicted;
                 emit CredentialSwept(holder, tokenId);
             }
@@ -236,66 +274,125 @@ contract LeXcheXBadge is
         return true;
     }
 
-    /// @notice True when the owner holds a valid credential carrying the free-form issuer label `categoryId`.
-    /// The label is never interpreted by this contract; this is a plain match for issuer-tier gates (e.g.
-    /// Legion custom tiers) that live outside the K_* fact-keys. Index-backed: scans only same-label tokens.
-    function hasValidCredential(address owner, bytes32 categoryId) public view returns (bool) {
-        uint256[] storage ids = LeXcheXBadgeStorage.getLabelTokens(owner, categoryId);
-        for (uint256 i = 0; i < ids.length; i++) {
-            if (isValid(ids[i])) return true;
-        }
-        return false;
-    }
+    // Every read below walks the holder's active set with the same four filters, each off by default:
+    //   kindKey  fact-keys to cover; 0 asks for none (useful for custom queries with hook)
+    //   issuers  filter by issuers; empty accepts any
+    //   scope    the SPV an entitlement must name; empty accepts any
+    //   hook     ICredentialQueryHook injecting custom query logic
+    //   hookData hook-specific payload
+    // A shortcut is the full form with the rest left empty. All four filters empty reverts
 
-    /// @notice True when the owner's valid credentials TOGETHER assert every fact-key in `kindKey`. Serves the
-    /// LexChex parameterizations (accredited / QP / QIB / bad-actor-clear / non-U.S. person).
-    /// @dev A status fact does not contradict another, so two live credentials asserting different ones are both
-    /// true and a multi-key ask is answered from the whole active set. Requiring one credential to carry every
-    /// key would reject a holder whose facts arrived on separate attestations. Single-key asks read the same
-    /// either way. The empty key is rejected outright — a mask of nothing is trivially covered, and no credential
-    /// asserts nothing.
-    function hasValidCredentialOf(address owner, uint256 kindKey) public view returns (bool) {
-        if (kindKey == 0) return false;
+    /// @notice True when the owner's valid credentials TOGETHER cover `kindKey`, counting only those that clear
+    /// the issuer, scope and hook filters.
+    /// @dev Keys add up across credentials, so facts attested separately still qualify the holder. The filters
+    /// apply per credential: one that clears them all answers, which keeps a holder who is two things at once
+    /// (two tiers, two seats) true for both.
+    function hasValidCredentialOf(
+        address owner,
+        uint256 kindKey,
+        address[] memory issuers,
+        address scope,
+        address hook,
+        bytes memory hookData
+    ) public view returns (bool) {
+        _requireQuery(kindKey, issuers, scope, hook);
 
         uint256 covered;
         uint256[] storage ids = LeXcheXBadgeStorage.getActiveTokens(owner);
         for (uint256 i = 0; i < ids.length; i++) {
-            if (!isValid(ids[i])) continue;
+            if (!_eligible(owner, ids[i], issuers, scope, hook, hookData)) continue;
+            if (kindKey == 0) return true;
             covered |= LeXcheXBadgeStorage.getCredential(ids[i]).asserts;
             if ((covered & kindKey) == kindKey) return true;
         }
         return false;
     }
 
-    /// @notice True when the owner holds a valid credential granting scoped entitlement `scopeKey` for `spv`.
-    /// An entitlement answers only for the SPV it names, so one SPV's membership never leaks to another. Any
-    /// valid credential carrying the key and scope admits — a second grant of the same entitlement says the
-    /// same thing, so there is no recency contest. Scans the (bounded) active set.
-    function hasValidScopedCredentialOf(address owner, uint256 scopeKey, address spv) public view returns (bool) {
+    /// @notice Shortcut: a plain fact-key ask.
+    function hasValidCredentialOf(address owner, uint256 kindKey) public view returns (bool) {
+        return hasValidCredentialOf(owner, kindKey, new address[](0), address(0), address(0), "");
+    }
+
+    /// @notice Shortcut: only credentials from an issuer in `issuers` count.
+    function hasValidCredentialOf(address owner, uint256 kindKey, address[] memory issuers) public view returns (bool) {
+        return hasValidCredentialOf(owner, kindKey, issuers, address(0), address(0), "");
+    }
+
+    /// @notice Shortcut: only credentials naming `scope`, so an entitlement answers for its own SPV.
+    function hasValidCredentialOf(address owner, uint256 kindKey, address scope) public view returns (bool) {
+        return hasValidCredentialOf(owner, kindKey, new address[](0), scope, address(0), "");
+    }
+
+    /// @notice The owner's authoritative credential: the most recent valid one that covers `kindKey` on its own
+    /// and clears every filter. The resolution every value getter runs, exposed for callers that want the
+    /// credential itself.
+    /// @dev Use this when the matches contradict each other, like two credentials naming different U.S. states.
+    /// For membership use hasValidCredentialOf. `kindKey` is tested per credential here: one record has to
+    /// carry the whole set.
+    function getMostRecentValidWith(
+        address owner,
+        uint256 kindKey,
+        address[] memory issuers,
+        address scope,
+        address hook,
+        bytes memory hookData
+    ) public view returns (uint256 tokenId, bool found) {
+        _requireQuery(kindKey, issuers, scope, hook);
+
+        uint64 latest = 0;
         uint256[] storage ids = LeXcheXBadgeStorage.getActiveTokens(owner);
         for (uint256 i = 0; i < ids.length; i++) {
-            Credential storage cred = LeXcheXBadgeStorage.getCredential(ids[i]);
-            if ((cred.asserts & scopeKey) != 0 && cred.scope == spv && isValid(ids[i])) return true;
+            uint256 candidate = ids[i];
+            if (!_eligible(owner, candidate, issuers, scope, hook, hookData)) continue;
+            Credential storage cred = LeXcheXBadgeStorage.getCredential(candidate);
+            if (!_covers(cred, kindKey)) continue;
+            if (!found || cred.issuanceDate > latest || (cred.issuanceDate == latest && candidate > tokenId)) {
+                latest = cred.issuanceDate;
+                tokenId = candidate;
+                found = true;
+            }
         }
-        return false;
+    }
+
+    /// @notice Shortcut: a plain fact-key ask.
+    function getMostRecentValidWith(address owner, uint256 kindKey) public view returns (uint256 tokenId, bool found) {
+        return getMostRecentValidWith(owner, kindKey, new address[](0), address(0), address(0), "");
+    }
+
+    /// @notice Shortcut: only credentials from an issuer in `issuers` count.
+    function getMostRecentValidWith(address owner, uint256 kindKey, address[] memory issuers)
+        public
+        view
+        returns (uint256 tokenId, bool found)
+    {
+        return getMostRecentValidWith(owner, kindKey, issuers, address(0), address(0), "");
+    }
+
+    /// @notice Shortcut: only credentials naming `scope`.
+    function getMostRecentValidWith(address owner, uint256 kindKey, address scope)
+        public
+        view
+        returns (uint256 tokenId, bool found)
+    {
+        return getMostRecentValidWith(owner, kindKey, new address[](0), scope, address(0), "");
     }
 
     /// @notice Admission to one SPV's offers: backs per-SPV offer-visibility entitlements (§16.2) and any
     /// onchain issuer gating.
     function hasValidWhitelistFor(address owner, address spv) public view returns (bool) {
-        return hasValidScopedCredentialOf(owner, K_SPV_WHITELIST, spv);
+        return hasValidCredentialOf(owner, K_SPV_WHITELIST, spv);
     }
 
     /// @notice A seat in the issuer's private circle within one SPV (§4.1.3A). Read apart from the whitelist
     /// so an issuer can restrict a trade to the circle without admission to the SPV standing in for it.
     function hasValidSyndicateFor(address owner, address spv) public view returns (bool) {
-        return hasValidScopedCredentialOf(owner, K_SYNDICATE, spv);
+        return hasValidCredentialOf(owner, K_SYNDICATE, spv);
     }
 
-    /// @notice Individual vs. entity from the owner's authoritative credential; UNSET when unestablished. Only
-    /// an entity can have beneficial owners to look through, so this qualifies the §3(c)(1)(A) count.
+    /// @notice Individual vs. entity; UNSET when unestablished. Only an entity can have beneficial owners to
+    /// look through, so this qualifies the §3(c)(1)(A) count.
     function getInvestorType(address owner) public view returns (InvestorType value, uint64 expiry) {
-        (uint256 tokenId, bool found) = _mostRecentValidWith(owner, K_INVESTOR_TYPE);
+        (uint256 tokenId, bool found) = getMostRecentValidWith(owner, K_INVESTOR_TYPE);
         if (!found) return (InvestorType.UNSET, 0);
         Credential storage cred = LeXcheXBadgeStorage.getCredential(tokenId);
         return (cred.investorType, cred.expiryDate);
@@ -303,7 +400,7 @@ contract LeXcheXBadge is
 
     /// @notice U.S. state of residence/organization for USStateOfResidenceCondition; empty when unestablished.
     function getUsState(address owner) public view returns (bytes2 value, uint64 expiry) {
-        (uint256 tokenId, bool found) = _mostRecentValidWith(owner, K_US_STATE);
+        (uint256 tokenId, bool found) = getMostRecentValidWith(owner, K_US_STATE);
         if (!found) return (bytes2(0), 0);
         Credential storage cred = LeXcheXBadgeStorage.getCredential(tokenId);
         return (cred.usState, cred.expiryDate);
@@ -316,64 +413,75 @@ contract LeXcheXBadge is
     function getEffectiveBeneficialOwnerCount(address owner) public view returns (uint32 value, uint64 expiry) {
         (InvestorType investorType, uint64 typeExpiry) = getInvestorType(owner);
         if (investorType == InvestorType.INDIVIDUAL) return (1, typeExpiry);
-        (uint256 tokenId, bool found) = _mostRecentValidWith(owner, K_BO_COUNT);
+        (uint256 tokenId, bool found) = getMostRecentValidWith(owner, K_BO_COUNT);
         if (!found) return (0, 0);
         Credential storage cred = LeXcheXBadgeStorage.getCredential(tokenId);
         return (cred.beneficialOwnerCount, cred.expiryDate);
     }
 
-    /// @notice Generic programmable payload from the owner's authoritative credential; empty when none. The
-    /// badge never interprets it — downstream programs/conditions do, gated by K_DATA.
+    /// @notice Generic programmable payload; empty when none. The badge never interprets it — downstream
+    /// programs/conditions do, gated by K_DATA.
     function getData(address owner) public view returns (bytes memory value, uint64 expiry) {
-        (uint256 tokenId, bool found) = _mostRecentValidWith(owner, K_DATA);
+        (uint256 tokenId, bool found) = getMostRecentValidWith(owner, K_DATA);
         if (!found) return ("", 0);
         Credential storage cred = LeXcheXBadgeStorage.getCredential(tokenId);
         return (cred.data, cred.expiryDate);
     }
 
-    /// @notice Physical country jurisdiction from the owner's authoritative credential; empty when none.
+    /// @notice Physical country jurisdiction; empty when none.
     function getInvestorJurisdiction(address owner) public view returns (string memory value, uint64 expiry) {
-        (uint256 tokenId, bool found) = _mostRecentValidWith(owner, K_INVESTOR_JURISDICTION);
+        (uint256 tokenId, bool found) = getMostRecentValidWith(owner, K_INVESTOR_JURISDICTION);
         if (!found) return ("", 0);
         Credential storage cred = LeXcheXBadgeStorage.getCredential(tokenId);
         return (cred.investorJurisdiction, cred.expiryDate);
     }
 
-    /// @notice §3(c)(1)(A) look-through classification from the owner's authoritative credential; empty when
-    /// none. An offshore entity with any U.S. beneficial owner reads U.S. here (regulatory view) while its
-    /// physical investorJurisdiction stays foreign for CFIUS/blue-sky. Decoupled from investorJurisdiction.
+    /// @notice §3(c)(1)(A) look-through classification; empty when none. An offshore entity with any U.S.
+    /// beneficial owner reads U.S. here (regulatory view) while its physical investorJurisdiction stays
+    /// foreign for CFIUS/blue-sky. Decoupled from investorJurisdiction.
     function getLookThroughJurisdiction(address owner) public view returns (string memory value, uint64 expiry) {
-        (uint256 tokenId, bool found) = _mostRecentValidWith(owner, K_LOOKTHROUGH_JURISDICTION);
+        (uint256 tokenId, bool found) = getMostRecentValidWith(owner, K_LOOKTHROUGH_JURISDICTION);
         if (!found) return ("", 0);
         Credential storage cred = LeXcheXBadgeStorage.getCredential(tokenId);
         return (cred.lookThroughJurisdiction, cred.expiryDate);
     }
 
-    /// @notice Seasoning reference for the UI (§11.1B): the earliest ONE valid credential carrying all of
-    /// `kindKey` was issued; 0 when none does. The seasoning policy (30 vs 45 days) stays at the UI layer; this
-    /// only supplies the timestamp.
-    /// @dev Reads a multi-key ask differently from hasValidCredentialOf, on purpose. That one asks whether the
-    /// holder qualifies, which facts spread over separate credentials can answer. This asks how long something
-    /// has been true, and facts established on different dates have no one date to report — so it answers for a
-    /// single credential and reports 0 when none carries the whole set.
-    function earliestValidIssuance(address owner, uint256 kindKey) public view returns (uint64) {
-        if (kindKey == 0) return 0; // the empty key answers no fact; see _mostRecentValidWith
+    /// @notice Seasoning reference for the UI (§11.1B): when the earliest matching valid credential was issued;
+    /// 0 when none matches. The 30-vs-45-day policy stays at the UI layer; this supplies the timestamp.
+    /// @dev Takes the same filters as the reads above, so a tier's seasoning is asked the same way its
+    /// membership is. `kindKey` is tested per credential: how long something has been true is one record's
+    /// date.
+    function earliestValidIssuance(
+        address owner,
+        uint256 kindKey,
+        address[] memory issuers,
+        address scope,
+        address hook,
+        bytes memory hookData
+    ) public view returns (uint64) {
+        _requireQuery(kindKey, issuers, scope, hook);
 
         uint64 earliest = 0;
         uint256[] storage ids = LeXcheXBadgeStorage.getActiveTokens(owner);
         for (uint256 i = 0; i < ids.length; i++) {
             uint256 tokenId = ids[i];
-            if (!isValid(tokenId)) continue;
+            if (!_eligible(owner, tokenId, issuers, scope, hook, hookData)) continue;
             Credential storage cred = LeXcheXBadgeStorage.getCredential(tokenId);
-            if ((cred.asserts & kindKey) != kindKey) continue;
+            if (!_covers(cred, kindKey)) continue;
             if (earliest == 0 || cred.issuanceDate < earliest) earliest = cred.issuanceDate;
         }
         return earliest;
     }
 
+    /// @notice Shortcut: a plain fact-key ask.
+    function earliestValidIssuance(address owner, uint256 kindKey) public view returns (uint64) {
+        return earliestValidIssuance(owner, kindKey, new address[](0), address(0), address(0), "");
+    }
+
     // ── Carried over from LeXcheX v1 (interface-compatible reads, §0.10) ─────
 
     /// @notice v1-compatible read: true when the owner holds any valid credential (scans the active set)
+    // TODO should integrate v1 LexCheX as another issuer instead
     function hasValidLexCheX(address owner) public view returns (bool) {
         uint256[] storage ids = LeXcheXBadgeStorage.getActiveTokens(owner);
         for (uint256 i = 0; i < ids.length; i++) {
@@ -455,27 +563,45 @@ contract LeXcheXBadge is
     // Internals
     // ─────────────────────────────────────────────────────────────────────────
 
-    /// @dev The owner's authoritative credential for `key`: the most recent (by issuanceDate — a superseding
-    /// credential wins; ties → higher tokenId) valid credential that asserts every requested fact-key, so an
-    /// unrelated credential can neither answer the fact nor shadow one that does. Scans the (bounded) active set;
-    /// expired-but-not-yet-swept entries are skipped by isValid.
-    function _mostRecentValidWith(address owner, uint256 key) internal view returns (uint256 tokenId, bool found) {
-        // reject empty key early
-        if (key == 0) return (0, false);
+    /// @dev Per-credential eligibility shared by every read: valid, right scope, accepted issuer, accepted by
+    /// the hook.
+    /// Note it does not check the fact-key because its callers treat it differently.
+    function _eligible(
+        address owner,
+        uint256 tokenId,
+        address[] memory issuers,
+        address scope,
+        address hook,
+        bytes memory hookData
+    ) private view returns (bool) {
+        if (!isValid(tokenId)) return false;
+        Credential storage cred = LeXcheXBadgeStorage.getCredential(tokenId);
+        if (scope != address(0) && cred.scope != scope) return false;
+        if (!_fromIssuer(cred, issuers)) return false;
+        if (hook == address(0)) return true;
+        return ICredentialQueryHook(hook).matchesCredential(owner, tokenId, cred, hookData);
+    }
 
-        uint64 latest = 0;
-        uint256[] storage ids = LeXcheXBadgeStorage.getActiveTokens(owner);
-        for (uint256 i = 0; i < ids.length; i++) {
-            uint256 candidate = ids[i];
-            if (!isValid(candidate)) continue;
-            Credential storage cred = LeXcheXBadgeStorage.getCredential(candidate);
-            if ((cred.asserts & key) != key) continue; // asserts every requested key
-            if (!found || cred.issuanceDate > latest || (cred.issuanceDate == latest && candidate > tokenId)) {
-                latest = cred.issuanceDate;
-                tokenId = candidate;
-                found = true;
-            }
+    /// @dev One credential carries the whole key set. A key of 0 asks for no fact, so everything covers it.
+    function _covers(Credential storage cred, uint256 key) private view returns (bool) {
+        return key == 0 || (cred.asserts & key) == key;
+    }
+
+    /// @dev Every filter empty would answer "holds any valid credential", which hasValidLexCheX already does.
+    /// Reverting keeps a blank parameterization from quietly admitting everyone.
+    function _requireQuery(uint256 kindKey, address[] memory issuers, address scope, address hook) private pure {
+        if (kindKey == 0 && issuers.length == 0 && scope == address(0) && hook == address(0)) {
+            revert LexChexBadge_EmptyQuery();
         }
+    }
+
+    /// @dev True when `cred` came from an issuer the caller accepts; an empty list accepts any.
+    function _fromIssuer(Credential storage cred, address[] memory issuers) internal view returns (bool) {
+        if (issuers.length == 0) return true;
+        for (uint256 i = 0; i < issuers.length; i++) {
+            if (cred.issuer == issuers[i]) return true;
+        }
+        return false;
     }
 
     /// @dev `asserts` is the sole source of truth: reject empty/unknown bits, require a value for each asserted

--- a/src/creds/lexchexBadge.sol
+++ b/src/creds/lexchexBadge.sol
@@ -137,9 +137,14 @@ contract LeXcheXBadge is
         return LeXcheXBadgeStorage.badgeStorage().issuerKeys[issuer];
     }
 
-    /// @dev Non-reverting ADMIN_ROLE test. Mirrors BorgAuth's hierarchy (roles at or above the level pass)
+    /// @dev Non-reverting ADMIN_ROLE test. Asks BorgAuth rather than comparing userRoles, so an admin whose
+    /// authority comes from a role adapter counts here just as it does under onlyAdmin.
     function _isAdmin(address user) internal view returns (bool) {
-        return AUTH.userRoles(user) >= AUTH.ADMIN_ROLE();
+        try AUTH.onlyRole(AUTH.ADMIN_ROLE(), user) {
+            return true;
+        } catch {
+            return false;
+        }
     }
 
     // ─────────────────────────────────────────────────────────────────────────

--- a/src/creds/storage/lexchexBadgeStorage.sol
+++ b/src/creds/storage/lexchexBadgeStorage.sol
@@ -28,7 +28,7 @@ import {InvestorType} from "../../interfaces/ILexChexBadge.sol";
 /// `asserts` is the sole source of truth: a field is authoritative only when its key is asserted.
 struct Credential {
     uint256 asserts;                    // K_* fact-keys this credential attests; the authority axis
-    bytes32 categoryId;                 // free-form issuer label; off-chain meaning, never enforced on-chain
+    address issuer;                     // who minted it; consumers filter on this to pick whose word they take
     string investorName;                // who the credential names; display/audit only, no fact-key asserts it
     string investorJurisdiction;        // value for K_INVESTOR_JURISDICTION ("US"/"USA"/"United States" all read US)
     // value for K_LOOKTHROUGH_JURISDICTION — §3(c)(1)(A) ICA look-through classification, decoupled from the
@@ -38,7 +38,9 @@ struct Credential {
     InvestorType investorType;          // value for K_INVESTOR_TYPE
     bytes2 usState;                     // value for K_US_STATE
     uint32 beneficialOwnerCount;        // value for K_BO_COUNT
-    address scope;                      // SPV entitled by a scoped credential (K_SPV_WHITELIST / K_SYNDICATE)
+    // The SPV this credential is about. Any key may carry one and every read can filter on it;
+    // it is mandatory for SCOPED_KEYS.
+    address scope;
     uint64 issuanceDate;                // mint time; recency key (max) and §11.1B seasoning reference (min); immutable
     uint64 expiryDate;                  // isValid fails after it
     string voided;                      // non-empty = voided, with reason
@@ -56,14 +58,14 @@ library LeXcheXBadgeStorage {
     struct LeXcheXBadgeData {
         mapping(uint256 => Credential) credentials;         // per-token records (append-only; never deleted)
         uint256 supply;                                     // next token id / total minted
+        // What each issuer is allowed to say. mint rejects any asserted key outside the mask, so several
+        // operators can share one deployment without each of them being able to write every fact.
+        mapping(address => uint256) issuerKeys;             // issuer => K_* fact-keys it may assert
         // Active set = the holder's non-voided, not-yet-swept credentials. Compliance reads scan THIS (bounded)
         // instead of the full ERC-721 enumeration; void() evicts at once and sweep() evicts expired. Soulbound +
         // never-burned ⇒ the holder is stable, so a per-holder list + 1-based position index gives O(1) swap-pop.
         mapping(address => uint256[]) activeTokens;         // holder => active token ids
         mapping(uint256 => uint256) activePos;              // id => 1-based idx in activeTokens[holder]; 0 = inactive
-        // categoryId label index, kept active-only in lockstep with activeTokens (hasValidCredential scans it).
-        mapping(address => mapping(bytes32 => uint256[])) labelTokens; // holder => categoryId => active token ids
-        mapping(uint256 => uint256) labelPos;               // id => 1-based idx in labelTokens[holder][categoryId]
     }
 
     function badgeStorage() internal pure returns (LeXcheXBadgeData storage s) {
@@ -83,35 +85,26 @@ library LeXcheXBadgeStorage {
         badgeStorage().credentials[tokenId] = cred;
     }
 
-    // ── Active set + categoryId label index (both active-only) ─────────────────
+    // ── Active set (active-only) ───────────────────────────────────────────────
 
     function getActiveTokens(address holder) internal view returns (uint256[] storage) {
         return badgeStorage().activeTokens[holder];
     }
 
-    function getLabelTokens(address holder, bytes32 categoryId) internal view returns (uint256[] storage) {
-        return badgeStorage().labelTokens[holder][categoryId];
-    }
-
-    /// @dev Track a freshly-minted token in the holder's active set (and label index when categoryId is set).
-    function addActive(address holder, uint256 tokenId, bytes32 categoryId) internal {
+    /// @dev Track a freshly-minted token in the holder's active set.
+    function addActive(address holder, uint256 tokenId) internal {
         LeXcheXBadgeData storage s = badgeStorage();
         s.activeTokens[holder].push(tokenId);
         s.activePos[tokenId] = s.activeTokens[holder].length;
-        if (categoryId != bytes32(0)) {
-            s.labelTokens[holder][categoryId].push(tokenId);
-            s.labelPos[tokenId] = s.labelTokens[holder][categoryId].length;
-        }
     }
 
-    /// @dev Evict a voided/expired token from the active set and label index. Idempotent (no-op if absent).
+    /// @dev Evict a voided/expired token from the active set. Idempotent (no-op if absent).
     /// `holder` MUST be the token's owner — `activePos` is a global id→index map, so a mismatched pair would
     /// index into the wrong holder's array. Callers derive it from ownership, never from an argument.
     /// @return removed True when the token was still in the active set, so callers can count real evictions.
-    function removeActive(address holder, uint256 tokenId, bytes32 categoryId) internal returns (bool removed) {
+    function removeActive(address holder, uint256 tokenId) internal returns (bool removed) {
         LeXcheXBadgeData storage s = badgeStorage();
         removed = _swapPop(s.activeTokens[holder], s.activePos, tokenId);
-        if (categoryId != bytes32(0)) _swapPop(s.labelTokens[holder][categoryId], s.labelPos, tokenId);
     }
 
     function _swapPop(uint256[] storage arr, mapping(uint256 => uint256) storage pos, uint256 tokenId)

--- a/src/interfaces/ICredentialQueryHook.sol
+++ b/src/interfaces/ICredentialQueryHook.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.28;
+
+import {Credential} from "../creds/storage/lexchexBadgeStorage.sol";
+
+/// @title  ICredentialQueryHook - caller-supplied test for one credential
+/// @author MetaLeX Labs, Inc.
+/// @notice Lets a caller ask the badge something its fact-keys cannot express. The badge picks the eligible
+/// credentials and how matches are resolved; the hook says which ones count. Its usual job is reading
+/// `Credential.data`, whose schema the badge never learns.
+/// @dev The hook is untrusted code the caller chose. Reads are view, so it cannot change state, but one that
+/// reverts or burns gas breaks the read for whoever passed it.
+interface ICredentialQueryHook {
+    /// @param owner    Holder whose set is being scanned.
+    /// @param tokenId  Credential under test.
+    /// @param cred     Its record, passed in full so the hook needs no callback.
+    /// @param hookData The caller's payload, forwarded untouched. The hook defines its schema; the badge only
+    ///                 carries it. This is how a query carries context info.
+    /// @return True when this credential counts.
+    function matchesCredential(address owner, uint256 tokenId, Credential calldata cred, bytes calldata hookData)
+        external
+        view
+        returns (bool);
+}

--- a/src/interfaces/ILexChexBadge.sol
+++ b/src/interfaces/ILexChexBadge.sol
@@ -5,9 +5,10 @@ import "./IERC5484.sol";
 import {Credential} from "../creds/storage/lexchexBadgeStorage.sol";
 
 // Fact-keys — a credential's `asserts` bitmask is the sole authority axis. VALUE keys carry a payload in the
-// matching Credential field; STATUS keys carry no payload (asserting the key IS the truth); SCOPE keys require
-// Credential.scope (the SPV entitled). Each group owns a bit block (VALUE 0-15, STATUS 16-31, SCOPE 32+) so a
-// new key joins its own kind without reshuffling, and a key's group is legible from its position.
+// matching Credential field; STATUS keys carry no payload (asserting the key IS the truth); any credential may carry a
+// scope and every read can filter on it, however, it does not always make sense to scope certain value keys (ex. K_US_STATE),
+// and the downstream consumer (ex. getUsState) might ignore the scope altogether for the same reason.
+// Each group owns a bit block (VALUE 0-15, STATUS 16-31, SCOPE 32+) so a new key joins its own kind without reshuffling.
 uint256 constant K_INVESTOR_TYPE           = 1 << 0;   // Individual / entity
 uint256 constant K_INVESTOR_JURISDICTION   = 1 << 1;   // physical country of residence/organization
 uint256 constant K_LOOKTHROUGH_JURISDICTION = 1 << 2;   // §3(c)(1)(A) look-through classification
@@ -23,9 +24,9 @@ uint256 constant K_NON_US          = 1 << 20;          // Reg S (§6.5): the hol
 
 uint256 constant STATUS_KEYS = K_ACCREDITED | K_QP | K_QIB | K_BAD_ACTOR_CLEAR | K_NON_US;
 
-// SCOPE keys. A whitelist admits the holder to one SPV's offers (§16.2); a syndicate seats them in that
-// issuer's private circle (§4.1.3A). Separate grants an issuer makes for separate reasons, so neither key
-// ever satisfies the other, and each names the SPV it entitles in Credential.scope.
+// SCOPE keys — meaningless without an SPV, so mint rejects them without one. A whitelist admits the holder to
+// one SPV's offers (§16.2); a syndicate seats them in that issuer's private circle (§4.1.3A). Separate grants
+// an issuer makes for separate reasons, so neither key ever satisfies the other.
 uint256 constant K_SPV_WHITELIST = 1 << 32;
 uint256 constant K_SYNDICATE     = 1 << 33;
 
@@ -71,8 +72,13 @@ interface ILexChexBadge is IERC5484 {
     /// change: the credential stopped counting back at its expiryDate, which may be long before this event.
     /// Read it to track active-set size (the keeper's workload) and to confirm a sweep transaction did work.
     event CredentialSwept(address indexed owner, uint256 indexed tokenId);
+    /// @notice An issuer's authority changed. `keys` is the complete set it may assert from now on, not a
+    /// delta — read it as a replacement.
+    event IssuerKeysUpdated(address indexed issuer, uint256 keys);
 
     error LexChexBadge_SoulBound();
+    error LexChexBadge_KeysNotAuthorized(address issuer, uint256 keys);
+    error LexChexBadge_EmptyQuery();
     error LexChexBadge_TokenDoesNotExist();
     error LexChexBadge_InvalidExpiry();
     error LexChexBadge_BadAsserts();
@@ -81,6 +87,15 @@ interface ILexChexBadge is IERC5484 {
     error LexChexBadge_MissingVoidReason();
     error LexChexBadge_BoCountRequiresEntity();
     error LexChexBadge_NoValidCredential();
+
+    // ── Issuing authority ────────────────────────────────────────────────────
+    /// @notice Sets the complete set of fact-keys `issuer` may assert. The grant is the whole authority to
+    /// issue — no BorgAuth role goes with it, so a delegate cannot re-delegate. Admin-set, and a grant
+    /// outlives the admin that made it: revoking an admin does not revoke what it delegated.
+    function setIssuerKeys(address issuer, uint256 keys) external;
+    /// @notice The fact-keys `issuer` was granted; 0 means it cannot mint. Admins run the deployment and are
+    /// not listed, so read this as the authority of every issuer other than the operator itself.
+    function issuerKeys(address issuer) external view returns (uint256);
 
     // ── Lifecycle ────────────────────────────────────────────────────────────
     function mint(address to, Credential memory cred) external returns (uint256 tokenId);
@@ -100,14 +115,54 @@ interface ILexChexBadge is IERC5484 {
 
     // ── Validity reads (issued, not voided, not expired) ─────────────────────
     function isValid(uint256 tokenId) external view returns (bool);
-    /// @notice True when the owner holds a valid credential carrying the free-form issuer label `categoryId`.
-    function hasValidCredential(address owner, bytes32 categoryId) external view returns (bool);
-    /// @notice True when the owner's valid credentials together assert every fact-key in `kindKey` (K_* status/
-    /// kind keys). Note they do not have to live in the same badge token.
+    // Both reads below walk the holder's active set with the same four filters, each off by default:
+    // `kindKey` (0 asks for no fact), `issuers` (empty accepts any), `scope` (the SPV an entitlement names) and
+    // `hook` (ICredentialQueryHook consulted per credential), plus `hookData`, the hook's own payload.
+    // A shortcut is the full form with the rest left empty. All four filters empty reverts; use hasValidLexCheX.
+
+    /// @notice True when the owner's valid credentials TOGETHER cover `kindKey`, counting only those that clear
+    /// the issuer, scope and hook filters.
+    /// @dev Keys add up across credentials, so facts attested separately still qualify the holder. The filters
+    /// apply per credential, keeping a holder who is two things at once true for both.
+    function hasValidCredentialOf(
+        address owner,
+        uint256 kindKey,
+        address[] memory issuers,
+        address scope,
+        address hook,
+        bytes memory hookData
+    ) external view returns (bool);
+    /// @notice Shortcut: a plain fact-key ask.
     function hasValidCredentialOf(address owner, uint256 kindKey) external view returns (bool);
-    /// @notice True when the owner holds a valid credential granting scoped entitlement `scopeKey` for `spv`.
-    /// An entitlement granted for another SPV never answers here.
-    function hasValidScopedCredentialOf(address owner, uint256 scopeKey, address spv) external view returns (bool);
+    /// @notice Shortcut: only credentials from an issuer in `issuers` count.
+    function hasValidCredentialOf(address owner, uint256 kindKey, address[] memory issuers) external view returns (bool);
+    /// @notice Shortcut: only credentials naming `scope`, so an entitlement answers for its own SPV.
+    function hasValidCredentialOf(address owner, uint256 kindKey, address scope) external view returns (bool);
+
+    /// @notice The owner's authoritative credential: the most recent valid one that covers `kindKey` on its own
+    /// and clears every filter. Use it when the matches contradict each other, like two different U.S. states;
+    /// for membership use hasValidCredentialOf.
+    function getMostRecentValidWith(
+        address owner,
+        uint256 kindKey,
+        address[] memory issuers,
+        address scope,
+        address hook,
+        bytes memory hookData
+    ) external view returns (uint256 tokenId, bool found);
+    /// @notice Shortcut: a plain fact-key ask.
+    function getMostRecentValidWith(address owner, uint256 kindKey) external view returns (uint256 tokenId, bool found);
+    /// @notice Shortcut: only credentials from an issuer in `issuers` count.
+    function getMostRecentValidWith(address owner, uint256 kindKey, address[] memory issuers)
+        external
+        view
+        returns (uint256 tokenId, bool found);
+    /// @notice Shortcut: only credentials naming `scope`.
+    function getMostRecentValidWith(address owner, uint256 kindKey, address scope)
+        external
+        view
+        returns (uint256 tokenId, bool found);
+
     function hasValidWhitelistFor(address owner, address spv) external view returns (bool);
     /// @notice True when the owner holds a valid syndicate seat in `spv`'s circle. Never satisfied by a
     /// whitelist credential, nor by a syndicate seat in another SPV.
@@ -135,6 +190,15 @@ interface ILexChexBadge is IERC5484 {
     /// @notice Seasoning reference (§11.1B): when the earliest valid credential carrying ALL of `kindKey` was
     /// issued. Note all kindKey specified must live on the same badge token to qualify
     function earliestValidIssuance(address owner, uint256 kindKey) external view returns (uint64);
+    /// @notice Same, with the filters, so a tier's seasoning is asked the same way its membership is.
+    function earliestValidIssuance(
+        address owner,
+        uint256 kindKey,
+        address[] memory issuers,
+        address scope,
+        address hook,
+        bytes memory hookData
+    ) external view returns (uint64);
 
     // ── Carried over from LeXcheX v1 ─────────────────────────────────────────
     function hasValidLexCheX(address owner) external view returns (bool);

--- a/src/libs/conditions/secondary/LegionSoulboundCondition.sol
+++ b/src/libs/conditions/secondary/LegionSoulboundCondition.sol
@@ -7,32 +7,50 @@ import "./SecondaryTradingConditionBase.sol";
 import "./BadgeScopedCondition.sol";
 import "../../auth.sol";
 import "../../../interfaces/ILexChexBadge.sol";
+import {Credential} from "../../../creds/storage/lexchexBadgeStorage.sol";
 import {Offer} from "../../../interfaces/ISecondaryTradeStorage.sol";
 
-/// @title  LegionSoulboundCondition - issuer-specific credential category/tier gate
+/// @notice Legion's membership ladder, stored in `Credential.data`. The badge never learns what the bytes
+/// mean. Stands in for whatever ladder a real issuer runs.
+enum LegionTier {
+    NONE,
+    PROSPECT,
+    MEMBER,
+    LEAD
+}
+
+/// @title  LegionSoulboundCondition - issuer circle gate: seat plus rank
 /// @author MetaLeX Labs, Inc.
-/// @notice Shared singleton, configured per SPV. Gates on an issuer's own credential label — syndicate
-/// circles, non-accredited tiers — which generic credentials do not capture. Each SPV names the label its
-/// parties must hold and whether the seller is checked too. An SPV whose operator runs its own LeXcheXBadge
-/// layer is pointed at it through the per-SPV badge override.
+/// @notice Shared singleton, configured per SPV. Wants a seat in one issuer's circle and a minimum rank on
+/// its ladder — "MEMBER or better", not just "in the circle". For membership alone, name the lowest rung.
+/// An SPV running its own badge layer is pointed at it through the per-SPV override.
+/// @dev A qualifying credential carries both keys on one record: K_SYNDICATE scoped to this SPV (the seat)
+/// and K_DATA (the rank). A rank is a value, not a flag — two of them contradict — so the badge resolves the
+/// holder's current seat with getMostRecentValidWith, and the rank on THAT one is compared to the bar. A
+/// holder demoted by a newer seat reads as demoted even if the old seat was never voided.
 contract LegionSoulboundCondition is SecondaryTradingConditionBase, UUPSUpgradeable, BadgeScopedCondition {
+    /// @notice What a qualifying credential must assert, on one record.
+    uint256 private constant SEAT_AND_RANK = K_SYNDICATE | K_DATA;
+
     struct SpvConfig {
-        bytes32 requiredCategoryId;  // issuer label the party must hold; zero = not configured
+        LegionTier minTier;  // lowest rank that clears the gate; NONE = not configured
         bool applyToSeller;
     }
 
     error InvalidSpv();
-    error InvalidCategory();
+    error InvalidTier();
 
-    event ConfigUpdated(address indexed spv, bytes32 requiredCategoryId, bool applyToSeller);
+    event ConfigUpdated(address indexed spv, LegionTier minTier, bool applyToSeller);
+    event IssuersUpdated(address[] issuers);
 
     struct LegionSoulboundStorage {
         mapping(address => SpvConfig) configs;
+        address[] issuers; // tier credentials must come from one of these; empty accepts any issuer
     }
 
     bytes32 private constant STORAGE_POSITION = keccak256("metalex.condition.secondary.legion-soulbound.storage.v1");
 
-    // Upgrade notes: reduced gap to account for the contract's variables (50 - 1 = 49)
+    // Upgrade notes: reduced gap to account for the contract's variables (50 - 2 = 48)
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -45,13 +63,19 @@ contract LegionSoulboundCondition is SecondaryTradingConditionBase, UUPSUpgradea
         __BadgeScopedCondition_init(_defaultBadge);
     }
 
-    /// @notice Sets an SPV's circle requirement; only the SPV's own BorgAuth admin
-    function setConfig(address spv, bytes32 _requiredCategoryId, bool _applyToSeller) external {
+    /// @notice Sets an SPV's tier requirement; only the SPV's own BorgAuth admin
+    function setConfig(address spv, LegionTier _minTier, bool _applyToSeller) external {
         if (spv == address(0)) revert InvalidSpv();
-        if (_requiredCategoryId == bytes32(0)) revert InvalidCategory();
+        if (_minTier == LegionTier.NONE) revert InvalidTier();
         _requireAuthAdmin(spv);
-        _legionStorage().configs[spv] = SpvConfig({requiredCategoryId: _requiredCategoryId, applyToSeller: _applyToSeller});
-        emit ConfigUpdated(spv, _requiredCategoryId, _applyToSeller);
+        _legionStorage().configs[spv] = SpvConfig({minTier: _minTier, applyToSeller: _applyToSeller});
+        emit ConfigUpdated(spv, _minTier, _applyToSeller);
+    }
+
+    /// @notice Whose seats count; empty accepts any issuer's.
+    function updateIssuers(address[] calldata _issuers) external onlyAdmin {
+        _legionStorage().issuers = _issuers;
+        emit IssuersUpdated(_issuers);
     }
 
     function checkCondition(
@@ -63,25 +87,56 @@ contract LegionSoulboundCondition is SecondaryTradingConditionBase, UUPSUpgradea
         Offer memory offer = dealManager.getOffer(offerId);
         SpvConfig storage config = _legionStorage().configs[offer.spvAddress];
 
-        // Attached but never configured. There is no circle to be a member of, and silence is not a finding
-        // that none applies, so nothing passes until the GP names one.
-        if (config.requiredCategoryId == bytes32(0)) return false;
+        // Never configured: no rank to have reached, so nothing passes until the GP names one.
+        if (config.minTier == LegionTier.NONE) return false;
 
         (address seller, address buyer,) = _resolveParties(dealManager, offer, agreementId);
         ILexChexBadge badge = badgeFor(offer.spvAddress);
 
-        if (buyer != address(0) && !badge.hasValidCredential(buyer, config.requiredCategoryId)) {
+        if (buyer != address(0) && !_holds(badge, buyer, offer.spvAddress, config.minTier)) {
             return false;
         }
-        if (config.applyToSeller && seller != address(0) && !badge.hasValidCredential(seller, config.requiredCategoryId)) {
+        if (config.applyToSeller && seller != address(0) && !_holds(badge, seller, offer.spvAddress, config.minTier)) {
             return false;
         }
         return true;
     }
 
-    /// @notice An SPV's circle requirement
+    /// @notice How a rank goes into `Credential.data`. Issuers mint through it so both sides agree.
+    function encodeTier(LegionTier tier) public pure returns (bytes memory) {
+        return abi.encode(uint256(tier));
+    }
+
+    /// @notice An SPV's tier requirement
     function configs(address spv) public view returns (SpvConfig memory) {
         return _legionStorage().configs[spv];
+    }
+
+    /// @notice Issuers whose tier credentials this gate accepts; empty means any.
+    function issuers() public view returns (address[] memory) {
+        return _legionStorage().issuers;
+    }
+
+    /// @dev The party's current rank in this SPV's circle, tested against the bar. `scope` keeps seats from
+    /// other SPVs out.
+    /// A rank the gate cannot read is no rank, so an unreadable newest seat blocks rather than letting an
+    /// older one answer in its place.
+    function _holds(ILexChexBadge badge, address party, address spv, LegionTier required)
+        private
+        view
+        returns (bool)
+    {
+        (uint256 tokenId, bool found) =
+            badge.getMostRecentValidWith(party, SEAT_AND_RANK, _legionStorage().issuers, spv, address(0), "");
+        if (!found) return false;
+        return _tierOf(badge.getCredential(tokenId).data) >= uint256(required);
+    }
+
+    /// @dev The rank in a payload; 0 when it is not one this gate wrote.
+    function _tierOf(bytes memory data) private pure returns (uint256) {
+        if (data.length != 32) return 0;
+        uint256 tier = abi.decode(data, (uint256));
+        return tier > uint256(type(LegionTier).max) ? 0 : tier;
     }
 
     function _legionStorage() private pure returns (LegionSoulboundStorage storage $) {

--- a/src/libs/conditions/secondary/LexChexBadgeKindCondition.sol
+++ b/src/libs/conditions/secondary/LexChexBadgeKindCondition.sol
@@ -25,14 +25,20 @@ import {Offer} from "../../../interfaces/ISecondaryTradeStorage.sol";
 ///
 /// The first four are statuses, which follow the party anywhere. The last two are entitlements granted per
 /// SPV, so they only count for the SPV the offer belongs to.
+///
+/// Any parameterization can also name the issuers it accepts (updateIssuers); empty accepts any. A gate for
+/// one operator's own circle — an issuer tier, a non-accredited tier — is K_SYNDICATE plus that operator's
+/// address, because a shared deployment lets other issuers grant a seat in the same SPV.
 contract LexChexBadgeKindCondition is SecondaryTradingConditionBase, UUPSUpgradeable, BadgeScopedCondition {
     error InvalidKindKey();
 
     event ParametersUpdated(uint256 kindKey, bool checkSeller);
+    event IssuersUpdated(address[] issuers);
 
     struct LexChexBadgeKindStorage {
         uint256 kindKey;
         bool checkSeller;
+        address[] issuers; // credentials must come from one of these; empty accepts any issuer
     }
 
     bytes32 private constant STORAGE_POSITION = keccak256("metalex.condition.secondary.lexchex-badge-kind.storage.v1");
@@ -70,7 +76,8 @@ contract LexChexBadgeKindCondition is SecondaryTradingConditionBase, UUPSUpgrade
 
     /// @dev Keys this gate can enforce: one or more status facts, or exactly one entitlement. The rest are
     /// wiring slips —
-    ///  - empty: the badge rejects an empty key, so every trade is blocked
+    ///  - empty: asks the badge for no fact at all, which without a query hook would admit any credentialed
+    ///    holder — rejected here so a blank parameterization cannot fail open
     ///  - a value key: asks if a fact was recorded, not if the party qualifies
     ///  - an undefined bit: matches nothing, so every trade is blocked
     ///  - status and entitlement mixed: no one credential answers both
@@ -99,12 +106,25 @@ contract LexChexBadgeKindCondition is SecondaryTradingConditionBase, UUPSUpgrade
         return true;
     }
 
+    /// @notice Restricts which issuers' credentials count; empty accepts any. Set it when the gate must name a
+    /// credentialing operator rather than take any issuer's word — an issuer's own circle is the usual case.
+    function updateIssuers(address[] calldata _issuers) external onlyAdmin {
+        _kindStorage().issuers = _issuers;
+        emit IssuersUpdated(_issuers);
+    }
+
+    /// @notice Issuers whose credentials this gate accepts; empty means any.
+    function issuers() public view returns (address[] memory) {
+        return _kindStorage().issuers;
+    }
+
     /// @dev A status follows the party anywhere. An entitlement is granted per SPV, so it only counts for the
-    /// SPV this offer belongs to.
+    /// SPV this offer belongs to. Either way the issuer filter decides whose word the gate takes.
     function _holds(ILexChexBadge badge, address party, address spv) private view returns (bool) {
-        uint256 key = _kindStorage().kindKey;
-        if ((key & SCOPED_KEYS) != 0) return badge.hasValidScopedCredentialOf(party, key, spv);
-        return badge.hasValidCredentialOf(party, key);
+        LexChexBadgeKindStorage storage $ = _kindStorage();
+        // An entitlement only counts for the SPV it names. A status carries no scope, so none is asked for.
+        address scope = ($.kindKey & SCOPED_KEYS) != 0 ? spv : address(0);
+        return badge.hasValidCredentialOf(party, $.kindKey, $.issuers, scope, address(0), "");
     }
 
     /// @notice The status fact-key or entitlement this gate requires

--- a/test/DealManagerSecondaryTradeExemptionPathwayTest.t.sol
+++ b/test/DealManagerSecondaryTradeExemptionPathwayTest.t.sol
@@ -16,8 +16,16 @@ import {IDealManager} from "../src/interfaces/IDealManager.sol";
 import {IERC5484} from "../src/interfaces/IERC5484.sol";
 import {BorgAuth} from "../src/libs/auth.sol";
 import {LeXcheXBadge} from "../src/creds/lexchexBadge.sol";
-import {K_INVESTOR_TYPE, K_INVESTOR_JURISDICTION, K_US_STATE, K_ACCREDITED, K_QIB, K_NON_US, InvestorType}
-    from "../src/interfaces/ILexChexBadge.sol";
+import {
+    K_INVESTOR_TYPE,
+    K_INVESTOR_JURISDICTION,
+    K_US_STATE,
+    K_ACCREDITED,
+    K_QIB,
+    K_NON_US,
+    K_SYNDICATE,
+    InvestorType
+} from "../src/interfaces/ILexChexBadge.sol";
 import {Credential} from "../src/creds/storage/lexchexBadgeStorage.sol";
 import {FundInterestData} from "../src/storage/extensions/FundInterestExtension.sol";
 import {
@@ -35,7 +43,6 @@ import {
 import {EligibilityCondition} from "../src/libs/conditions/secondary/EligibilityCondition.sol";
 import {HolderCapCondition} from "../src/libs/conditions/secondary/HolderCapCondition.sol";
 import {USStateOfResidenceCondition} from "../src/libs/conditions/secondary/USStateOfResidenceCondition.sol";
-import {LegionSoulboundCondition} from "../src/libs/conditions/secondary/LegionSoulboundCondition.sol";
 import {HoldingPeriodCondition} from "../src/libs/conditions/secondary/HoldingPeriodCondition.sol";
 import {LexChexBadgeKindCondition} from "../src/libs/conditions/secondary/LexChexBadgeKindCondition.sol";
 import {RegSDistributionComplianceCondition} from "../src/libs/conditions/secondary/RegSDistributionComplianceCondition.sol";
@@ -100,7 +107,6 @@ contract DealManagerSecondaryTradeExemptionPathwayTest is Test {
     bytes32 constant CAT_ACCREDITED = keccak256("cat.accredited");
     bytes32 constant CAT_QIB = keccak256("cat.qib");
     bytes32 constant CAT_NONUS = keccak256("cat.nonus");
-    bytes32 constant CAT_LEGION = keccak256("cat.legion");
 
     bytes2 constant CA = "CA";
 
@@ -113,6 +119,9 @@ contract DealManagerSecondaryTradeExemptionPathwayTest is Test {
     address public seller;
     uint256 public sellerKey;
     address public keeper;
+    // A second credentialing operator on the same badge, granted K_SYNDICATE and no BorgAuth role. Its
+    // credentials are what the circle gate accepts; an identical one from anyone else does not clear it.
+    address public legionIssuer;
 
     SecERC20Mock public paymentToken;
     BorgAuth public auth;
@@ -128,7 +137,7 @@ contract DealManagerSecondaryTradeExemptionPathwayTest is Test {
     EligibilityCondition public eligibility;
     HolderCapCondition public holderCap;
     USStateOfResidenceCondition public usState;
-    LegionSoulboundCondition public legion;
+    LexChexBadgeKindCondition public legion;
     HoldingPeriodCondition public holdingPeriod;
     LexChexBadgeKindCondition public accredited;
     LexChexBadgeKindCondition public qib;
@@ -149,6 +158,7 @@ contract DealManagerSecondaryTradeExemptionPathwayTest is Test {
         (owner, ownerKey) = makeAddrAndKey("owner");
         (seller, sellerKey) = makeAddrAndKey("seller");
         keeper = makeAddr("keeper");
+        legionIssuer = makeAddr("legion.issuer");
 
         paymentToken = new SecERC20Mock();
         auth = new BorgAuth(owner);
@@ -200,7 +210,7 @@ contract DealManagerSecondaryTradeExemptionPathwayTest is Test {
         vm.prank(owner);
         auth.updateRole(address(dm), 99);
 
-        _deployBadgeAndCategories();
+        _deployBadge();
         _deployConditions();
         _wireConditions();
 
@@ -236,7 +246,7 @@ contract DealManagerSecondaryTradeExemptionPathwayTest is Test {
         vm.startPrank(owner);
         eligibility.setClearance(address(corp), seller, true);
         holderCap.setConfig(address(corp), HolderCapCondition.IcaException.SECTION_3C1, uint256(100), false, false);
-        legion.setConfig(address(corp), CAT_LEGION, false);
+        legion.updateIssuers(_list(legionIssuer));
         vm.stopPrank();
         _setRule144Info(true);
         _setSection4a7Package(true);
@@ -1059,7 +1069,7 @@ contract DealManagerSecondaryTradeExemptionPathwayTest is Test {
     // Setup helpers
     // ─────────────────────────────────────────────────────────────────────────
 
-    function _deployBadgeAndCategories() internal {
+    function _deployBadge() internal {
         badge = LeXcheXBadge(
             address(
                 new ERC1967Proxy(
@@ -1068,6 +1078,10 @@ contract DealManagerSecondaryTradeExemptionPathwayTest is Test {
                 )
             )
         );
+        // Legion issues on the shared badge, trusted for circle seats only. The grant is all it gets: no
+        // BorgAuth role, so it picks up none of the admin power this auth carries over the rest of the stack.
+        vm.prank(owner);
+        badge.setIssuerKeys(legionIssuer, K_SYNDICATE);
     }
 
     function _deployConditions() internal {
@@ -1086,10 +1100,12 @@ contract DealManagerSecondaryTradeExemptionPathwayTest is Test {
                 abi.encodeCall(USStateOfResidenceCondition.initialize, (address(auth), address(badge)))
             )
         );
-        legion = LegionSoulboundCondition(
+        legion = LexChexBadgeKindCondition(
             _proxy(
-                address(new LegionSoulboundCondition()),
-                abi.encodeCall(LegionSoulboundCondition.initialize, (address(auth), address(badge)))
+                address(new LexChexBadgeKindCondition()),
+                abi.encodeCall(
+                    LexChexBadgeKindCondition.initialize, (address(auth), address(badge), K_SYNDICATE, false)
+                )
             )
         );
         holdingPeriod = HoldingPeriodCondition(
@@ -1176,7 +1192,7 @@ contract DealManagerSecondaryTradeExemptionPathwayTest is Test {
 
     function _commonBuyerSetup(address buyer, string memory jurisdiction, bytes2 state) internal {
         _mintCred(buyer, CAT_KYC, jurisdiction, state);
-        _mintCred(buyer, CAT_LEGION, jurisdiction, state);
+        _mintSyndicate(buyer);
         vm.prank(owner);
         eligibility.setClearance(address(corp), buyer, true);
 
@@ -1185,20 +1201,19 @@ contract DealManagerSecondaryTradeExemptionPathwayTest is Test {
         paymentToken.approve(address(dm), type(uint256).max);
     }
 
-    /// @dev Mints a credential whose facts follow the categoryId's role: CAT_KYC carries the residence anchor
-    /// (jurisdiction + state), CAT_ACCREDITED / CAT_QIB / CAT_NONUS assert the corresponding status fact-key,
-    /// and every categoryId is also written as the free-form label so the Legion issuer-tier gate matches.
+    /// @dev Mints a credential whose facts follow `cat`: CAT_KYC carries the residence anchor (jurisdiction +
+    /// state), CAT_ACCREDITED / CAT_QIB / CAT_NONUS assert the matching status fact-key. `cat` is a test-local
+    /// way to name a profile — the badge has no such notion.
     // TODO make it closer to real-world scenarios
-    function _mintCred(address to, bytes32 categoryId, string memory jurisdiction, bytes2 state) internal {
-        _mintCred(to, categoryId, jurisdiction, state, uint64(block.timestamp + 3650 days));
+    function _mintCred(address to, bytes32 cat, string memory jurisdiction, bytes2 state) internal {
+        _mintCred(to, cat, jurisdiction, state, uint64(block.timestamp + 3650 days));
     }
 
     /// @dev Overload for tests that need a credential to lapse mid-trade.
-    function _mintCred(address to, bytes32 categoryId, string memory jurisdiction, bytes2 state, uint64 expiry)
+    function _mintCred(address to, bytes32 cat, string memory jurisdiction, bytes2 state, uint64 expiry)
         internal
     {
         Credential memory cred;
-        cred.categoryId = categoryId; // free-form label (the Legion tier gate matches on it)
         cred.investorType = InvestorType.INDIVIDUAL;
         cred.investorJurisdiction = jurisdiction;
         cred.usState = state;
@@ -1206,12 +1221,24 @@ contract DealManagerSecondaryTradeExemptionPathwayTest is Test {
 
         uint256 asserts = K_INVESTOR_TYPE | K_INVESTOR_JURISDICTION;
         if (state != bytes2(0)) asserts |= K_US_STATE;
-        if (categoryId == CAT_ACCREDITED) asserts |= K_ACCREDITED;
-        else if (categoryId == CAT_QIB) asserts |= K_QIB;
-        else if (categoryId == CAT_NONUS) asserts |= K_NON_US;
+        if (cat == CAT_ACCREDITED) asserts |= K_ACCREDITED;
+        else if (cat == CAT_QIB) asserts |= K_QIB;
+        else if (cat == CAT_NONUS) asserts |= K_NON_US;
         cred.asserts = asserts;
 
         vm.prank(owner);
+        badge.mint(to, cred);
+    }
+
+    /// @dev A seat in Legion's circle for this SPV. Minted by Legion rather than the owner, because the gate
+    /// takes only Legion's word for who is in the circle.
+    function _mintSyndicate(address to) internal {
+        Credential memory cred;
+        cred.asserts = K_SYNDICATE;
+        cred.scope = address(corp);
+        cred.expiryDate = uint64(block.timestamp + 3650 days);
+
+        vm.prank(legionIssuer);
         badge.mint(to, cred);
     }
 

--- a/test/LeXcheXBadge.t.sol
+++ b/test/LeXcheXBadge.t.sol
@@ -25,6 +25,7 @@ import {
     PRESET_ENTITY_LOOKTHROUGH,
     PRESET_KYC_AML
 } from "../src/interfaces/ILexChexBadge.sol";
+import {IAuthAdapter} from "../src/interfaces/IAuthAdapter.sol";
 import {BorgAuth} from "../src/libs/auth.sol";
 import {Test} from "forge-std/Test.sol";
 import {Vm} from "forge-std/Vm.sol";
@@ -894,6 +895,23 @@ contract LeXcheXBadgeTest is Test {
 
         assertEq(badge.issuerKeys(operator), 0);
         uint256 id = _mintAs(operator, makeAddr("byAdmin"), _cred(K_ACCREDITED));
+        assertEq(badge.getCredential(id).issuer, operator);
+    }
+
+    // An operator whose admin authority comes from a BorgAuth role adapter (a Safe, a Hats tree) is an admin
+    // everywhere else on this badge, so it issues without a grant like any other. Reading userRoles directly
+    // would miss it and demote it to an ungranted issuer.
+    function test_Mint_AdapterBackedAdminNeedsNoGrant() public {
+        address operator = makeAddr("adapterOperator");
+        AdminAdapter adapter = new AdminAdapter(operator);
+        uint256 adminRole = auth.ADMIN_ROLE();
+        vm.prank(owner);
+        auth.setRoleAdapter(adminRole, address(adapter));
+
+        assertEq(auth.userRoles(operator), 0, "authority is the adapter's, not a stored role");
+        assertEq(badge.issuerKeys(operator), 0);
+
+        uint256 id = _mintAs(operator, makeAddr("byAdapterAdmin"), _cred(K_ACCREDITED));
         assertEq(badge.getCredential(id).issuer, operator);
     }
 
@@ -1923,6 +1941,20 @@ contract RevertingHook is ICredentialQueryHook {
 
     function matchesCredential(address, uint256, Credential calldata, bytes calldata) external pure returns (bool) {
         revert HookFailed();
+    }
+}
+
+/// @notice A BorgAuth role adapter that grants ADMIN_ROLE to one address, standing in for the external
+/// authority (a Safe, a Hats tree) an operator can point BorgAuth at instead of storing the role.
+contract AdminAdapter is IAuthAdapter {
+    address immutable ADMIN;
+
+    constructor(address admin) {
+        ADMIN = admin;
+    }
+
+    function isAuthorized(address user) external view returns (uint256) {
+        return user == ADMIN ? 98 : 0;
     }
 }
 

--- a/test/LeXcheXBadge.t.sol
+++ b/test/LeXcheXBadge.t.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.28;
 import {ERC1967Proxy} from "../dependencies/openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {LeXcheXBadge} from "../src/creds/lexchexBadge.sol";
 import {Credential} from "../src/creds/storage/lexchexBadgeStorage.sol";
+import {ICredentialQueryHook} from "../src/interfaces/ICredentialQueryHook.sol";
 import {IERC5484} from "../src/interfaces/IERC5484.sol";
 import {
     ILexChexBadge,
@@ -52,20 +53,25 @@ import {Vm} from "forge-std/Vm.sol";
 ///
 /// What those facts mean for the §3(c)(1)(A) holder count is covered in LookThroughPolicy.t.sol.
 contract LeXcheXBadgeTest is Test {
-    bytes32 constant LABEL_LEGION = keccak256("label.legion");
-
     // Local copies of the emitted events (the indexer surface asserted by the event tests).
     event CredentialIssued(address indexed owner, uint256 indexed tokenId, Credential cred);
     event CredentialVoided(address indexed owner, uint256 indexed tokenId, string reason);
     event CredentialSwept(address indexed owner, uint256 indexed tokenId);
     event Issued(address indexed from, address indexed to, uint256 indexed tokenId, IERC5484.BurnAuth burnAuth);
 
+    // Legion's tier ids. Only the hook knows what these mean; the badge stores 32 opaque bytes.
+    bytes32 constant TIER1 = keccak256("legion.tier.1");
+    bytes32 constant TIER2 = keccak256("legion.tier.2");
+    bytes32 constant TIER3 = keccak256("legion.tier.3");
+
     address owner;
+    BorgAuth auth;
     LeXcheXBadge badge;
+    TierQueryHook tierHook; // one deployment; every tier question is a payload (see _tierHook)
 
     function setUp() public {
         owner = makeAddr("owner");
-        BorgAuth auth = new BorgAuth(owner);
+        auth = new BorgAuth(owner);
         badge = LeXcheXBadge(
             address(
                 new ERC1967Proxy(address(new LeXcheXBadge()), abi.encodeCall(LeXcheXBadge.initialize, (address(auth))))
@@ -371,46 +377,6 @@ contract LeXcheXBadgeTest is Test {
 
     // ── Existence / entitlement reads ─────────────────────────────────────────
 
-    // hasValidCredential matches the free-form issuer label verbatim. The label is never interpreted: it
-    // neither gates nor shadows the credential's fact reads.
-    function test_HasValidCredential_LabelMatch() public {
-        address holder = makeAddr("legion");
-        Credential memory c = _kyc("US", "CA");
-        c.categoryId = LABEL_LEGION;
-        _mint(holder, c);
-        assertTrue(badge.hasValidCredential(holder, LABEL_LEGION));
-        assertFalse(badge.hasValidCredential(holder, keccak256("label.other")));
-        assertFalse(badge.hasValidCredential(makeAddr("nobody2"), LABEL_LEGION));
-        assertEq(_readUsState(holder), bytes2("CA")); // facts resolve regardless of the label
-    }
-
-    // An unlabelled credential carries no label, so the empty label matches nothing — it is not a catch-all.
-    function test_HasValidCredential_UnlabelledMatchesNoLabel() public {
-        address holder = makeAddr("unlabelled");
-        _mint(holder, _kyc("US", "CA")); // categoryId left zero
-        assertFalse(badge.hasValidCredential(holder, bytes32(0)));
-        assertFalse(badge.hasValidCredential(holder, LABEL_LEGION));
-        assertTrue(badge.hasValidLexCheX(holder)); // still a valid credential, just not label-addressable
-    }
-
-    function test_HasValidCredential_DeniedWhenExpiredOrVoided() public {
-        address expired = makeAddr("exp");
-        Credential memory shortLived = _kyc("US", "CA");
-        shortLived.categoryId = LABEL_LEGION;
-        shortLived.expiryDate = uint64(block.timestamp + 1 days);
-        _mint(expired, shortLived);
-        vm.warp(block.timestamp + 2 days);
-        assertFalse(badge.hasValidCredential(expired, LABEL_LEGION));
-
-        address voided = makeAddr("vd");
-        Credential memory c = _kyc("US", "CA");
-        c.categoryId = LABEL_LEGION;
-        uint256 id = _mint(voided, c);
-        vm.prank(owner);
-        badge.void(id, "revoked");
-        assertFalse(badge.hasValidCredential(voided, LABEL_LEGION));
-    }
-
     // hasValidCredentialOf resolves a status fact-key: the asserted key admits, another is rejected.
     function test_HasValidCredentialOf_StatusKey() public {
         address holder = makeAddr("acc");
@@ -446,12 +412,19 @@ contract LeXcheXBadgeTest is Test {
         assertGt(uint256(badge.earliestValidIssuance(both, K_QP | K_QIB)), 0);
     }
 
-    function test_HasValidCredentialOf_EmptyKeyIsRejected() public {
+    // A key of nothing with no hook and no issuer list filters nothing, so it would quietly mean "holds any
+    // credential at all". That is hasValidLexCheX's job, and asking it this way is a wiring slip — rejected so
+    // a blank parameterization cannot fail open.
+    function test_HasValidCredentialOf_EmptyQueryIsRejected() public {
         address holder = makeAddr("emptyKey");
         _mint(holder, _cred(K_ACCREDITED));
         assertTrue(badge.hasValidLexCheX(holder)); // the holder does have an active badge
-        assertFalse(badge.hasValidCredentialOf(holder, 0)); // but no credential asserts nothing
-        assertEq(uint256(badge.earliestValidIssuance(holder, 0)), 0);
+
+        vm.expectRevert(ILexChexBadge.LexChexBadge_EmptyQuery.selector);
+        badge.hasValidCredentialOf(holder, 0);
+
+        vm.expectRevert(ILexChexBadge.LexChexBadge_EmptyQuery.selector);
+        badge.earliestValidIssuance(holder, 0);
     }
 
     // A status gate closes on expiry and on void, the same way a value fact does.
@@ -676,27 +649,6 @@ contract LeXcheXBadgeTest is Test {
         assertFalse(badge.hasValidCredentialOf(holder, K_BAD_ACTOR_CLEAR));
     }
 
-    // The categoryId label index is evicted in lockstep with the active set: voiding one labelled credential
-    // must leave the holder's other credential under that label findable.
-    function test_ActiveSet_LabelIndexEvictedInLockstep() public {
-        address holder = makeAddr("labelIdx");
-        Credential memory first = _kyc("US", "CA");
-        first.categoryId = LABEL_LEGION;
-        Credential memory second = _kyc("US", "NY");
-        second.categoryId = LABEL_LEGION;
-        uint256 id1 = _mint(holder, first);
-        uint256 id2 = _mint(holder, second);
-
-        vm.prank(owner);
-        badge.void(id1, "superseded"); // head of the label index; id2 swaps into its slot
-        assertTrue(badge.hasValidCredential(holder, LABEL_LEGION));
-
-        vm.prank(owner);
-        badge.void(id2, "revoked");
-        assertFalse(badge.hasValidCredential(holder, LABEL_LEGION));
-        assertEq(badge.getActiveTokenIds(holder).length, 0);
-    }
-
     // sweep evicts only what has expired, is safe to repeat, and is a no-op for an uncredentialed holder.
     function test_Sweep_EvictsOnlyExpired_AndIsIdempotent() public {
         address holder = makeAddr("sweeper");
@@ -887,9 +839,517 @@ contract LeXcheXBadgeTest is Test {
         assertEq(uint256(badge.earliestValidIssuance(holder, K_ACCREDITED)), uint256(t0));
     }
 
+    // ── Issuing authority ─────────────────────────────────────────────────────
+    // One badge can host more than one credentialing operator. Mint rights alone are not authority: each
+    // delegate is granted a set of facts it may assert, every credential records who issued it, and a reader
+    // can insist on the issuer it trusts. Without this, letting a second operator issue anything would mean
+    // trusting it for everything.
+
+    // A delegate writes only what it was granted. It holds mint rights, so nothing but the mask stops it
+    // asserting a fact that belongs to another operator.
+    function test_IssuerKeys_DelegateLimitedToGrantedKeys() public {
+        address legion = _delegateIssuer("legion", K_SYNDICATE);
+        address holder = makeAddr("member");
+
+        Credential memory seat = _cred(K_SYNDICATE);
+        seat.scope = makeAddr("spvA");
+        _mintAs(legion, holder, seat);
+        assertTrue(badge.hasValidCredentialOf(holder, K_SYNDICATE, seat.scope));
+
+        Credential memory accredited = _cred(K_ACCREDITED);
+        vm.prank(legion);
+        vm.expectRevert(
+            abi.encodeWithSelector(ILexChexBadge.LexChexBadge_KeysNotAuthorized.selector, legion, K_ACCREDITED)
+        );
+        badge.mint(holder, accredited);
+    }
+
+    function test_IssuerKeys_GrantAloneAuthorizesIssuing() public {
+        address legion = _delegateIssuer("legionNoRole", K_ACCREDITED);
+        assertEq(auth.userRoles(legion), 0, "issues with no BorgAuth role at all");
+        _mintAs(legion, makeAddr("granted"), _cred(K_ACCREDITED));
+
+        address nobody = makeAddr("ungranted");
+        Credential memory c = _cred(K_ACCREDITED);
+        address holder = makeAddr("wouldBeAccredited");
+        vm.prank(nobody);
+        vm.expectRevert(
+            abi.encodeWithSelector(ILexChexBadge.LexChexBadge_KeysNotAuthorized.selector, nobody, K_ACCREDITED)
+        );
+        badge.mint(holder, c);
+    }
+
+    // mint records the issuer; that record is what a filtered read later consults.
+    function test_Mint_RecordsIssuer() public {
+        address legion = _delegateIssuer("legionRec", K_ACCREDITED);
+        uint256 id = _mintAs(legion, makeAddr("recorded"), _cred(K_ACCREDITED));
+        assertEq(badge.getCredential(id).issuer, legion);
+    }
+
+    // Admins run the deployment, so they issue anything without a grant.
+    function test_Mint_AdminNeedsNoGrant() public {
+        address operator = makeAddr("operator");
+        vm.prank(owner);
+        auth.updateRole(operator, 98);
+
+        assertEq(badge.issuerKeys(operator), 0);
+        uint256 id = _mintAs(operator, makeAddr("byAdmin"), _cred(K_ACCREDITED));
+        assertEq(badge.getCredential(id).issuer, operator);
+    }
+
+    // A delegate revokes only its own work. Otherwise the mask would bound what it can write but not what it
+    // can destroy, and one operator could wipe another's credentials.
+    function test_Void_DelegateCannotVoidAnotherIssuersCredential() public {
+        address legion = _delegateIssuer("legionVoid", K_SYNDICATE);
+        address holder = makeAddr("crossVoid");
+        uint256 ownerIssued = _mint(holder, _cred(K_ACCREDITED));
+
+        vm.prank(legion);
+        vm.expectRevert(abi.encodeWithSignature("BorgAuth_NotAuthorized(uint256,address)", uint256(98), legion));
+        badge.void(ownerIssued, "not yours");
+        assertTrue(badge.isValid(ownerIssued));
+
+        Credential memory seat = _cred(K_SYNDICATE);
+        seat.scope = makeAddr("spvB");
+        uint256 own = _mintAs(legion, holder, seat);
+        vm.prank(legion);
+        badge.void(own, "left the circle");
+        assertFalse(badge.isValid(own));
+    }
+
+    // The owner can still void a delegate's credential — the lever for an issuer that goes rogue.
+    function test_Void_OwnerCanVoidDelegatesCredential() public {
+        address legion = _delegateIssuer("legionRogue", K_SYNDICATE);
+        Credential memory seat = _cred(K_SYNDICATE);
+        seat.scope = makeAddr("spvC");
+        uint256 id = _mintAs(legion, makeAddr("ownerVoid"), seat);
+
+        vm.prank(owner);
+        badge.void(id, "issuer compromised");
+        assertFalse(badge.isValid(id));
+    }
+
+    // A filtered read takes only the issuer it names; the unfiltered read still takes either.
+    function test_IssuerFilter_NarrowsAStatusFact() public {
+        address legion = _delegateIssuer("legionFilter", K_ACCREDITED);
+        address holder = makeAddr("filtered");
+        _mintAs(legion, holder, _cred(K_ACCREDITED));
+
+        assertTrue(badge.hasValidCredentialOf(holder, K_ACCREDITED));
+        assertTrue(badge.hasValidCredentialOf(holder, K_ACCREDITED, _issuers(legion)));
+        assertFalse(badge.hasValidCredentialOf(holder, K_ACCREDITED, _issuers(owner)));
+    }
+
+    // An entitlement answers for the SPV it names AND the operator who granted it, so one operator's seat in
+    // an SPV does not clear a gate that takes another operator's word for that same SPV.
+    function test_IssuerFilter_NarrowsAScopedSeat() public {
+        address legion = _delegateIssuer("legionScoped", K_SYNDICATE);
+        address spv = makeAddr("spvShared");
+        address holder = makeAddr("twoCircles");
+
+        Credential memory ownerSeat = _cred(K_SYNDICATE);
+        ownerSeat.scope = spv;
+        _mint(holder, ownerSeat);
+        assertTrue(badge.hasValidCredentialOf(holder, K_SYNDICATE, spv));
+        assertFalse(badge.hasValidCredentialOf(holder, K_SYNDICATE, _issuers(legion), spv, address(0), ""));
+
+        Credential memory legionSeat = _cred(K_SYNDICATE);
+        legionSeat.scope = spv;
+        _mintAs(legion, holder, legionSeat);
+        assertTrue(badge.hasValidCredentialOf(holder, K_SYNDICATE, _issuers(legion), spv, address(0), ""));
+    }
+
+    // ── Query hooks: questions the fact-key vocabulary cannot ask ─────────────
+    // The badge picks the eligible credentials (valid, in the active set) and the resolution; a caller-supplied
+    // hook decides what counts as a match. That is how `data` becomes queryable without the badge learning any
+    // issuer's schema.
+
+    // The case that broke the earlier design: Alice holds tier1 AND tier2 at the same time and both are true,
+    // so both queries must say yes. Any read that picked one credential would have thrown a true answer away.
+    function test_Hook_ConcurrentTiersBothMatch() public {
+        address legion = _delegateIssuer("legionTiers", K_SYNDICATE | K_DATA);
+        address spv = makeAddr("spvTiers");
+        address alice = makeAddr("alice");
+
+        _seat(legion, alice, spv, abi.encode(TIER1));
+        vm.warp(block.timestamp + 30 days);
+        _seat(legion, alice, spv, abi.encode(TIER2));
+
+        assertTrue(
+            badge.hasValidCredentialOf(alice, 0, new address[](0), address(0), _tierHook(), _tier(spv, legion, TIER1)),
+            "older tier still true"
+        );
+        assertTrue(
+            badge.hasValidCredentialOf(alice, 0, new address[](0), address(0), _tierHook(), _tier(spv, legion, TIER2)),
+            "newer tier true too"
+        );
+        assertFalse(
+            badge.hasValidCredentialOf(alice, 0, new address[](0), address(0), _tierHook(), _tier(spv, legion, TIER3)),
+            "a tier she was never given"
+        );
+    }
+
+    // The hook sees the whole credential, so the SPV and the issuer are part of its test — a seat in another
+    // SPV, or the same tier from a rival operator, is not a match.
+    function test_Hook_TierIsScopedAndIssuerBound() public {
+        address legion = _delegateIssuer("legionBound", K_SYNDICATE | K_DATA);
+        address rival = _delegateIssuer("rivalBound", K_SYNDICATE | K_DATA);
+        address spv = makeAddr("spvBound");
+        address holder = makeAddr("boundHolder");
+
+        _seat(legion, holder, makeAddr("otherSpv"), abi.encode(TIER2)); // right tier, wrong SPV
+        _seat(rival, holder, spv, abi.encode(TIER2)); // right tier and SPV, wrong issuer
+
+        assertFalse(badge.hasValidCredentialOf(holder, 0, new address[](0), address(0), _tierHook(), _tier(spv, legion, TIER2)));
+        assertTrue(
+            badge.hasValidCredentialOf(holder, 0, new address[](0), address(0), _tierHook(), _tier(spv, rival, TIER2)),
+            "it is the rival's tier"
+        );
+    }
+
+    // Validity stays the badge's decision: a voided credential never reaches the hook, so even a hook that
+    // accepts everything cannot resurrect it.
+    function test_Hook_NeverSeesVoidedOrExpired() public {
+        address legion = _delegateIssuer("legionVoided", K_SYNDICATE | K_DATA);
+        address spv = makeAddr("spvVoided");
+        address holder = makeAddr("revoked");
+        uint256 id = _seat(legion, holder, spv, abi.encode(TIER1));
+
+        address anything = address(new AlwaysMatchHook());
+        assertTrue(badge.hasValidCredentialOf(holder, 0, new address[](0), address(0), anything, ""));
+
+        vm.prank(legion);
+        badge.void(id, "left the circle");
+        assertFalse(
+            badge.hasValidCredentialOf(holder, 0, new address[](0), address(0), anything, ""),
+            "voided is not eligible, whatever the hook says"
+        );
+    }
+
+    // The two resolutions answer differently on the same data, on purpose. Membership wants every match;
+    // recency wants the one that supersedes.
+    function test_Hook_AnyMatchVersusMostRecent() public {
+        address legion = _delegateIssuer("legionBoth", K_SYNDICATE | K_DATA);
+        address spv = makeAddr("spvBoth");
+        address holder = makeAddr("bothWays");
+
+        uint256 older = _seat(legion, holder, spv, abi.encode(TIER1));
+        vm.warp(block.timestamp + 30 days);
+        uint256 newer = _seat(legion, holder, spv, abi.encode(TIER2));
+
+        address anySeat = address(new AlwaysMatchHook());
+        (uint256 id, bool found) = badge.getMostRecentValidWith(holder, 0, new address[](0), address(0), anySeat, "");
+        assertTrue(found);
+        assertEq(id, newer, "recency picks the latest");
+        assertTrue(
+            badge.hasValidCredentialOf(holder, 0, new address[](0), address(0), _tierHook(), _tier(spv, legion, TIER1)),
+            "which the older one still is"
+        );
+        assertTrue(badge.isValid(older));
+    }
+
+    // The fact-key resolution, exposed. Same answer the value getters resolve to, so a caller can reach the
+    // credential instead of just the field.
+    function test_GetMostRecentValidWith_MatchesTheValueGetter() public {
+        address holder = makeAddr("relocating");
+        _mint(holder, _kyc("US", "NY"));
+        vm.warp(block.timestamp + 30 days);
+        uint256 tx_ = _mint(holder, _kyc("US", "TX"));
+
+        (uint256 id, bool found) = badge.getMostRecentValidWith(holder, K_US_STATE);
+        assertTrue(found);
+        assertEq(id, tx_);
+        assertEq(_readUsState(holder), bytes2("TX"));
+    }
+
+    // Either filter on its own is a real question; neither is a wiring slip. A hook with no key is the whole
+    // point of the hook, so it must not be caught by the empty-query guard.
+    function test_Hook_AloneIsAValidQueryButNeitherIsNot() public {
+        address legion = _delegateIssuer("legionAlone", K_SYNDICATE | K_DATA);
+        address spv = makeAddr("spvAlone");
+        address holder = makeAddr("hookOnly");
+        _seat(legion, holder, spv, abi.encode(TIER1));
+
+        assertTrue(
+            badge.hasValidCredentialOf(holder, 0, new address[](0), address(0), _tierHook(), _tier(spv, legion, TIER1)),
+            "key 0 + hook is fine"
+        );
+        assertTrue(badge.hasValidCredentialOf(holder, K_SYNDICATE), "key alone is fine");
+
+        vm.expectRevert(ILexChexBadge.LexChexBadge_EmptyQuery.selector);
+        badge.hasValidCredentialOf(holder, 0, new address[](0), address(0), address(0), "");
+
+        vm.expectRevert(ILexChexBadge.LexChexBadge_EmptyQuery.selector);
+        badge.getMostRecentValidWith(holder, 0, new address[](0), address(0), address(0), "");
+    }
+
+    // Seasoning asked the same way membership is: how long has she been tier1, not how long she has been in
+    // the circle. The later tier2 seat is a different fact and must not move the tier1 clock.
+    function test_Hook_SeasoningIsPerTier() public {
+        address legion = _delegateIssuer("legionSeason", K_SYNDICATE | K_DATA);
+        address spv = makeAddr("spvSeason");
+        address alice = makeAddr("aliceSeason");
+
+        uint256 seat1 = _seat(legion, alice, spv, abi.encode(TIER1));
+        vm.warp(block.timestamp + 90 days);
+        uint256 seat2 = _seat(legion, alice, spv, abi.encode(TIER2));
+
+        // Read the dates off the credentials rather than the test's own clock, which vm.warp does not move.
+        uint256 tier1At = uint256(badge.getCredential(seat1).issuanceDate);
+        uint256 tier2At = uint256(badge.getCredential(seat2).issuanceDate);
+        assertGt(tier2At, tier1At, "the second seat is the later one");
+
+        assertEq(
+            uint256(badge.earliestValidIssuance(alice, 0, new address[](0), address(0), _tierHook(), _tier(spv, legion, TIER1))),
+            tier1At,
+            "tier1"
+        );
+        assertEq(
+            uint256(badge.earliestValidIssuance(alice, 0, new address[](0), address(0), _tierHook(), _tier(spv, legion, TIER2))),
+            tier2At,
+            "tier2"
+        );
+        // Without the hook the question is just "in the circle", which she has been since the first seat.
+        assertEq(uint256(badge.earliestValidIssuance(alice, K_SYNDICATE)), tier1At, "circle since tier1");
+        assertEq(
+            uint256(badge.earliestValidIssuance(alice, 0, new address[](0), address(0), _tierHook(), _tier(spv, legion, TIER3))),
+            0,
+            "never held"
+        );
+    }
+
+    // All four filters on one call, which is the point of the combined form: the right fact, from the right
+    // operator, for the right SPV, at the right tier. Dropping any one of them lets a near-miss through.
+    function test_AllFiltersCompose() public {
+        address legion = _delegateIssuer("legionAll", K_SYNDICATE | K_DATA);
+        address rival = _delegateIssuer("rivalAll", K_SYNDICATE | K_DATA);
+        address spv = makeAddr("spvAll");
+        address other = makeAddr("spvOther");
+        address holder = makeAddr("nearMisses");
+
+        _seat(rival, holder, spv, abi.encode(TIER2)); // wrong issuer
+        _seat(legion, holder, other, abi.encode(TIER2)); // wrong SPV
+        _seat(legion, holder, spv, abi.encode(TIER1)); // wrong tier
+        assertFalse(
+            badge.hasValidCredentialOf(holder, K_SYNDICATE, _issuers(legion), spv, _tierHook(), _tier(spv, legion, TIER2)),
+            "three near misses, no match"
+        );
+
+        _seat(legion, holder, spv, abi.encode(TIER2)); // all four line up
+        assertTrue(
+            badge.hasValidCredentialOf(holder, K_SYNDICATE, _issuers(legion), spv, _tierHook(), _tier(spv, legion, TIER2))
+        );
+    }
+
+    // The two filters compose: the key narrows to credentials carrying the fact, the hook to those its schema
+    // accepts, and a credential has to clear both.
+    function test_Hook_KeyAndHookBothApply() public {
+        address legion = _delegateIssuer("legionBoth2", K_SYNDICATE | K_DATA | K_ACCREDITED);
+        address spv = makeAddr("spvCompose");
+        address holder = makeAddr("composed");
+        _seat(legion, holder, spv, abi.encode(TIER1));
+
+        bytes memory tier1 = _tier(spv, legion, TIER1);
+        assertTrue(badge.hasValidCredentialOf(holder, K_SYNDICATE, new address[](0), address(0), _tierHook(), tier1));
+        // The seat clears the hook but does not carry K_ACCREDITED, and no other credential does either.
+        assertFalse(badge.hasValidCredentialOf(holder, K_ACCREDITED, new address[](0), address(0), _tierHook(), tier1));
+    }
+
+    // A multi-bit scoped ask needs every bit covered, and the credentials scoped to that SPV add up to cover
+    // them. One seat alone does not answer for both.
+    function test_ScopedFilter_MultiKeyAddsUpWithinOneSpv() public {
+        address spv = makeAddr("spvMultiKey");
+        address holder = makeAddr("bothSeats");
+        uint256 both = K_SPV_WHITELIST | K_SYNDICATE;
+
+        _mint(holder, _scoped(K_SPV_WHITELIST, spv));
+        assertFalse(badge.hasValidCredentialOf(holder, both, spv), "whitelist alone does not cover both");
+
+        _mint(holder, _scoped(K_SYNDICATE, spv));
+        assertTrue(badge.hasValidCredentialOf(holder, both, spv), "the two seats together do");
+    }
+
+    // Keys only add up within the scope asked for: a seat in another SPV contributes nothing.
+    function test_ScopedFilter_MultiKeyDoesNotAddUpAcrossSpvs() public {
+        address spvA = makeAddr("spvSplitA");
+        address spvB = makeAddr("spvSplitB");
+        address holder = makeAddr("splitSeats");
+
+        _mint(holder, _scoped(K_SPV_WHITELIST, spvA));
+        _mint(holder, _scoped(K_SYNDICATE, spvB));
+        assertFalse(badge.hasValidCredentialOf(holder, K_SPV_WHITELIST | K_SYNDICATE, spvA));
+        assertFalse(badge.hasValidCredentialOf(holder, K_SPV_WHITELIST | K_SYNDICATE, spvB));
+    }
+
+    // The recency read takes the issuer filter too: the newest credential overall is skipped when a rival
+    // issued it.
+    function test_GetMostRecentValidWith_RespectsIssuerFilter() public {
+        address legion = _delegateIssuer("legionRecent", K_ACCREDITED);
+        address rival = _delegateIssuer("rivalRecent", K_ACCREDITED);
+        address holder = makeAddr("recentFiltered");
+
+        uint256 legionId = _mintAs(legion, holder, _cred(K_ACCREDITED));
+        vm.warp(block.timestamp + 30 days);
+        uint256 rivalId = _mintAs(rival, holder, _cred(K_ACCREDITED));
+
+        (uint256 anyIssuer,) = badge.getMostRecentValidWith(holder, K_ACCREDITED);
+        assertEq(anyIssuer, rivalId, "newest overall");
+        (uint256 fromLegion, bool found) = badge.getMostRecentValidWith(holder, K_ACCREDITED, _issuers(legion));
+        assertTrue(found);
+        assertEq(fromLegion, legionId, "newest of Legion's");
+    }
+
+    // And the scope filter: the newest seat in another SPV does not answer for this one.
+    function test_GetMostRecentValidWith_RespectsScopeFilter() public {
+        address spvA = makeAddr("spvRecentA");
+        address spvB = makeAddr("spvRecentB");
+        address holder = makeAddr("recentScoped");
+
+        uint256 seatA = _mint(holder, _scoped(K_SYNDICATE, spvA));
+        vm.warp(block.timestamp + 30 days);
+        _mint(holder, _scoped(K_SYNDICATE, spvB));
+
+        (uint256 id, bool found) = badge.getMostRecentValidWith(holder, K_SYNDICATE, spvA);
+        assertTrue(found);
+        assertEq(id, seatA);
+    }
+
+    // Seasoning takes the same filters: how long in THIS SPV's circle, on THIS issuer's word.
+    function test_EarliestValidIssuance_RespectsIssuerAndScope() public {
+        address legion = _delegateIssuer("legionSeason2", K_SYNDICATE);
+        address spvA = makeAddr("spvSeasonA");
+        address spvB = makeAddr("spvSeasonB");
+        address holder = makeAddr("seasonFiltered");
+
+        Credential memory early = _scoped(K_SYNDICATE, spvB); // earlier, but another SPV
+        uint256 earlyId = _mintAs(legion, holder, early);
+        vm.warp(block.timestamp + 60 days);
+        uint256 lateId = _mintAs(legion, holder, _scoped(K_SYNDICATE, spvA));
+
+        uint256 earlyAt = uint256(badge.getCredential(earlyId).issuanceDate);
+        uint256 lateAt = uint256(badge.getCredential(lateId).issuanceDate);
+        assertGt(lateAt, earlyAt);
+
+        assertEq(uint256(badge.earliestValidIssuance(holder, K_SYNDICATE)), earlyAt, "unfiltered takes the earliest");
+        assertEq(
+            uint256(badge.earliestValidIssuance(holder, K_SYNDICATE, new address[](0), spvA, address(0), "")),
+            lateAt,
+            "spvA's circle started later"
+        );
+        assertEq(
+            uint256(
+                badge.earliestValidIssuance(holder, K_SYNDICATE, _issuers(makeAddr("nobody")), address(0), address(0), "")
+            ),
+            0,
+            "no seat from that issuer"
+        );
+    }
+
+    // An expired credential is out of the query before the hook runs, the same as a voided one.
+    function test_Hook_NeverSeesExpired() public {
+        address legion = _delegateIssuer("legionExpiring", K_SYNDICATE | K_DATA);
+        address spv = makeAddr("spvExpiring");
+        address holder = makeAddr("lapsed");
+
+        Credential memory c = _cred(K_SYNDICATE | K_DATA);
+        c.scope = spv;
+        c.data = abi.encode(TIER1);
+        c.expiryDate = uint64(block.timestamp + 1 days);
+        _mintAs(legion, holder, c);
+
+        address anything = address(new AlwaysMatchHook());
+        assertTrue(badge.hasValidCredentialOf(holder, 0, new address[](0), address(0), anything, ""));
+
+        vm.warp(block.timestamp + 2 days);
+        assertFalse(badge.hasValidCredentialOf(holder, 0, new address[](0), address(0), anything, ""));
+    }
+
+    // The badge hands the hook the holder, the token id, that token's record, and the caller's payload
+    // verbatim — the payload is what the hook is told, so it has to arrive byte for byte.
+    function test_Hook_ReceivesOwnerTokenIdCredentialAndPayload() public {
+        address legion = _delegateIssuer("legionArgs", K_SYNDICATE | K_DATA);
+        address spv = makeAddr("spvArgs");
+        address holder = makeAddr("argsHolder");
+        uint256 id = _seat(legion, holder, spv, abi.encode(TIER1));
+
+        address checker = address(new ArgCheckHook());
+        bytes memory right = abi.encode(holder, id, "carried through untouched");
+        assertTrue(badge.hasValidCredentialOf(holder, 0, new address[](0), address(0), checker, right));
+
+        bytes memory wrongToken = abi.encode(holder, id + 1, "carried through untouched");
+        assertFalse(badge.hasValidCredentialOf(holder, 0, new address[](0), address(0), checker, wrongToken));
+
+        bytes memory wrongNote = abi.encode(holder, id, "mangled");
+        assertFalse(badge.hasValidCredentialOf(holder, 0, new address[](0), address(0), checker, wrongNote));
+    }
+
+    // The hook is code the caller chose, so its revert is the caller's problem: the read reverts with it
+    // rather than reading false.
+    function test_Hook_RevertPropagates() public {
+        address legion = _delegateIssuer("legionReverting", K_SYNDICATE | K_DATA);
+        address spv = makeAddr("spvReverting");
+        address holder = makeAddr("revertHolder");
+        _seat(legion, holder, spv, abi.encode(TIER1));
+
+        address boom = address(new RevertingHook());
+        vm.expectRevert(RevertingHook.HookFailed.selector);
+        badge.hasValidCredentialOf(holder, 0, new address[](0), address(0), boom, "");
+    }
+
+    // An empty list accepts any issuer, so a caller that does not care reads exactly as before.
+    function test_IssuerFilter_EmptyListAcceptsAnyIssuer() public {
+        address legion = _delegateIssuer("legionAny", K_ACCREDITED);
+        address holder = makeAddr("anyIssuer");
+        _mintAs(legion, holder, _cred(K_ACCREDITED));
+        assertTrue(badge.hasValidCredentialOf(holder, K_ACCREDITED, new address[](0)));
+    }
+
+    // Admins hand out authority — they already assert everything themselves, so delegating gives away nothing
+    // they lack. A delegate holds no role, so it cannot pass its own grant on to anyone else.
+    function test_SetIssuerKeys_AdminGrantsButDelegateCannotReDelegate() public {
+        address operator = makeAddr("operatorGrant");
+        vm.prank(owner);
+        auth.updateRole(operator, 98);
+
+        address legion = makeAddr("legionGrantee");
+        vm.prank(operator);
+        badge.setIssuerKeys(legion, K_SYNDICATE);
+        assertEq(badge.issuerKeys(legion), K_SYNDICATE);
+
+        address downstream = makeAddr("downstream");
+        vm.prank(legion);
+        vm.expectRevert(abi.encodeWithSignature("BorgAuth_NotAuthorized(uint256,address)", uint256(98), legion));
+        badge.setIssuerKeys(downstream, K_SYNDICATE);
+    }
+
+    // A grant is not tied to the admin that made it: revoking that admin leaves the delegate issuing, so
+    // offboarding an admin means clearing what it delegated too.
+    function test_SetIssuerKeys_GrantOutlivesTheGrantingAdmin() public {
+        address operator = makeAddr("operatorLeaving");
+        vm.prank(owner);
+        auth.updateRole(operator, 98);
+        vm.prank(operator);
+        badge.setIssuerKeys(makeAddr("legionSurvivor"), K_ACCREDITED);
+
+        vm.prank(owner);
+        auth.updateRole(operator, 0); // admin offboarded
+
+        address legion = makeAddr("legionSurvivor");
+        assertEq(badge.issuerKeys(legion), K_ACCREDITED, "the grant did not lapse with its granter");
+        _mintAs(legion, makeAddr("stillCredentialed"), _cred(K_ACCREDITED));
+    }
+
+    // An undefined bit is a wiring slip, not a new fact to grant.
+    function test_SetIssuerKeys_RejectsUnknownBits() public {
+        vm.prank(owner);
+        vm.expectRevert(ILexChexBadge.LexChexBadge_BadAsserts.selector);
+        badge.setIssuerKeys(makeAddr("badGrant"), 1 << 60);
+    }
+
     // ── Mint validation & lifecycle ───────────────────────────────────────────
 
-    function test_Mint_OnlyAdmin() public {
+    // Issuing is gated on the grant, so a caller with neither grant nor role gets nowhere.
+    function test_Mint_UngrantedCallerRejected() public {
         vm.prank(makeAddr("stranger"));
         vm.expectRevert();
         badge.mint(makeAddr("to"), _kyc("US", "CA"));
@@ -1010,7 +1470,6 @@ contract LeXcheXBadgeTest is Test {
         c.beneficialOwnerCount = 9;
         c.data = abi.encode("payload");
         c.scope = makeAddr("spvFrozen");
-        c.categoryId = LABEL_LEGION;
         c.agreementId = keccak256("agreement");
         c.evidenceHash = keccak256("evidence");
         uint256 id = _mint(holder, c);
@@ -1030,7 +1489,7 @@ contract LeXcheXBadgeTest is Test {
         assertEq(uint256(afterVoid.beneficialOwnerCount), uint256(beforeVoid.beneficialOwnerCount));
         assertEq(afterVoid.data, beforeVoid.data);
         assertEq(afterVoid.scope, beforeVoid.scope);
-        assertEq(afterVoid.categoryId, beforeVoid.categoryId);
+        assertEq(afterVoid.issuer, beforeVoid.issuer);
         assertEq(afterVoid.agreementId, beforeVoid.agreementId);
         assertEq(afterVoid.evidenceHash, beforeVoid.evidenceHash);
         assertEq(uint256(afterVoid.issuanceDate), uint256(beforeVoid.issuanceDate));
@@ -1118,7 +1577,9 @@ contract LeXcheXBadgeTest is Test {
         address holder = makeAddr("mintEvent");
         Credential memory c = _kyc("US", "CA");
         uint256 expectedId = badge.totalSupply();
-        c.issuanceDate = uint64(block.timestamp); // stamped by mint; mirrored here for the record comparison
+        // stamped by mint; mirrored here for the record comparison
+        c.issuanceDate = uint64(block.timestamp);
+        c.issuer = owner;
 
         vm.expectEmit(true, true, false, true, address(badge));
         emit CredentialIssued(holder, expectedId, c);
@@ -1355,6 +1816,49 @@ contract LeXcheXBadgeTest is Test {
         return badge.mint(to, c);
     }
 
+    /// @dev A second operator on the same badge. The grant is all it gets — deliberately no BorgAuth role, so
+    /// these tests also pin that issuing needs none.
+    function _delegateIssuer(string memory name, uint256 keys) internal returns (address issuer) {
+        issuer = makeAddr(name);
+        vm.prank(owner);
+        badge.setIssuerKeys(issuer, keys);
+    }
+
+    function _mintAs(address issuer, address to, Credential memory c) internal returns (uint256) {
+        vm.prank(issuer);
+        return badge.mint(to, c);
+    }
+
+    /// @dev The one tier hook every query in this suite goes through; the question travels in the payload.
+    function _tierHook() internal returns (address) {
+        if (address(tierHook) == address(0)) tierHook = new TierQueryHook();
+        return address(tierHook);
+    }
+
+    /// @dev The question `_tierHook` answers: whose seats, in which SPV, at which tier.
+    function _tier(address spv, address issuer, bytes32 tierId) internal pure returns (bytes memory) {
+        return abi.encode(spv, issuer, tierId);
+    }
+
+    /// @dev A scoped entitlement naming `spv`.
+    function _scoped(uint256 scopeKey, address spv) internal view returns (Credential memory c) {
+        c = _cred(scopeKey);
+        c.scope = spv;
+    }
+
+    /// @dev A seat in `issuer`'s circle for `spv`, carrying `tier` as its programmable payload.
+    function _seat(address issuer, address holder, address spv, bytes memory tier) internal returns (uint256) {
+        Credential memory c = _cred(K_SYNDICATE | K_DATA);
+        c.scope = spv;
+        c.data = tier;
+        return _mintAs(issuer, holder, c);
+    }
+
+    function _issuers(address a) internal pure returns (address[] memory out) {
+        out = new address[](1);
+        out[0] = a;
+    }
+
     /// @dev Asserts `key` alone, leaving every value field empty, and expects the mint to be rejected.
     function _expectMissingValue(uint256 key) internal {
         address to = makeAddr("missingValue");
@@ -1371,6 +1875,54 @@ contract LeXcheXBadgeTest is Test {
         vm.prank(owner);
         vm.expectRevert(ILexChexBadge.LexChexBadge_MissingScope.selector);
         badge.mint(to, c);
+    }
+}
+
+/// @notice Legion's tier schema, which lives here rather than in the badge: `Credential.data` is
+/// abi.encode(bytes32 tierId). The hook owns the encoding, so the badge never learns what a tier is.
+contract TierQueryHook is ICredentialQueryHook {
+    function matchesCredential(address, uint256, Credential calldata cred, bytes calldata hookData)
+        external
+        pure
+        returns (bool)
+    {
+        (address spv, address issuer, bytes32 tierId) = abi.decode(hookData, (address, address, bytes32));
+        if ((cred.asserts & K_SYNDICATE) == 0 || cred.scope != spv || cred.issuer != issuer) return false;
+        // The badge does not validate the payload's shape, so a malformed blob must read as "no match" rather
+        // than revert the whole query.
+        if (cred.data.length != 32) return false;
+        return abi.decode(cred.data, (bytes32)) == tierId;
+    }
+}
+
+/// @notice Accepts every credential it is shown, so a test can tell what the BADGE filtered out before the
+/// hook ever ran.
+contract AlwaysMatchHook is ICredentialQueryHook {
+    function matchesCredential(address, uint256, Credential calldata, bytes calldata) external pure returns (bool) {
+        return true;
+    }
+}
+
+/// @notice Matches only if holder, token id and payload all arrived intact.
+contract ArgCheckHook is ICredentialQueryHook {
+    function matchesCredential(address owner, uint256 tokenId, Credential calldata cred, bytes calldata hookData)
+        external
+        pure
+        returns (bool)
+    {
+        (address expectedOwner, uint256 expectedTokenId, string memory note) =
+            abi.decode(hookData, (address, uint256, string));
+        return owner == expectedOwner && tokenId == expectedTokenId && cred.issuanceDate != 0
+            && keccak256(bytes(note)) == keccak256("carried through untouched");
+    }
+}
+
+/// @notice A hook that fails, standing in for one that is buggy or hostile.
+contract RevertingHook is ICredentialQueryHook {
+    error HookFailed();
+
+    function matchesCredential(address, uint256, Credential calldata, bytes calldata) external pure returns (bool) {
+        revert HookFailed();
     }
 }
 
@@ -1428,3 +1980,4 @@ contract LeXcheXBadgeSweepGasTest is Test {
         assertEq(badge.getActiveTokenIds(holder).length, before - batch.length); // and its progress persisted
     }
 }
+

--- a/test/LeXcheXBadgeIndexerTest.t.sol
+++ b/test/LeXcheXBadgeIndexerTest.t.sol
@@ -90,9 +90,6 @@ contract LeXcheXBadgeIndexerTest is Test {
     // Chain fixtures
     // ─────────────────────────────────────────────────────────────────────────
 
-    bytes32 constant LABEL_LEGION = keccak256("label.legion");
-    bytes32 constant LABEL_TIER2 = keccak256("label.tier2");
-
     address owner;
     address alice;
     address bob;
@@ -100,11 +97,10 @@ contract LeXcheXBadgeIndexerTest is Test {
     address spvB;
     LeXcheXBadge badge;
 
-    // What every holder assertion probes: each fact-key on its own, each SPV, each label. Kept at contract
-    // level so the assertion helpers stay single-argument.
+    // What every holder assertion probes: each fact-key on its own, and each SPV. Kept at contract level so
+    // the assertion helpers stay single-argument.
     uint256[] internal probeKeys;
     address[] internal probeSpvs;
-    bytes32[] internal probeLabels;
 
     function setUp() public {
         owner = makeAddr("owner");
@@ -139,9 +135,6 @@ contract LeXcheXBadgeIndexerTest is Test {
             K_ACCREDITED | K_QP
         ];
         probeSpvs = [spvA, spvB];
-        // bytes32(0) is probed on purpose: an unlabelled credential is not in the on-chain label index, so no
-        // label read may answer for it.
-        probeLabels = [LABEL_LEGION, LABEL_TIER2, bytes32(0)];
     }
 
     // ─────────────────────────────────────────────────────────────────────────
@@ -155,14 +148,13 @@ contract LeXcheXBadgeIndexerTest is Test {
         c.evidenceHash = keccak256(abi.encodePacked("evidence", asserts, block.timestamp));
     }
 
-    /// @dev Individual with a physical jurisdiction and U.S. state, under an issuer label.
-    function _kyc(string memory jurisdiction, bytes2 state, bytes32 label) internal view returns (Credential memory c) {
+    /// @dev Individual with a physical jurisdiction and U.S. state.
+    function _kyc(string memory jurisdiction, bytes2 state) internal view returns (Credential memory c) {
         c = _cred(K_INVESTOR_TYPE | K_INVESTOR_JURISDICTION | K_US_STATE);
         c.investorType = InvestorType.INDIVIDUAL;
         c.investorName = "Alice Individual";
         c.investorJurisdiction = jurisdiction;
         c.usState = state;
-        c.categoryId = label;
     }
 
     /// @dev Entity feeder: physical domicile and §3(c)(1)(A) look-through classification kept separate.
@@ -342,17 +334,6 @@ contract LeXcheXBadgeIndexerTest is Test {
         return false;
     }
 
-    /// @dev The zero label is not written to the on-chain label index, so an unlabelled credential is never
-    /// findable by label. Mirrored here, or the indexer would answer for records the chain cannot see.
-    function _idxHasValidCredential(address holder, bytes32 label) internal view returns (bool) {
-        if (label == bytes32(0)) return false;
-        uint256[] storage ids = idxHolderTokens[holder];
-        for (uint256 i = 0; i < ids.length; i++) {
-            if (idxCreds[ids[i]].cred.categoryId == label && _idxIsValid(ids[i])) return true;
-        }
-        return false;
-    }
-
     function _idxInvestorType(address holder) internal view returns (InvestorType) {
         (uint256 tokenId, bool found) = _idxMostRecentValidWith(holder, K_INVESTOR_TYPE);
         return found ? idxCreds[tokenId].cred.investorType : InvestorType.UNSET;
@@ -437,7 +418,7 @@ contract LeXcheXBadgeIndexerTest is Test {
         Credential memory c = badge.getCredential(tokenId);
         assertTrue(i.exists, "credential reconstructed from logs");
         assertEq(i.cred.asserts, c.asserts, "asserts");
-        assertEq(i.cred.categoryId, c.categoryId, "categoryId");
+        assertEq(i.cred.issuer, c.issuer, "issuer");
         assertEq(i.cred.investorName, c.investorName, "investorName");
         assertEq(i.cred.investorJurisdiction, c.investorJurisdiction, "investorJurisdiction");
         assertEq(i.cred.lookThroughJurisdiction, c.lookThroughJurisdiction, "lookThroughJurisdiction");
@@ -502,13 +483,6 @@ contract LeXcheXBadgeIndexerTest is Test {
                 "hasValidSyndicateFor"
             );
         }
-        for (uint256 i = 0; i < probeLabels.length; i++) {
-            bytes32 label = probeLabels[i];
-            assertEq(
-                _idxHasValidCredential(holder, label), badge.hasValidCredential(holder, label), "hasValidCredential"
-            );
-        }
-
         // ERC-721 enumeration is the full audit record: every credential ever issued to the holder, in mint
         // order, voided and expired ones included.
         uint256[] memory chainTokens = badge.getTokenIdsByOwner(holder);
@@ -573,10 +547,8 @@ contract LeXcheXBadgeIndexerTest is Test {
         vm.recordLogs();
 
         // Alice: a person, KYC'd, lives in NY. Plus a second badge saying she's accredited.
-        uint256 aliceNy = _mint(alice, _kyc("US", "NY", LABEL_LEGION));
-        Credential memory accredited = _cred(K_ACCREDITED);
-        accredited.categoryId = LABEL_TIER2;
-        _mint(alice, accredited);
+        uint256 aliceNy = _mint(alice, _kyc("US", "NY"));
+        _mint(alice, _cred(K_ACCREDITED));
 
         // Bob: a company registered offshore that still counts as U.S. for fund-size rules. Plus access to
         // spvA, a blob of data the badge just carries around, and a QP badge that expires in 10 days.
@@ -590,7 +562,7 @@ contract LeXcheXBadgeIndexerTest is Test {
         vm.warp(block.timestamp + 30 days);
         // Alice moves to TX. supersede kills the NY badge and mints the TX one in one go.
         vm.prank(owner);
-        uint256 aliceTx = badge.supersede(aliceNy, _kyc("US", "TX", LABEL_LEGION), "relocated to TX");
+        uint256 aliceTx = badge.supersede(aliceNy, _kyc("US", "TX"), "relocated to TX");
         // Bob's access to spvA is pulled.
         vm.prank(owner);
         badge.void(bobWhitelist, "delisted");
@@ -606,7 +578,7 @@ contract LeXcheXBadgeIndexerTest is Test {
         assertEq(bytes32(_idxUsState(alice)), bytes32(bytes2("TX")), "she reads as TX now, not NY");
         assertEq(idxCreds[aliceNy].cred.voided, "relocated to TX", "the dead badge is kept, with its reason");
         assertEq(idxCreds[aliceTx].cred.investorName, "Alice Individual", "her name came through in the log");
-        assertTrue(_idxHasValidCredential(alice, LABEL_TIER2), "her other badge still works");
+        assertTrue(_idxHasValidCredentialOf(alice, K_ACCREDITED), "her other badge still works");
 
         assertEq(_idxLookThroughJurisdiction(bob), "US", "counts as U.S. for fund-size rules");
         assertEq(_idxInvestorJurisdiction(bob), "KY", "but is still registered offshore");
@@ -633,7 +605,7 @@ contract LeXcheXBadgeIndexerTest is Test {
 
         vm.warp(block.timestamp + 1 days);
         // A day later: new badge, moved to CA. It says nothing about the fund-size classification.
-        _mint(alice, _kyc("KY", "CA", LABEL_LEGION));
+        _mint(alice, _kyc("KY", "CA"));
         // Two more in the same block as that one, so all three are the same age.
         uint256 tieLoser = _mint(alice, _jurisdictionOnly("FR"));
         uint256 tieWinner = _mint(alice, _jurisdictionOnly("DE"));
@@ -679,7 +651,7 @@ contract LeXcheXBadgeIndexerTest is Test {
     function test_Indexer_Expiry_ReDerivedWithoutAnyEvent() public {
         vm.recordLogs();
         _mint(alice, _expiring(K_ACCREDITED, 10 days));
-        _mint(alice, _kyc("US", "CA", LABEL_LEGION));
+        _mint(alice, _kyc("US", "CA"));
         _index(vm.getRecordedLogs());
 
         _assertRegistryReconstructed();
@@ -704,7 +676,7 @@ contract LeXcheXBadgeIndexerTest is Test {
     function test_Indexer_Sweep_LogsEachDropAndChangesNoAnswer() public {
         vm.recordLogs();
         uint256 lapsing = _mint(alice, _expiring(K_ACCREDITED, 10 days));
-        _mint(alice, _kyc("US", "CA", LABEL_LEGION));
+        _mint(alice, _kyc("US", "CA"));
         _index(vm.getRecordedLogs());
 
         vm.warp(block.timestamp + 11 days);
@@ -771,10 +743,10 @@ contract LeXcheXBadgeIndexerTest is Test {
     // one mint per badge, never a transfer to someone else, and cancelled badges still in the holder's list.
     function test_Indexer_AppendOnlyRegistry_FromLogsAlone() public {
         vm.recordLogs();
-        uint256 first = _mint(alice, _kyc("US", "NY", LABEL_LEGION));
+        uint256 first = _mint(alice, _kyc("US", "NY"));
         _mint(alice, _cred(K_ACCREDITED));
         vm.prank(owner);
-        uint256 replacement = badge.supersede(first, _kyc("US", "TX", LABEL_LEGION), "relocated to TX");
+        uint256 replacement = badge.supersede(first, _kyc("US", "TX"), "relocated to TX");
         _index(vm.getRecordedLogs());
 
         _assertRegistryReconstructed();

--- a/test/conditions/secondary/LegionSoulboundCondition.t.sol
+++ b/test/conditions/secondary/LegionSoulboundCondition.t.sol
@@ -1,145 +1,431 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity 0.8.28;
 
-import {K_INVESTOR_JURISDICTION, K_INVESTOR_TYPE, InvestorType} from "../../../src/interfaces/ILexChexBadge.sol";
 import {Credential} from "../../../src/creds/storage/lexchexBadgeStorage.sol";
 import {IDealManager} from "../../../src/interfaces/IDealManager.sol";
+import {ILexChexBadge, K_ACCREDITED, K_DATA, K_SYNDICATE} from "../../../src/interfaces/ILexChexBadge.sol";
 import {BadgeScopedCondition} from "../../../src/libs/conditions/secondary/BadgeScopedCondition.sol";
-import {LegionSoulboundCondition} from "../../../src/libs/conditions/secondary/LegionSoulboundCondition.sol";
+import {
+    LegionSoulboundCondition,
+    LegionTier
+} from "../../../src/libs/conditions/secondary/LegionSoulboundCondition.sol";
 import {SecondaryConditionIntegrationBase} from "./SecondaryConditionIntegration.sol";
 
 // ─────────────────────────────────────────────────────────────────────────────
-// LegionSoulboundCondition — issuer-specific credential category/tier gate.
+// Legion's circle gate — "a MEMBER or better in Legion's circle, for this SPV".
 //
-// Legal/economic intent: enforce issuer-specific gating not captured by generic credentials —
-// syndicate-circle restrictions, non-accredited-tier requirements. Configured with a required
-// category and whether it applies to the buyer only, or buyer and seller.
+// Supersedes the old circle gate (LexChexBadgeKindCondition + K_SYNDICATE), which answered the seat but not
+// the rank. A qualifying credential now carries both: K_SYNDICATE scoped to this SPV, and K_DATA holding the
+// rank. Membership alone is just the lowest rung.
 //
-// Real integration: circle membership is a real badge credential in the required category; parties are
-// resolved from a real posted/accepted sell offer.
+// Two things a plain fact-key gate cannot do:
+//  - Issuer keys: Legion may assert K_SYNDICATE | K_DATA and nothing else. The gate names Legion, so only
+//    its circle counts.
+//  - Value-key resolution: a rank is a value, not a flag, so two of them contradict. getMostRecentValidWith
+//    picks the holder's current seat and the rank on THAT one is compared to the bar, so a demotion counts
+//    even when the old seat was never voided.
 //
-// Scenario × outcome
-// | # | applyToSeller | context       | buyer cred | seller cred | expect | rationale                     |
-// |---|:-------------:|---------------|:----------:|:-----------:|:------:|-------------------------------|
-// | 1 |      no       | SELL posting  |    n/a     |     no      |  pass  | buyer unknown, seller ungated |
-// | 2 |      no       | accepted      |    yes     |     no      |  pass  | buyer in the circle           |
-// | 3 |      no       | accepted      |     no     |     yes     |  fail  | buyer not in the circle       |
-// | 4 |     yes       | accepted      |    yes     |     no      |  fail  | seller also gated             |
-// | 5 |     yes       | accepted      |    yes     |     yes     |  pass  | both in the circle            |
-// | 6 |     yes       | SELL posting  |    n/a     |     no      |  fail  | seller gated even at posting  |
+// Real integration: parties come from a real posted/accepted sell offer. Config is MEMBER, buyer-only,
+// issuer filter = Legion, unless a row says otherwise.
 //
-// Config/authorization
-// | #  | case                            | expect                |
-// |----|---------------------------------|-----------------------|
-// | 7  | initialize zero default badge   | revert InvalidBadge   |
-// | 8  | setConfig zero category         | revert InvalidCategory|
-// | 9  | setConfig by non-SPV-admin      | revert (not admin)    |
-// | 10 | SPV never configured            | fail — no circle named|
+// Rank ladder — higher up the ladder is what "clears" means. A rank is a value, so the NEWEST seat answers.
+// | # | applyToSeller | context      | buyer rank | seller rank | expect | rationale                       |
+// |---|:-------------:|--------------|:----------:|:-----------:|:------:|---------------------------------|
+// | 1 |      no       | SELL posting |    n/a     |    none     |  pass  | buyer unknown, seller ungated   |
+// | 2 |      no       | accepted     |   MEMBER   |    none     |  pass  | buyer is exactly at the bar     |
+// | 3 |      no       | accepted     |    LEAD    |    none     |  pass  | higher up the ladder clears it  |
+// | 4 |      no       | accepted     |  PROSPECT  |    none     |  fail  | seated, but below the bar       |
+// | 5 |      no       | accepted     |    none    |   MEMBER    |  fail  | buyer holds no seat at all      |
+// | 6 |     yes       | accepted     |   MEMBER   |  PROSPECT   |  fail  | seller gated too, and is below  |
+// | 7 |     yes       | accepted     |   MEMBER   |   MEMBER    |  pass  | both at the bar                 |
+// | 8 |     yes       | SELL posting |    n/a     |  PROSPECT   |  fail  | seller gated even at posting    |
+//
+// Seat and rank — one record must carry both; neither half answers alone. (Merged from the circle gate.)
+// | #  | case                                    | expect                                                   |
+// |----|-----------------------------------------|----------------------------------------------------------|
+// | 9  | lowest rung configured                  | pass for any seat — the old circle gate, as a config      |
+// | 10 | seat with no rank (K_SYNDICATE only)    | fail — nothing says how far along the holder is           |
+// | 11 | rank with no seat (K_DATA only)         | fail — a rank in no circle is not a seat in this one      |
+// | 12 | bare seat + bare rank held together     | fail — the two do not add up into a qualifying credential |
+// | 13 | rank bytes present but K_DATA unasserted | fail — `asserts` is the authority, not a populated field  |
+//
+// Issuer authority — who may seat and rank, and whose circle the gate believes.
+// | #  | case                                    | expect                                                   |
+// |----|-----------------------------------------|----------------------------------------------------------|
+// | 14 | issuer holds no grant                   | mint reverts KeysNotAuthorized — cannot seat anyone       |
+// | 15 | Legion asserts a key outside its grant  | mint reverts KeysNotAuthorized — seat and rank only       |
+// | 16 | rival issuer's MEMBER seat, same SPV    | fail — the filter is what makes it Legion's circle        |
+// | 17 | no issuer filter, rival's MEMBER seat   | pass — an empty filter means "anyone's circle"            |
+//
+// Scope, payload and lifecycle — what the badge's filters and the rank check throw out.
+// | #  | case                                    | expect                                                   |
+// |----|-----------------------------------------|----------------------------------------------------------|
+// | 18 | MEMBER seat in a different SPV          | fail — a seat answers for the SPV it names                |
+// | 19 | seat with no scope                      | mint reverts MissingScope — the badge will not issue it   |
+// | 20 | rank payload not 32 bytes               | fail closed — an unreadable rank is no rank                |
+// | 21 | rank decodes past the ladder's end      | fail closed — unknown rung is not a high rung             |
+// | 22 | SPV never configured                    | fail closed, whatever the party holds                      |
+// | 23 | newest seat unreadable                  | fail — no falling back to an older readable one            |
+// | 24 | promotion via supersede                 | pass — PROSPECT replaced by MEMBER                         |
+// | 25 | newer, lower rank minted                | fail — newest wins, so demoting needs no void              |
+// | 26 | newer, higher rank minted               | pass — same rule the other way                             |
+// | 27 | seat expired                            | fail — the badge filters on validity before recency        |
+//
+// Configuration — the SPV names its bar; the platform names whose circle is read.
+// | #  | case                                    | expect                                                   |
+// |----|-----------------------------------------|----------------------------------------------------------|
+// | 28 | setConfig by a stranger                 | revert — SPV's own BorgAuth admin only                    |
+// | 29 | setConfig with NONE                     | revert InvalidTier — that is the unconfigured value       |
+// | 30 | setConfig for the zero SPV              | revert InvalidSpv                                         |
+// | 31 | updateIssuers by a stranger             | revert — platform-set, not SPV-set                        |
+// | 32 | initialize zero default badge           | revert InvalidBadge                                       |
 // ─────────────────────────────────────────────────────────────────────────────
 
 contract LegionSoulboundConditionTest is SecondaryConditionIntegrationBase {
     LegionSoulboundCondition internal legion;
-    bytes32 internal constant CAT = keccak256("cat.legion");
+
+    // Two operators on the one badge, each able to seat and rank, neither holding a BorgAuth role.
+    address internal legionIssuer = makeAddr("legion.issuer");
+    address internal rivalIssuer = makeAddr("rival.issuer");
+    address internal ungrantedIssuer = makeAddr("ungranted.issuer");
+
+    uint256 internal constant SEAT_AND_RANK = K_SYNDICATE | K_DATA;
 
     function setUp() public {
         _setUpIntegration();
-        legion = _deploy(false);
+        badge.setIssuerKeys(legionIssuer, SEAT_AND_RANK);
+        badge.setIssuerKeys(rivalIssuer, SEAT_AND_RANK);
+        legion = _deploy();
+        legion.updateIssuers(_only(legionIssuer));
+        _configure(LegionTier.MEMBER, false);
     }
 
-    function _deploy(bool applyToSeller) internal returns (LegionSoulboundCondition c) {
+    function _deploy() internal returns (LegionSoulboundCondition c) {
         c = LegionSoulboundCondition(
             _proxy(
                 address(new LegionSoulboundCondition()),
                 abi.encodeCall(LegionSoulboundCondition.initialize, (address(auth), address(badge)))
             )
         );
-        c.setConfig(address(corp), CAT, applyToSeller);
     }
 
-    function _grant(address who) internal {
-        Credential memory c;
-        c.investorType = InvestorType.INDIVIDUAL;
-        c.investorJurisdiction = "US";
-        c.categoryId = CAT; // Legion gates on the free-form categoryId label
-        _mintCred(who, K_INVESTOR_TYPE | K_INVESTOR_JURISDICTION, c);
+    /// @dev The test contract is the SPV's own BorgAuth admin, so this runs unpranked.
+    function _configure(LegionTier minTier, bool applyToSeller) internal {
+        legion.setConfig(address(corp), minTier, applyToSeller);
     }
 
-    function _check(LegionSoulboundCondition c, bytes32 offerId, bytes32 agreementId) internal view returns (bool) {
-        return c.checkCondition(IDealManager(address(dm)), bytes4(0), offerId, agreementId);
+    /// @dev A seat in `issuer`'s circle for `spv`, at rung `tier`.
+    function _grantTierFor(address issuer, address who, address spv, LegionTier tier) internal returns (uint256) {
+        return _grantDataFor(issuer, who, spv, legion.encodeTier(tier));
     }
+
+    /// @dev Same, with the rank written by hand, so a test can mint one the gate cannot read.
+    function _grantDataFor(address issuer, address who, address spv, bytes memory data) internal returns (uint256) {
+        Credential memory c = _tierCred(spv, data);
+        vm.prank(issuer);
+        return badge.mint(who, c);
+    }
+
+    /// @dev A ranked seat: both keys on one record, which is what the gate asks for.
+    function _tierCred(address spv, bytes memory data) internal view returns (Credential memory c) {
+        c.asserts = SEAT_AND_RANK;
+        c.scope = spv;
+        c.data = data;
+        c.expiryDate = uint64(block.timestamp + 3650 days);
+    }
+
+    /// @dev Mints only part of what the gate asks for, to show halves do not qualify.
+    function _grantPartial(address who, uint256 asserts, address spv, bytes memory data)
+        internal
+        returns (uint256)
+    {
+        Credential memory c = _tierCred(spv, data);
+        c.asserts = asserts;
+        vm.prank(legionIssuer);
+        return badge.mint(who, c);
+    }
+
+    function _grant(address who, LegionTier tier) internal returns (uint256) {
+        return _grantTierFor(legionIssuer, who, address(corp), tier);
+    }
+
+    function _only(address a) internal pure returns (address[] memory out) {
+        out = new address[](1);
+        out[0] = a;
+    }
+
+    function _check(bytes32 offerId, bytes32 agreementId) internal view returns (bool) {
+        return legion.checkCondition(IDealManager(address(dm)), bytes4(0), offerId, agreementId);
+    }
+
+    // ── Rank ladder ──────────────────────────────────────────────────────────
 
     // 1
     function test_BuyerOnly_Posting_SellerUngated_Passes() public {
-        assertTrue(_check(legion, _postSell(), bytes32(0)));
+        assertTrue(_check(_postSell(), bytes32(0)));
     }
 
     // 2
-    function test_BuyerOnly_Accepted_BuyerInCircle_Passes() public {
-        _grant(buyer);
+    function test_BuyerAtRequiredTier_Passes() public {
+        _grant(buyer, LegionTier.MEMBER);
         (bytes32 offerId, bytes32 settlementId) = _postAndAcceptSell();
-        assertTrue(_check(legion, offerId, settlementId));
+        assertTrue(_check(offerId, settlementId));
     }
 
-    // 3
-    function test_BuyerOnly_Accepted_BuyerNotInCircle_Fails() public {
-        _grant(seller);
+    // 3 — why the rank is a value and not a key: a bitmask cannot say "MEMBER or better".
+    function test_BuyerAboveRequiredTier_Passes() public {
+        _grant(buyer, LegionTier.LEAD);
         (bytes32 offerId, bytes32 settlementId) = _postAndAcceptSell();
-        assertFalse(_check(legion, offerId, settlementId));
+        assertTrue(_check(offerId, settlementId));
     }
 
     // 4
-    function test_ApplyToSeller_SellerMissing_Fails() public {
-        LegionSoulboundCondition c = _deploy(true);
-        _grant(buyer);
+    function test_BuyerBelowRequiredTier_Fails() public {
+        _grant(buyer, LegionTier.PROSPECT);
         (bytes32 offerId, bytes32 settlementId) = _postAndAcceptSell();
-        assertFalse(_check(c, offerId, settlementId));
+        assertFalse(_check(offerId, settlementId));
     }
 
     // 5
-    function test_ApplyToSeller_BothInCircle_Passes() public {
-        LegionSoulboundCondition c = _deploy(true);
-        _grant(buyer);
-        _grant(seller);
+    function test_BuyerHoldsNoSeat_Fails() public {
+        _grant(seller, LegionTier.MEMBER);
         (bytes32 offerId, bytes32 settlementId) = _postAndAcceptSell();
-        assertTrue(_check(c, offerId, settlementId));
+        assertFalse(_check(offerId, settlementId));
     }
 
     // 6
-    function test_ApplyToSeller_Posting_SellerMissing_Fails() public {
-        LegionSoulboundCondition c = _deploy(true);
-        assertFalse(_check(c, _postSell(), bytes32(0)));
+    function test_ApplyToSeller_SellerBelowTier_Fails() public {
+        _configure(LegionTier.MEMBER, true);
+        _grant(buyer, LegionTier.MEMBER);
+        _grant(seller, LegionTier.PROSPECT);
+        (bytes32 offerId, bytes32 settlementId) = _postAndAcceptSell();
+        assertFalse(_check(offerId, settlementId));
     }
 
     // 7
-    function test_Initialize_ZeroBadge_Reverts() public {
-        LegionSoulboundCondition impl = new LegionSoulboundCondition();
-        vm.expectRevert(BadgeScopedCondition.InvalidBadge.selector);
-        _proxy(address(impl), abi.encodeCall(LegionSoulboundCondition.initialize, (address(auth), address(0))));
+    function test_ApplyToSeller_BothAtTier_Passes() public {
+        _configure(LegionTier.MEMBER, true);
+        _grant(buyer, LegionTier.MEMBER);
+        _grant(seller, LegionTier.MEMBER);
+        (bytes32 offerId, bytes32 settlementId) = _postAndAcceptSell();
+        assertTrue(_check(offerId, settlementId));
     }
 
     // 8
-    function test_SetConfig_ZeroCategory_Reverts() public {
-        vm.expectRevert(LegionSoulboundCondition.InvalidCategory.selector);
-        legion.setConfig(address(corp), bytes32(0), false);
+    function test_ApplyToSeller_Posting_SellerBelowTier_Fails() public {
+        _configure(LegionTier.MEMBER, true);
+        _grant(seller, LegionTier.PROSPECT);
+        assertFalse(_check(_postSell(), bytes32(0)));
     }
 
-    // 9
+    // ── Seat and rank (merged from the circle gate) ──────────────────────────
+
+    // 9 — the old circle gate, as a config: name the lowest rung and any seat clears.
+    function test_LowestRungConfigured_AnySeatAdmits() public {
+        _configure(LegionTier.PROSPECT, false);
+        _grant(buyer, LegionTier.PROSPECT);
+        (bytes32 offerId, bytes32 settlementId) = _postAndAcceptSell();
+        assertTrue(_check(offerId, settlementId));
+    }
+
+    // 10 — a seat with no rank clears no bar, not even the lowest. So Legion ranks every seat.
+    function test_SeatWithoutRank_DoesNotAdmit() public {
+        _configure(LegionTier.PROSPECT, false);
+        _grantPartial(buyer, K_SYNDICATE, address(corp), "");
+        (bytes32 offerId, bytes32 settlementId) = _postAndAcceptSell();
+        assertFalse(_check(offerId, settlementId));
+    }
+
+    // 11 — a rank with no seat is a rank in no circle.
+    function test_RankWithoutSeat_DoesNotAdmit() public {
+        _grantPartial(buyer, K_DATA, address(corp), legion.encodeTier(LegionTier.LEAD));
+        (bytes32 offerId, bytes32 settlementId) = _postAndAcceptSell();
+        assertFalse(_check(offerId, settlementId));
+    }
+
+    // 12 — the key set is tested per credential, so the halves never add up to a qualifying one.
+    function test_BareSeatPlusBareRank_DoNotCombine() public {
+        _grantPartial(buyer, K_SYNDICATE, address(corp), "");
+        _grantPartial(buyer, K_DATA, address(corp), legion.encodeTier(LegionTier.LEAD));
+        (bytes32 offerId, bytes32 settlementId) = _postAndAcceptSell();
+        assertFalse(_check(offerId, settlementId));
+    }
+
+    // 13 — `asserts` is the authority: a full `data` field no key claims is not a rank.
+    function test_RankBytesWithoutTheKey_DoNotAdmit() public {
+        _grantPartial(buyer, K_SYNDICATE, address(corp), legion.encodeTier(LegionTier.LEAD));
+        (bytes32 offerId, bytes32 settlementId) = _postAndAcceptSell();
+        assertFalse(_check(offerId, settlementId));
+    }
+
+    // ── Issuer authority ─────────────────────────────────────────────────────
+
+    // 14 — the grant IS the authority to issue, so an ungranted operator cannot seat anyone.
+    function test_UngrantedIssuer_CannotMintSeat() public {
+        Credential memory c = _tierCred(address(corp), legion.encodeTier(LegionTier.MEMBER));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILexChexBadge.LexChexBadge_KeysNotAuthorized.selector, ungrantedIssuer, SEAT_AND_RANK
+            )
+        );
+        vm.prank(ungrantedIssuer);
+        badge.mint(buyer, c);
+    }
+
+    // 15 — running a circle does not let Legion call anyone accredited.
+    function test_LegionIssuer_CannotAssertKeysOutsideItsGrant() public {
+        Credential memory c = _tierCred(address(corp), legion.encodeTier(LegionTier.MEMBER));
+        c.asserts = SEAT_AND_RANK | K_ACCREDITED;
+        vm.expectRevert(
+            abi.encodeWithSelector(ILexChexBadge.LexChexBadge_KeysNotAuthorized.selector, legionIssuer, K_ACCREDITED)
+        );
+        vm.prank(legionIssuer);
+        badge.mint(buyer, c);
+    }
+
+    // 16 — a rival can seat this buyer high in its own circle; the gate reads Legion.
+    function test_RivalIssuersTier_DoesNotAdmit() public {
+        _grantTierFor(rivalIssuer, buyer, address(corp), LegionTier.LEAD);
+        (bytes32 offerId, bytes32 settlementId) = _postAndAcceptSell();
+        assertFalse(_check(offerId, settlementId));
+    }
+
+    // 17 — with no issuer named the gate takes any operator's word for where the buyer sits.
+    function test_NoIssuerFilter_AnyIssuersTierAdmits() public {
+        legion.updateIssuers(new address[](0));
+        _grantTierFor(rivalIssuer, buyer, address(corp), LegionTier.MEMBER);
+        (bytes32 offerId, bytes32 settlementId) = _postAndAcceptSell();
+        assertTrue(_check(offerId, settlementId));
+    }
+
+    // ── Scope, payload, lifecycle ────────────────────────────────────────────
+
+    // 18
+    function test_SeatInAnotherSpv_DoesNotAdmit() public {
+        _grantTierFor(legionIssuer, buyer, makeAddr("otherSpv"), LegionTier.LEAD);
+        (bytes32 offerId, bytes32 settlementId) = _postAndAcceptSell();
+        assertFalse(_check(offerId, settlementId));
+    }
+
+    // 19 — a seat needs an SPV, so an unscoped one fails at issuance, not at the gate.
+    function test_UnscopedSeat_CannotBeMinted() public {
+        Credential memory c = _tierCred(address(0), legion.encodeTier(LegionTier.LEAD));
+        vm.expectRevert(ILexChexBadge.LexChexBadge_MissingScope.selector);
+        vm.prank(legionIssuer);
+        badge.mint(buyer, c);
+    }
+
+    // 20 — a payload the gate cannot parse is no rank at all.
+    function test_MalformedPayload_FailsClosed() public {
+        _grantDataFor(legionIssuer, buyer, address(corp), bytes("LEAD"));
+        (bytes32 offerId, bytes32 settlementId) = _postAndAcceptSell();
+        assertFalse(_check(offerId, settlementId));
+    }
+
+    // 21
+    function test_TierPastEndOfLadder_FailsClosed() public {
+        _grantDataFor(legionIssuer, buyer, address(corp), abi.encode(uint256(99)));
+        (bytes32 offerId, bytes32 settlementId) = _postAndAcceptSell();
+        assertFalse(_check(offerId, settlementId));
+    }
+
+    // 22 — never configured blocks, whatever the party holds.
+    function test_UnconfiguredSpv_FailsClosed() public {
+        LegionSoulboundCondition fresh = _deploy();
+        _grant(buyer, LegionTier.LEAD);
+        (bytes32 offerId, bytes32 settlementId) = _postAndAcceptSell();
+
+        assertFalse(fresh.checkCondition(IDealManager(address(dm)), bytes4(0), offerId, settlementId));
+    }
+
+    // 23 — an unreadable newest seat blocks; it does not hand the answer back to an older readable one.
+    function test_UnreadableNewestSeat_DoesNotFallBack() public {
+        _grant(buyer, LegionTier.MEMBER);
+        (bytes32 offerId, bytes32 settlementId) = _postAndAcceptSell();
+        assertTrue(_check(offerId, settlementId));
+
+        vm.warp(block.timestamp + 1 days);
+        _grantDataFor(legionIssuer, buyer, address(corp), bytes("LEAD"));
+        assertFalse(_check(offerId, settlementId));
+    }
+
+    // 24 — promotion. Credentials are immutable, so moving up means replacing the old one.
+    function test_PromotionBySupersede_Passes() public {
+        uint256 staleId = _grant(buyer, LegionTier.PROSPECT);
+        Credential memory promoted = _tierCred(address(corp), legion.encodeTier(LegionTier.MEMBER));
+        vm.prank(legionIssuer);
+        badge.supersede(staleId, promoted, "promoted to member");
+
+        (bytes32 offerId, bytes32 settlementId) = _postAndAcceptSell();
+        assertTrue(_check(offerId, settlementId));
+    }
+
+    // 25 — two ranks contradict, so the newest wins. Demoting is a mint; no void needed.
+    function test_NewestRankWins_DemotionTakesEffectAtOnce() public {
+        _grant(buyer, LegionTier.MEMBER);
+        (bytes32 offerId, bytes32 settlementId) = _postAndAcceptSell();
+        assertTrue(_check(offerId, settlementId));
+
+        vm.warp(block.timestamp + 1 days);
+        _grant(buyer, LegionTier.PROSPECT);
+        assertFalse(_check(offerId, settlementId), "the newer, lower rank is the one that counts");
+    }
+
+    // 26 — and the same the other way: a newer higher rank lifts the holder without voiding the old one.
+    function test_NewestRankWins_PromotionWithoutVoiding() public {
+        _grant(buyer, LegionTier.PROSPECT);
+        (bytes32 offerId, bytes32 settlementId) = _postAndAcceptSell();
+        assertFalse(_check(offerId, settlementId));
+
+        vm.warp(block.timestamp + 1 days);
+        _grant(buyer, LegionTier.MEMBER);
+        assertTrue(_check(offerId, settlementId));
+    }
+
+    // 27 — the badge drops expired seats before picking the newest.
+    function test_ExpiredTier_Fails() public {
+        _grant(buyer, LegionTier.LEAD);
+        (bytes32 offerId, bytes32 settlementId) = _postAndAcceptSell();
+        assertTrue(_check(offerId, settlementId));
+
+        vm.warp(block.timestamp + 3651 days);
+        assertFalse(_check(offerId, settlementId));
+    }
+
+    // ── Configuration ────────────────────────────────────────────────────────
+
+    // 28 — the bar is the SPV's to set, on its own BorgAuth.
     function test_SetConfig_ByStranger_Reverts() public {
         vm.prank(stranger);
         vm.expectRevert();
-        legion.setConfig(address(corp), CAT, true);
+        legion.setConfig(address(corp), LegionTier.MEMBER, false);
     }
 
-    // 10 — silence is not a finding that no circle applies, so an unconfigured SPV admits nobody
-    function test_UnconfiguredSpv_Fails() public {
-        LegionSoulboundCondition c = LegionSoulboundCondition(
-            _proxy(
-                address(new LegionSoulboundCondition()),
-                abi.encodeCall(LegionSoulboundCondition.initialize, (address(auth), address(badge)))
-            )
-        );
-        _grant(buyer);
-        (bytes32 offerId, bytes32 settlementId) = _postAndAcceptSell();
-        assertFalse(_check(c, offerId, settlementId));
+    // 29
+    function test_SetConfig_NoneTier_Reverts() public {
+        vm.expectRevert(LegionSoulboundCondition.InvalidTier.selector);
+        legion.setConfig(address(corp), LegionTier.NONE, false);
+    }
+
+    // 30
+    function test_SetConfig_ZeroSpv_Reverts() public {
+        vm.expectRevert(LegionSoulboundCondition.InvalidSpv.selector);
+        legion.setConfig(address(0), LegionTier.MEMBER, false);
+    }
+
+    // 31 — the platform picks whose circle is read; the SPV is the party being judged.
+    function test_UpdateIssuers_ByStranger_Reverts() public {
+        address[] memory list = _only(rivalIssuer);
+        vm.prank(stranger);
+        vm.expectRevert();
+        legion.updateIssuers(list);
+    }
+
+    // 32
+    function test_Initialize_ZeroBadge_Reverts() public {
+        address impl = address(new LegionSoulboundCondition());
+        bytes memory initData = abi.encodeCall(LegionSoulboundCondition.initialize, (address(auth), address(0)));
+        vm.expectRevert(BadgeScopedCondition.InvalidBadge.selector);
+        _proxy(impl, initData);
     }
 }

--- a/test/conditions/secondary/LexChexBadgeKindCondition.t.sol
+++ b/test/conditions/secondary/LexChexBadgeKindCondition.t.sol
@@ -47,6 +47,12 @@ import {SecondaryConditionIntegrationBase} from "./SecondaryConditionIntegration
 // | 8  | SYNDICATE       | this SPV                |  pass  | seated in the issuer's circle      |
 // | 9  | SYNDICATE       | whitelist on this SPV   |  fail  | admission is not a seat            |
 //
+// Issuer filter — whose word the gate takes; empty accepts any
+// | #  | config          | buyer's grant           | expect | rationale                          |
+// |----|-----------------|-------------------------|:------:|------------------------------------|
+// | 9a | no issuers named | any issuer's seat      |  pass  | an empty filter means "anyone's"   |
+// | 9b | issuers = [A]    | issuer B's seat        |  fail  | the filter is the whole point      |
+//
 // Config/authorization
 // | #  | case                              | expect                |
 // |----|-----------------------------------|-----------------------|
@@ -92,6 +98,22 @@ contract LexChexBadgeKindConditionTest is SecondaryConditionIntegrationBase {
         Credential memory c;
         c.scope = spv;
         _mintCred(who, kindKey, c);
+    }
+
+    /// @dev An operator that may seat people, holding no BorgAuth role.
+    function _delegate(string memory name) internal returns (address issuer) {
+        issuer = makeAddr(name);
+        badge.setIssuerKeys(issuer, K_SYNDICATE);
+    }
+
+    /// @dev Same as _grantScoped, but minted BY `issuer`, so the credential records whose word it is.
+    function _grantScopedFrom(address issuer, address who, uint256 kindKey, address spv) internal {
+        Credential memory c;
+        c.scope = spv;
+        c.asserts = kindKey;
+        c.expiryDate = uint64(block.timestamp + 3650 days);
+        vm.prank(issuer);
+        badge.mint(who, c);
     }
 
     function _check(LexChexBadgeKindCondition c, bytes32 offerId, bytes32 agreementId) internal view returns (bool) {
@@ -166,6 +188,31 @@ contract LexChexBadgeKindConditionTest is SecondaryConditionIntegrationBase {
         _grantScoped(buyer, K_SPV_WHITELIST, address(corp));
         (bytes32 offerId, bytes32 settlementId) = _postAndAcceptSell();
         assertFalse(_check(c, offerId, settlementId));
+    }
+
+    // 9a — no issuer named, so any operator's seat admits.
+    function test_NoIssuerFilter_AnyIssuersSeatAdmits() public {
+        LexChexBadgeKindCondition c = _deploy(K_SYNDICATE, false);
+        _grantScopedFrom(_delegate("issuerA"), buyer, K_SYNDICATE, address(corp));
+        (bytes32 offerId, bytes32 settlementId) = _postAndAcceptSell();
+        assertTrue(_check(c, offerId, settlementId));
+    }
+
+    // 9b — with an issuer named, another operator's seat in the same SPV does not admit.
+    function test_IssuerFilter_ExcludesOtherIssuersSeat() public {
+        address accepted = _delegate("acceptedIssuer");
+        LexChexBadgeKindCondition c = _deploy(K_SYNDICATE, false);
+        address[] memory only = new address[](1);
+        only[0] = accepted;
+        c.updateIssuers(only);
+        assertEq(c.issuers().length, 1);
+
+        _grantScopedFrom(_delegate("otherIssuer"), buyer, K_SYNDICATE, address(corp));
+        (bytes32 offerId, bytes32 settlementId) = _postAndAcceptSell();
+        assertFalse(_check(c, offerId, settlementId));
+
+        _grantScopedFrom(accepted, buyer, K_SYNDICATE, address(corp));
+        assertTrue(_check(c, offerId, settlementId));
     }
 
     // ── Config / authorization ──────────────────────────────────────────────


### PR DESCRIPTION
## Updated

- Added issuer permissions to LexChexBadge:
  - so Legion could mint exclusive credentials for LegionSoulboundCondition (previously all issuers have the same permissions)
  - each issuer is granted a set of fact keys (`issuerKeys`) he is allowed to issue
  - a fact key (ex. `K_SPV_WHITELIST`) gains an `issuer` property so the downstream conditions can filter their trusted issuers (ex. Legion allowing only credentials issued by themselves)
  - LexChexBadgeKindCondition also gains the issuer allowlist as a side-benefit

- Added example for Legion-defined custom data (ex. member tiers) to LegionSoulboundCondition

- Refactored LexChexBadge ABI to increase flexibility and support LegionSoulboundCondition
  - `hasValidCredentialOf`, `getMostRecentValidWith` and `earliestValidIssuance` all take the same four filters — fact-keys, accepted issuers, SPV scope, custom hook — with short forms for the common asks

- Added hooks to LexChexBadge for condition's own custom query logic: this is for future-proof, not used atm